### PR TITLE
优化倒计时组件文本间隙

### DIFF
--- a/ClassIsland/Controls/Components/CountDownComponent.xaml
+++ b/ClassIsland/Controls/Components/CountDownComponent.xaml
@@ -25,17 +25,17 @@
             <TextBlock Text="{Binding Settings.CountDownName}"
                        Foreground="{Binding Settings.FontColor,Converter={StaticResource ColorToColorPickerBrushConverter}}"
                        FontSize="{Binding Settings.FontSize}"
-                       VerticalAlignment="Center" Margin="0 0 4 0"
+                       VerticalAlignment="Center" Margin="0 0 2 0"
                        FontWeight="Medium"/>
             <TextBlock Text="还有" 
                        VerticalAlignment="Center"
-                       Margin="0 0 2 0"
                        Visibility="{Binding Settings.IsCompactModeEnabled, Converter={StaticResource InverseBoolToVisConverter}}"/>
             <TextBlock Text="{Binding DaysLeft, Mode=OneWay}" 
                        Foreground="{Binding Settings.FontColor,Converter={StaticResource ColorToColorPickerBrushConverter}}"
                        FontSize="{Binding Settings.FontSize}"
                        VerticalAlignment="Center"
-                       FontWeight="Medium"/>
+                       FontWeight="Medium"
+                       Margin="2 0 0 0"/>
         </StackPanel>
     </Grid>
 </controls:ComponentBase>


### PR DESCRIPTION
原本倒计时名称与“距离”和“还有”之间是不对称的，我更改了margin。
由于只改动倒计时内容的margin会使紧凑模式下间隔与之前不一样，所以改动了其他的margin
Before:
![before1](https://github.com/ClassIsland/ClassIsland/assets/66517348/fee31d45-06e2-4d5e-bf69-5a8e5ff560fe)
![before2](https://github.com/ClassIsland/ClassIsland/assets/66517348/685a1eff-f2dd-4712-a2fc-32e149f58a70)
After:
![after1](https://github.com/ClassIsland/ClassIsland/assets/66517348/23b75a61-a133-4d0e-991a-75eaa4b0a790)
![after2](https://github.com/ClassIsland/ClassIsland/assets/66517348/57b3f82c-f7bc-4ec2-8709-928aeee5497e)
