### PR TITLE
feat: 使`倒计时`组件的`倒计时名称`设置对绑定源即时更新

### DIFF
--- a/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
@@ -18,7 +18,7 @@
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=components:CountDownComponentSettingsControl}}">
         <StackPanel>
             <TextBlock Text="倒计时名称"/>
-            <TextBox Text="{Binding Settings.CountDownName, Mode=TwoWay}" 
+            <TextBox Text="{Binding Settings.CountDownName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                      Margin="10 8 0 0" MinWidth="180" HorizontalAlignment="Left"/>
             <TextBlock Text="结束日期" Margin="0 8 0 0"/>
             <DatePicker SelectedDate="{Binding Settings.OverTime, Mode=TwoWay}"


### PR DESCRIPTION
设置`UpdateSourceTrigger`为`PropertyChanged`。此时更改TextBox的Text可以即时反映到主界面的倒计时文字


> TextBox.Text 属性的 UpdateSourceTrigger 默认值为 LostFocus。 这意味着如果应用程序的 TextBox 包含数据绑定 TextBox.Text 属性，则直到 TextBox 失去焦点（例如，将鼠标移到 TextBox 外单击时），键入到 TextBox 中的文本才会更新源。
> 节选自[如何：控制文本框文本更新源的时间 | Microsoft Learn](https://learn.microsoft.com/zh-cn/dotnet/desktop/wpf/data/how-to-control-when-the-textbox-text-updates-the-source?view=netframeworkdesktop-4.8)

而这不仅对于大屏，而且对于电脑来说操作都较为不便
