### PR TITLE
feat: 手动设定多周轮换周数

### DIFF
--- a/ClassIsland.Core/Abstractions/Services/ILessonsService.cs
+++ b/ClassIsland.Core/Abstractions/Services/ILessonsService.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using ClassIsland.Shared.Enums;
 using ClassIsland.Shared.Models.Profile;
 
@@ -35,6 +36,11 @@ public interface ILessonsService : INotifyPropertyChanged, INotifyPropertyChangi
     /// 停止主计时器。
     /// </summary>
     public void StopMainTimer();
+
+    /// <summary>
+    /// 刷新多周轮换周数。
+    /// </summary>
+    public void RefreshMultiWeekRotation();
 
     #endregion
 
@@ -111,6 +117,21 @@ public interface ILessonsService : INotifyPropertyChanged, INotifyPropertyChangi
     /// 距下课剩余时间
     /// </summary>
     TimeSpan OnBreakingTimeLeftTime { get; set; }
+
+    /// <summary>
+    /// 本周多周轮换周数。
+    /// </summary>
+    /// <remarks>
+    /// 第 2 位 - 双周轮换<br/>
+    /// 第 3 位 - 三周轮换<br/>
+    /// ……<br/>
+    /// <br/>
+    /// 1 - 本周单周<br/>
+    /// 2 - 本周是双周<br/>
+    /// 3 - 本周是 3/x 周<br/>
+    /// ……<br/>
+    /// </remarks>
+    ObservableCollection<int> MultiWeekRotation { get; set; }
 
     #endregion
 

--- a/ClassIsland.Core/Abstractions/Services/IProfileService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IProfileService.cs
@@ -53,8 +53,8 @@ public interface IProfileService
     /// </summary>
     /// <param name="plan">要检查的课表</param>
     /// <returns>是否满足启用规则</returns>
-    [Obsolete]
-    bool CheckClassPlan(ClassPlan plan);
+    //[Obsolete]
+    //bool CheckClassPlan(ClassPlan plan);
     
     /// <summary>
     /// 将当前临时层课表转换为普通课表。

--- a/ClassIsland/Controls/WeekOffsetSettingsControl.xaml
+++ b/ClassIsland/Controls/WeekOffsetSettingsControl.xaml
@@ -1,0 +1,58 @@
+﻿<UserControl x:Class="ClassIsland.Controls.WeekOffsetSettingsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="clr-namespace:ClassIsland.Controls"
+             xmlns:ci="http://classisland.tech/schemas/xaml/core"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800"
+             IsVisibleChanged="WeekOffsetSettingsControl_OnIsVisibleChanged">
+    <Grid
+         Margin="12"
+         DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=controls:WeekOffsetSettingsControl}}">
+        <StackPanel>
+
+            <TextBlock Text="设置本周在多周轮换中的周数。" TextWrapping="Wrap" Margin="0 0 0 8" />
+            <TextBlock Text="单双周：" />
+            <ListBox
+                Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                SelectedIndex="{Binding CurrentWeeks[2]}"
+                Tag="2">
+                <ListBoxItem Visibility="Collapsed" />
+                <ListBoxItem Content="单周" />
+                <ListBoxItem Content="双周" />
+            </ListBox>
+            <TextBlock Text="三周轮换：" />
+            <ListBox
+                Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                SelectedIndex="{Binding CurrentWeeks[3]}"
+                Tag="3">
+                <ListBoxItem Visibility="Collapsed" />
+                <ListBoxItem Content="1/3周" />
+                <ListBoxItem Content="2/3周" />
+                <ListBoxItem Content="3/3周" />
+            </ListBox>
+            <TextBlock Text="四周轮换：" />
+            <ListBox
+                Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                SelectedIndex="{Binding CurrentWeeks[4]}"
+                Tag="4">
+                <ListBoxItem Visibility="Collapsed" />
+                <ListBoxItem Content="1/4周" />
+                <ListBoxItem Content="2/4周" />
+                <ListBoxItem Content="3/4周" />
+                <ListBoxItem Content="4/4周" />
+            </ListBox>
+            <WrapPanel Margin="0 6 0 0">
+                <Button HorizontalAlignment="Left" Click="ButtonFinish_OnClick">
+                    <ci:IconText Kind="Check" Text="应用" />
+                </Button>
+                <Button Style="{StaticResource MaterialDesignFlatButton}"
+                        Click="ButtonClear_OnClick">
+                    <ci:IconText Kind="Refresh" Text="重置偏移"/>
+                </Button>
+            </WrapPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/ClassIsland/Controls/WeekOffsetSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/WeekOffsetSettingsControl.xaml.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Services;
+using ClassIsland.Shared.Helpers;
+using ControlzEx;
+
+namespace ClassIsland.Controls;
+
+/// <summary>
+/// WeekOffsetSettingsControl.xaml 的交互逻辑
+/// </summary>
+public partial class WeekOffsetSettingsControl : UserControl, INotifyPropertyChanged
+{
+    private ObservableCollection<int> _currentWeeks = [-1, -1, 0, 0, 0];
+
+    private IExactTimeService ExactTimeService { get; } = App.GetService<IExactTimeService>();
+
+    public SettingsService SettingsService { get; } = App.GetService<SettingsService>();
+    public ILessonsService LessonsService { get; } = App.GetService<ILessonsService>();
+
+    public ObservableCollection<int> CurrentWeeks
+    {
+        get => _currentWeeks;
+        set
+        {
+            if (Equals(value, _currentWeeks)) return;
+            _currentWeeks = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 初始化一个 <see cref="WeekOffsetSettingsControl"/> 对象。
+    /// </summary>
+    public WeekOffsetSettingsControl()
+    {
+        InitializeComponent();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void WeekOffsetSettingsControl_OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        Init();
+    }
+
+    private void Init()
+    {
+        CurrentWeeks = ConfigureFileHelper.CopyObject(LessonsService.MultiWeekRotation);
+    }
+
+    private void ButtonFinish_OnClick(object sender, RoutedEventArgs e)
+    {
+        var settings = SettingsService.Settings;
+
+        var dd = (ExactTimeService.GetCurrentLocalDateTime().Date - settings.SingleWeekStartTime).TotalDays;
+        for (int i = 2; i < 5; i++)
+        {
+            
+            int dw = (int)Math.Floor(dd / 7);
+            int w = (dw - (CurrentWeeks[i] - 1) + i) % i;
+            settings.MultiWeekRotationOffset[i] = w;
+        }
+        
+    }
+
+    private void ButtonClear_OnClick(object sender, RoutedEventArgs e)
+    {
+        SettingsService.Settings.MultiWeekRotationOffset = [-1, -1, 0, 0, 0];
+        
+    }
+}

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -241,7 +241,6 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
 
     #region Gerneral
 
-    [Obsolete]
     public DateTime SingleWeekStartTime
     {
         get => _singleWeekStartTime;

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using System.Windows;
 using System.Windows.Media;
+using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Core.Models.Plugin;
 using ClassIsland.Core.Models.Ruleset;
 using ClassIsland.Core.Models.Weather;
@@ -52,6 +53,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     {
         "explorer"
     };
+    private ObservableCollection<int> _multiWeekRotationOffset = [-1, -1, 0, 0, 0];
 
     private bool _hideOnMaxWindow = false;
     private double _opacity = 0.5;
@@ -239,6 +241,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
 
     #region Gerneral
 
+    [Obsolete]
     public DateTime SingleWeekStartTime
     {
         get => _singleWeekStartTime;
@@ -246,6 +249,30 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         {
             if (value.Equals(_singleWeekStartTime)) return;
             _singleWeekStartTime = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 以 2022/4/18 为基准周的多周轮换周数。
+    /// </summary>
+    /// <remarks>
+    /// 第 2 位 - 双周轮换<br/>
+    /// 第 3 位 - 三周轮换<br/>
+    /// ……<br/>
+    /// <br/>
+    /// 0 - 基准周是单周<br/>
+    /// 1 - 基准周是双周<br/>
+    /// 2 - 基准周是 3/x 周<br/>
+    /// ……<br/>
+    /// </remarks>
+    public ObservableCollection<int> MultiWeekRotationOffset
+    {
+        get => _multiWeekRotationOffset;
+        set
+        {
+            if (value.Equals(_multiWeekRotationOffset)) return;
+            _multiWeekRotationOffset = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Services/LessonsService.cs
+++ b/ClassIsland/Services/LessonsService.cs
@@ -468,11 +468,15 @@ public class LessonsService : ObservableRecipient, ILessonsService
 
     public void RefreshMultiWeekRotation()
     {
-        var dd = (ExactTimeService.GetCurrentLocalDateTime().Date - new DateTime(2022, 4, 18)).TotalDays;
-        int dw = (int)Math.Floor(dd / 7);
+        var deltaDays = (ExactTimeService.GetCurrentLocalDateTime().Date - Settings.SingleWeekStartTime.Date).TotalDays;
+        var deltaWeeks = (int)Math.Floor(deltaDays / 7);
         for (var i = 2; i <= 4; i++)
         {
-            int w = (dw - Settings.MultiWeekRotationOffset[i] + i) % i;
+            var w = (deltaWeeks - Settings.MultiWeekRotationOffset[i] + i) % i;
+            if (w < 0)
+            {
+                w += i;
+            }
             MultiWeekRotation[i] = w + 1;
         }
     }

--- a/ClassIsland/Services/ProfileService.cs
+++ b/ClassIsland/Services/ProfileService.cs
@@ -236,25 +236,10 @@ public class ProfileService : IProfileService
         }
     }
 
-    public bool CheckClassPlan(ClassPlan plan)
-    {
-        if (plan.TimeRule.WeekDay != (int)DateTime.Now.DayOfWeek)
-        {
-            return false;
-        }
-
-        if (plan.TimeRule.WeekCountDiv == 0)
-            return true;
-
-        var ExactTimeService = App.GetService<IExactTimeService>();
-        var Settings = App.GetService<SettingsService>().Settings;
-
-        var dd = Math.Abs((ExactTimeService.GetCurrentLocalDateTime().Date - Settings.SingleWeekStartTime.Date).TotalDays);
-        var dw = Math.Floor(dd / 7) + 1;
-        var w = (int)dw % plan.TimeRule.WeekCountDivTotal;
-        return (plan.TimeRule.WeekCountDiv == w ||
-                plan.TimeRule.WeekCountDiv == plan.TimeRule.WeekCountDivTotal && w == 0);
-    }
+    //[Obsolete]
+    //public bool CheckClassPlan(ClassPlan plan)
+    //{
+    //}
 
     public void ConvertToStdClassPlan()
     {

--- a/ClassIsland/Services/SettingsService.cs
+++ b/ClassIsland/Services/SettingsService.cs
@@ -186,6 +186,21 @@ public class SettingsService(ILogger<SettingsService> logger, IManagementService
             Logger.LogInformation("成功迁移了 1.4.3.0 以前的设置。");
         }
 
+        if (Settings.LastAppVersion < Version.Parse("1.4.4.1"))
+        {
+            if (Settings.SingleWeekStartTime != DateTime.MinValue)
+            {
+                var dd = (Settings.SingleWeekStartTime.Date - new DateTime(2022, 4, 18)).TotalDays;
+                int dw = (int)Math.Floor(dd / 7);
+                for (var i = 2; i <= 4; i++)
+                {
+                    Settings.MultiWeekRotationOffset[i] = dw % i;
+                }
+                Settings.SingleWeekStartTime = DateTime.MinValue;
+                Logger.LogInformation("成功迁移了 1.4.4.1 以前的设置。");
+            }
+        }
+
     }
 
     public void SaveSettings(string? note = "-")

--- a/ClassIsland/Services/SettingsService.cs
+++ b/ClassIsland/Services/SettingsService.cs
@@ -186,21 +186,6 @@ public class SettingsService(ILogger<SettingsService> logger, IManagementService
             Logger.LogInformation("成功迁移了 1.4.3.0 以前的设置。");
         }
 
-        if (Settings.LastAppVersion < Version.Parse("1.4.4.1"))
-        {
-            if (Settings.SingleWeekStartTime != DateTime.MinValue)
-            {
-                var dd = (Settings.SingleWeekStartTime.Date - new DateTime(2022, 4, 18)).TotalDays;
-                int dw = (int)Math.Floor(dd / 7);
-                for (var i = 2; i <= 4; i++)
-                {
-                    Settings.MultiWeekRotationOffset[i] = dw % i;
-                }
-                Settings.SingleWeekStartTime = DateTime.MinValue;
-                Logger.LogInformation("成功迁移了 1.4.4.1 以前的设置。");
-            }
-        }
-
     }
 
     public void SaveSettings(string? note = "-")

--- a/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
@@ -32,6 +32,7 @@ public class ProfileSettingsViewModel : ObservableRecipient
     private ClassPlan _selectedClassPlan = new();
     private bool _isUpdatingClassInfoIndexInBackend = false;
     private bool _isClassPlanEditComplete = false;
+    private bool _isWeekOffsetSettingsOpen = false;
 
     public object DrawerContent
     {
@@ -265,6 +266,17 @@ public class ProfileSettingsViewModel : ObservableRecipient
         {
             if (value == _isClassPlanEditComplete) return;
             _isClassPlanEditComplete = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsWeekOffsetSettingsOpen
+    {
+        get => _isWeekOffsetSettingsOpen;
+        set
+        {
+            if (value == _isWeekOffsetSettingsOpen) return;
+            _isWeekOffsetSettingsOpen = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/ViewModels/SettingsPages/GeneralSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/GeneralSettingsViewModel.cs
@@ -1,0 +1,19 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ClassIsland.ViewModels.SettingsPages;
+
+public class GeneralSettingsViewModel : ObservableRecipient
+{
+    private bool _isWeekOffsetSettingsOpen = false;
+
+    public bool IsWeekOffsetSettingsOpen
+    {
+        get => _isWeekOffsetSettingsOpen;
+        set
+        {
+            if (value == _isWeekOffsetSettingsOpen) return;
+            _isWeekOffsetSettingsOpen = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland/ViewModels/WelcomeViewModel.cs
+++ b/ClassIsland/ViewModels/WelcomeViewModel.cs
@@ -25,6 +25,7 @@ public class WelcomeViewModel : ObservableRecipient
     private bool _registerUrlScheme = false;
     private bool _createClassSwapShortcut = false;
     private bool _requiresRestarting = false;
+    private DateTime _singleWeekStartTime = DateTime.Now;
 
     public Guid DialogId
     {
@@ -203,6 +204,17 @@ public class WelcomeViewModel : ObservableRecipient
         {
             if (value == _requiresRestarting) return;
             _requiresRestarting = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public DateTime SingleWeekStartTime
+    {
+        get => _singleWeekStartTime;
+        set
+        {
+            if (value.Equals(_singleWeekStartTime)) return;
+            _singleWeekStartTime = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml
@@ -396,38 +396,32 @@
                     </ListBox.ItemTemplate>
                 </ListBox>
                 <StackPanel Grid.Row="2">
-                    <Separator Margin="0 16 0 4"/>
-                    <controls1:IconText Kind="CalendarOutline" Text="多周轮换" Margin="0 0 0 8"/>
-                    <TextBlock Text="设置本周在多周轮换中的周数。" TextWrapping="Wrap" Margin="0 0 0 8"/>
-                    <TextBlock Text="单双周："/>
-                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[2]}"
-                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="2"
-                             Loaded="MultiWeekRotation_OnLoaded">
-                        <ListBoxItem Visibility="Collapsed" />
-                        <ListBoxItem Content="单周" />
-                        <ListBoxItem Content="双周" />
-                    </ListBox>
-                    <TextBlock Text="三周轮换："/>
-                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[3]}"
-                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="3">
-                        <ListBoxItem Visibility="Collapsed" />
-                        <ListBoxItem Content="1/3周" />
-                        <ListBoxItem Content="2/3周" />
-                        <ListBoxItem Content="3/3周" />
-                    </ListBox>
-                    <TextBlock Text="四周轮换："/>
-                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[4]}"
-                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="4">
-                        <ListBoxItem Visibility="Collapsed" />
-                        <ListBoxItem Content="1/4周" />
-                        <ListBoxItem Content="2/4周" />
-                        <ListBoxItem Content="3/4周" />
-                        <ListBoxItem Content="4/4周" />
-                    </ListBox>
+                    <Separator Margin="0 16 0 4" />
+                    <controls1:IconText Kind="CalendarOutline" Text="多周轮换偏移" Margin="0 0 0 8" />
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            HorizontalAlignment="Left"
+                            Click="ButtonOpenWeekOffsetSettings_OnClick">
+                        <ci:IconText Kind="CalendarMultiple" Text="调整多周轮换偏移…"/>
+                    </Button>
                 </StackPanel>
+                <materialDesign:PopupEx Grid.Row="2"
+                                        AllowsTransparency="True"
+                                        StaysOpen="False"
+                                        Placement="Mouse"
+                                        IsOpen="{Binding ViewModel.IsWeekOffsetSettingsOpen}"
+                                        PopupAnimation="Fade">
+                    <Border Background="{DynamicResource MaterialDesignPaper}"
+                            Margin="8"
+                            Button.Click="ButtonWeekOffsetSettingsButtons_OnClick">
+                        <Border.Effect>
+                            <DropShadowEffect Direction="0"
+                                              ShadowDepth="0"
+                                              BlurRadius="8"
+                                              Opacity="0.5"/>
+                        </Border.Effect>
+                        <controls:WeekOffsetSettingsControl/>
+                    </Border>
+                </materialDesign:PopupEx>
             </Grid>
         </Grid>
 

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml
@@ -110,7 +110,7 @@
         <!-- 时间节点编辑 -->
         <ScrollViewer x:Key="TimePointEditor" Width="332" VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="16">
-                <TextBlock Text="Obslated."/>
+                <TextBlock Text="Obsolete."/>
             </StackPanel>
         </ScrollViewer>
 
@@ -323,6 +323,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <StackPanel Grid.Row="0">
                     <TextBlock Text="当前启用的课表" Style="{StaticResource MaterialDesignHeadline5TextBlock}"/>
@@ -394,6 +395,39 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
+                <StackPanel Grid.Row="2">
+                    <Separator Margin="0 16 0 4"/>
+                    <controls1:IconText Kind="CalendarOutline" Text="多周轮换" Margin="0 0 0 8"/>
+                    <TextBlock Text="设置本周在多周轮换中的周数。" TextWrapping="Wrap" Margin="0 0 0 8"/>
+                    <TextBlock Text="单双周："/>
+                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[2]}"
+                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="2"
+                             Loaded="MultiWeekRotation_OnLoaded">
+                        <ListBoxItem Visibility="Collapsed" />
+                        <ListBoxItem Content="单周" />
+                        <ListBoxItem Content="双周" />
+                    </ListBox>
+                    <TextBlock Text="三周轮换："/>
+                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[3]}"
+                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="3">
+                        <ListBoxItem Visibility="Collapsed" />
+                        <ListBoxItem Content="1/3周" />
+                        <ListBoxItem Content="2/3周" />
+                        <ListBoxItem Content="3/3周" />
+                    </ListBox>
+                    <TextBlock Text="四周轮换："/>
+                    <ListBox PreviewMouseWheel="UIElement_OnPreviewMouseWheel" Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                             SelectedIndex="{Binding LessonsService.MultiWeekRotation[4]}"
+                             SelectionChanged="MultiWeekRotation_OnSelectionChanged" Tag="4">
+                        <ListBoxItem Visibility="Collapsed" />
+                        <ListBoxItem Content="1/4周" />
+                        <ListBoxItem Content="2/4周" />
+                        <ListBoxItem Content="3/4周" />
+                        <ListBoxItem Content="4/4周" />
+                    </ListBox>
+                </StackPanel>
             </Grid>
         </Grid>
 

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml.cs
@@ -49,6 +49,8 @@ public partial class ProfileSettingsWindow : MyWindow
 
     public IManagementService ManagementService { get; } = App.GetService<IManagementService>();
 
+    public IExactTimeService ExactTimeService { get; } = App.GetService<IExactTimeService>();
+
     public MainViewModel MainViewModel
     {
         get;
@@ -1021,5 +1023,21 @@ public partial class ProfileSettingsWindow : MyWindow
         details.Owner = this;
         details.ShowDialog();
     }
-    
+
+    private void MultiWeekRotation_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        // LessonsService.RefreshMultiWeekRotation();
+    }
+
+    private void MultiWeekRotation_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        var settings = App.GetService<SettingsService>().Settings;
+        int i = int.Parse(((ListBox)sender).Tag.ToString()!);
+
+        var dd = (ExactTimeService.GetCurrentLocalDateTime().Date - new DateTime(2022, 4, 18)).TotalDays;
+        while (dd < i * 7) dd += i * 7;
+        int dw = (int)Math.Floor(dd / 7);
+        int w = (dw - (LessonsService.MultiWeekRotation[i] - 1) + i) % i;
+        settings.MultiWeekRotationOffset[i] = w;
+    }
 }

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml.cs
@@ -1031,13 +1031,20 @@ public partial class ProfileSettingsWindow : MyWindow
 
     private void MultiWeekRotation_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        var settings = App.GetService<SettingsService>().Settings;
-        int i = int.Parse(((ListBox)sender).Tag.ToString()!);
+        
+    }
 
-        var dd = (ExactTimeService.GetCurrentLocalDateTime().Date - new DateTime(2022, 4, 18)).TotalDays;
-        while (dd < i * 7) dd += i * 7;
-        int dw = (int)Math.Floor(dd / 7);
-        int w = (dw - (LessonsService.MultiWeekRotation[i] - 1) + i) % i;
-        settings.MultiWeekRotationOffset[i] = w;
+    private void ButtonOpenWeekOffsetSettings_OnClick(object sender, RoutedEventArgs e)
+    {
+        ViewModel.IsWeekOffsetSettingsOpen = true;
+    }
+
+    private void ButtonWeekOffsetSettingsButtons_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (e.OriginalSource is not Button)
+        {
+            return;
+        }
+        ViewModel.IsWeekOffsetSettingsOpen = false;
     }
 }

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
@@ -42,6 +42,39 @@
             <controls1:SettingsCard IconGlyph="Code" Header="注册 Url 协议"
                                     Description="注册 Url 协议后，可以从外部通过 classisland:// 协议调用本应用内的功能。"
                                     IsOn="{Binding SettingsService.Settings.IsUrlProtocolRegistered, Mode=TwoWay}" />
+            <!-- 学期开始时间 -->
+            <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
+                                    Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算，应设为一周的第一天。">
+                <controls1:SettingsCard.Switcher>
+                    <StackPanel Orientation="Horizontal">
+                        <DatePicker SelectedDate="{Binding SettingsService.Settings.SingleWeekStartTime}"
+                                    Width="120"
+                                    Foreground="{DynamicResource MaterialDesignBody}" />
+                        <Button Style="{StaticResource MaterialDesignFlatButton}"
+                                Content="{materialDesign:PackIcon CalendarMultiple}"
+                                Click="ButtonWeekOffsetSettingsOpen_OnClick"
+                                ToolTip="调整偏移…"/>
+                        <materialDesign:PopupEx Grid.Row="2"
+                                                AllowsTransparency="True"
+                                                StaysOpen="False"
+                                                Placement="Mouse"
+                                                IsOpen="{Binding ViewModel.IsWeekOffsetSettingsOpen}"
+                                                PopupAnimation="Fade">
+                            <Border Background="{DynamicResource MaterialDesignPaper}"
+                                    Margin="8"
+                                    Button.Click="ButtonWeekOffsetSettingsButtons_OnClick">
+                                <Border.Effect>
+                                    <DropShadowEffect Direction="0"
+                                                      ShadowDepth="0"
+                                                      BlurRadius="8"
+                                                      Opacity="0.5"/>
+                                </Border.Effect>
+                                <controls2:WeekOffsetSettingsControl/>
+                            </Border>
+                        </materialDesign:PopupEx>
+                    </StackPanel>
+                </controls1:SettingsCard.Switcher>
+            </controls1:SettingsCard>
             <!-- 隐藏窗口 -->
             <materialDesign:Card Margin="0 0 0 6">
                 <Expander Background="Transparent" IsExpanded="True">

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
@@ -42,15 +42,6 @@
             <controls1:SettingsCard IconGlyph="Code" Header="注册 Url 协议"
                                     Description="注册 Url 协议后，可以从外部通过 classisland:// 协议调用本应用内的功能。"
                                     IsOn="{Binding SettingsService.Settings.IsUrlProtocolRegistered, Mode=TwoWay}" />
-            <!-- 学期开始时间 -->
-            <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
-                                                           Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算，应设为一周的第一天。">
-                <controls1:SettingsCard.Switcher>
-                    <DatePicker SelectedDate="{Binding SettingsService.Settings.SingleWeekStartTime}"
-                                                        Width="120"
-                                                        Foreground="{DynamicResource MaterialDesignBody}" />
-                </controls1:SettingsCard.Switcher>
-            </controls1:SettingsCard>
             <!-- 隐藏窗口 -->
             <materialDesign:Card Margin="0 0 0 6">
                 <Expander Background="Transparent" IsExpanded="True">

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml.cs
@@ -18,6 +18,7 @@ using ClassIsland.Core.Abstractions.Services.Management;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Enums.SettingsWindow;
 using ClassIsland.Services;
+using ClassIsland.ViewModels.SettingsPages;
 
 namespace ClassIsland.Views.SettingPages;
 
@@ -34,6 +35,8 @@ public partial class GeneralSettingsPage : SettingsPageBase
     public IExactTimeService ExactTimeService { get; }
 
     public MiniInfoProviderHostService MiniInfoProviderHostService { get; }
+
+    public GeneralSettingsViewModel ViewModel { get; } = new();
 
     public GeneralSettingsPage(SettingsService settingsService, IManagementService managementService, IExactTimeService exactTimeService, MiniInfoProviderHostService miniInfoProviderHostService)
     {
@@ -53,5 +56,19 @@ public partial class GeneralSettingsPage : SettingsPageBase
     private void ButtonCloseMigrationTip_OnClick(object sender, RoutedEventArgs e)
     {
         SettingsService.Settings.ShowComponentsMigrateTip = false;
+    }
+
+    private void ButtonWeekOffsetSettingsButtons_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (e.OriginalSource is not Button)
+        {
+            return;
+        }
+        ViewModel.IsWeekOffsetSettingsOpen = false;
+    }
+
+    private void ButtonWeekOffsetSettingsOpen_OnClick(object sender, RoutedEventArgs e)
+    {
+        ViewModel.IsWeekOffsetSettingsOpen = true;
     }
 }

--- a/ClassIsland/Views/WelcomeWindow.xaml
+++ b/ClassIsland/Views/WelcomeWindow.xaml
@@ -262,10 +262,10 @@
 
                                     <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
                                                            Margin="0 6 0 0"
-                                                           Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算，应设为一周的第一天。">
+                                                           Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算。">
                                         <controls1:SettingsCard.Switcher>
                                             <DatePicker
-                                                SelectedDate="{Binding ViewModel.Settings.SingleWeekStartTime}"
+                                                SelectedDate="{Binding ViewModel.SingleWeekStartTime}"
                                                 Width="120"
                                                 Foreground="{DynamicResource MaterialDesignBody}" />
                                         </controls1:SettingsCard.Switcher>

--- a/ClassIsland/Views/WelcomeWindow.xaml
+++ b/ClassIsland/Views/WelcomeWindow.xaml
@@ -265,7 +265,7 @@
                                                            Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算。">
                                         <controls1:SettingsCard.Switcher>
                                             <DatePicker
-                                                SelectedDate="{Binding ViewModel.SingleWeekStartTime}"
+                                                SelectedDate="{Binding ViewModel.Settings.SingleWeekStartTime}"
                                                 Width="120"
                                                 Foreground="{DynamicResource MaterialDesignBody}" />
                                         </controls1:SettingsCard.Switcher>

--- a/ClassIsland/Views/WelcomeWindow.xaml.cs
+++ b/ClassIsland/Views/WelcomeWindow.xaml.cs
@@ -89,13 +89,6 @@ public partial class WelcomeWindow : MyWindow
             App.GetService<ILogger<WelcomeWindow>>().LogError(ex, "无法创建快捷方式。");
         }
 
-        var dd = (ViewModel.SingleWeekStartTime.Date - new DateTime(2022, 4, 18)).TotalDays;
-        int dw = (int)Math.Floor(dd / 7);
-        for (var i = 2; i <= 4; i++)
-        {
-            SettingsService.Settings.MultiWeekRotationOffset[i] = dw % i;
-        }
-
         Close();
         if (ViewModel.RequiresRestarting)
         {

--- a/ClassIsland/Views/WelcomeWindow.xaml.cs
+++ b/ClassIsland/Views/WelcomeWindow.xaml.cs
@@ -88,7 +88,14 @@ public partial class WelcomeWindow : MyWindow
         {
             App.GetService<ILogger<WelcomeWindow>>().LogError(ex, "无法创建快捷方式。");
         }
-        
+
+        var dd = (ViewModel.SingleWeekStartTime.Date - new DateTime(2022, 4, 18)).TotalDays;
+        int dw = (int)Math.Floor(dd / 7);
+        for (var i = 2; i <= 4; i++)
+        {
+            SettingsService.Settings.MultiWeekRotationOffset[i] = dw % i;
+        }
+
         Close();
         if (ViewModel.RequiresRestarting)
         {


### PR DESCRIPTION
> [!caution]
> ~逻辑写的非常烂非常烂非常烂，需要更长时间来测试 bug。~
> ~实验性功能可能要喜 +1 了（~
> 测试已完成，没有发现任何 bug

已知问题：
- 如果将时间偏移设定至 **2022 年 4 月 18 日或更早**，所有周轮换将会不可用
  原因：数学不好，给负数取正后总会发生错误 :disappointed_relieved:

- **无法设置一周的开始日**，每周开始日固定为周一
  原因：中国大陆学校课表大部分都是以周一为一周开始