### PR TITLE
fix: 修复自定义课间名称可能导致 TTS 多音字朗读不正确的问题

### DIFF
--- a/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
@@ -142,7 +142,7 @@ public class ClassNotificationProvider : INotificationProvider, IHostedService
                 ShowTeacherName = Settings.ShowTeacherName
             },
             OverlayDuration = TimeSpan.FromSeconds(10),
-            OverlaySpeechContent = $"本节{LessonsService.CurrentTimeLayoutItem.BreakNameText}长{TimeSpanFormatHelper.Format(LessonsService.CurrentTimeLayoutItem.Last)}，下节课是：{LessonsService.NextClassSubject.Name} {(Settings.ShowTeacherName ? FormatTeacher(LessonsService.NextClassSubject) : "")}。",
+            OverlaySpeechContent = $"本节{LessonsService.CurrentTimeLayoutItem.BreakNameText}常{TimeSpanFormatHelper.Format(LessonsService.CurrentTimeLayoutItem.Last)}，下节课是：{LessonsService.NextClassSubject.Name} {(Settings.ShowTeacherName ? FormatTeacher(LessonsService.NextClassSubject) : "")}。",
             IsSpeechEnabled = Settings.IsSpeechEnabledOnClassOff
         });
     }


### PR DESCRIPTION
不确定该怎么修复，所以交个 pr