### PR TITLE
feat: 优化人机交互

### DIFF
--- a/ClassIsland.Core/Controls/InfoCard.xaml
+++ b/ClassIsland.Core/Controls/InfoCard.xaml
@@ -16,9 +16,12 @@
             >
         <Grid>
             <StackPanel>
-                <materialDesign:PackIcon Kind="{Binding IconKind}"
-                                         Height="24" Width="24"
-                                         Foreground="{DynamicResource PrimaryHueMidBrush}" />
+                <StackPanel Orientation="Horizontal">
+                    <materialDesign:PackIcon Kind="{Binding IconKind}"
+                                            Height="24" Width="24"
+                                            Foreground="{DynamicResource PrimaryHueMidBrush}" />
+                    <TextBlock Margin="4 2 0 0" Text="{Binding Title}" FontWeight="Bold"/>
+                </StackPanel>
                 <TextBlock TextWrapping="Wrap" Margin="0 6 0 0"
                            Text="{Binding Content}"/>
                 <ContentPresenter 

--- a/ClassIsland.Core/Controls/InfoCard.xaml.cs
+++ b/ClassIsland.Core/Controls/InfoCard.xaml.cs
@@ -25,11 +25,19 @@ public partial class InfoCard : UserControl
 {
     public static readonly DependencyProperty ContentProperty = DependencyProperty.Register(
         nameof(Content), typeof(string), typeof(InfoCard), new PropertyMetadata(default(string)));
+    public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
+        nameof(Title), typeof(string), typeof(InfoCard), new PropertyMetadata(default(string)));
 
     public string Content
     {
         get { return (string)GetValue(ContentProperty); }
         set { SetValue(ContentProperty, value); }
+    }
+
+    public string Title
+    {
+        get { return (string)GetValue(TitleProperty); }
+        set { SetValue(TitleProperty, value); }
     }
 
     public static readonly DependencyProperty IconKindProperty = DependencyProperty.Register(

--- a/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml
+++ b/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml
@@ -84,7 +84,7 @@
             <!-- 课间时间 -->
             <TextBlock Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="12 0">
                 <Run Text="{Binding LessonsService.CurrentTimeLayoutItem.BreakNameText, StringFormat=本节{0}长, Mode=OneWay}"/>
-                <Run Text="{Binding LessonsService.CurrentTimeLayoutItem.Last, ConverterCulture=zh-cn, Mode=OneWay}" FontWeight="Bold"/>
+                <Run Text="{Binding NextTimeLayoutDurationHumanized, Mode=OneWay}" FontWeight="Bold"/>
             </TextBlock>
 
             <!-- 科目信息 -->

--- a/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
+++ b/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -91,7 +92,7 @@ public partial class ClassNotificationProviderControl : UserControl, INotifyProp
         {
             Timer.Start();
         }
-        
+
     }
 
     private void TimerOnTick(object? sender, EventArgs e)
@@ -114,5 +115,19 @@ public partial class ClassNotificationProviderControl : UserControl, INotifyProp
         field = value;
         OnPropertyChanged(propertyName);
         return true;
+    }
+
+    public string NextTimeLayoutDurationHumanized
+    {
+        get
+        {
+            TimeSpan span = LessonsService.CurrentTimeLayoutItem.Last;
+            if (span.TotalSeconds <= 0) return "0分钟";
+            StringBuilder sb = new();
+            if (span.Hours > 0) sb.Append($"{span.Hours}小时");
+            if (span.Minutes > 0) sb.Append($"{span.Minutes}分钟");
+            if (span.Seconds > 0) sb.Append($"{span.Seconds}秒");
+            return sb.ToString();
+        }
     }
 }

--- a/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
+++ b/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+ï»¿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -122,11 +122,11 @@ public partial class ClassNotificationProviderControl : UserControl, INotifyProp
         get
         {
             TimeSpan span = LessonsService.CurrentTimeLayoutItem.Last;
-            if (span.TotalSeconds <= 0) return "0·ÖÖÓ";
+            if (span.TotalSeconds <= 0) return "0åˆ†é’Ÿ";
             StringBuilder sb = new();
-            if (span.Hours > 0) sb.Append($"{span.Hours}Ð¡Ê±");
-            if (span.Minutes > 0) sb.Append($"{span.Minutes}·ÖÖÓ");
-            if (span.Seconds > 0) sb.Append($"{span.Seconds}Ãë");
+            if (span.Hours > 0) sb.Append($"{span.Hours}å°æ—¶");
+            if (span.Minutes > 0) sb.Append($"{span.Minutes}åˆ†é’Ÿ");
+            if (span.Seconds > 0) sb.Append($"{span.Seconds}ç§’");
             return sb.ToString();
         }
     }

--- a/ClassIsland/Views/CrashWindow.xaml
+++ b/ClassIsland/Views/CrashWindow.xaml
@@ -18,7 +18,7 @@
                    mc:Ignorable="d"
                    WindowStartupLocation="CenterScreen"
                    Icon="/Assets/AppLogo.ico"
-                   Title="崩溃啦！" Height="450" Width="800">
+                   Title="ClassIsland 已崩溃" Height="450" Width="800">
     <Grid Margin="12">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -39,7 +39,7 @@
                                  Height="56" Width="56" />
 
         <TextBlock Grid.Column="1" Grid.Row="1" TextWrapping="Wrap" FontSize="14">
-            <Run Text="应用发生了无法解决的错误，需要退出。这可能是由一个bug引起的。若要将此错误反馈至开发人员，请保留此错误信息，并一并提交至开发者。"/>
+            <Run Text="ClassIsland 碰到了严重错误而无法继续运行。您可以保存下方的错误信息并向他人寻求帮助。如果您认为这是由软件本身的错误所致，请点击下方【反馈问题】按钮。"/>
         </TextBlock>
         <TextBox Grid.Column="1"
                  x:Name="TextBoxCrashInfo" Grid.Row="2" 
@@ -56,7 +56,7 @@
         <Separator Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="3" Margin="-12 8"/>
         <StackPanel Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" HorizontalAlignment="Right" Orientation="Horizontal">
             <Button Style="{StaticResource MaterialDesignPaperButton}" Margin="0 0 6 0" Click="ButtonIgnore_OnClick">
-                <controls1:IconText Kind="Close" Text="忽略" IconMargin="3 0 0 0"/>
+                <controls1:IconText Kind="Close" Text="忽略错误，强制继续运行" IconMargin="3 0 0 0"/>
             </Button>
             <Button Style="{StaticResource MaterialDesignPaperButton}" Margin="0 0 6 0" Click="ButtonExit_OnClick">
                 <controls1:IconText Kind="ExitToApp" Text="退出应用" IconMargin="3 0 0 0"/>
@@ -82,7 +82,7 @@
                                   Padding="16">
             <Grid>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
-                    <TextBlock Text="ClassIsland 发生错误" Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                    <TextBlock Text="崩溃啦！(T_T)" Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center"
                                Margin="0 0 16 0"/>

--- a/ClassIsland/Views/SettingPages/AppearanceSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/AppearanceSettingsPage.xaml
@@ -54,7 +54,7 @@
             </controls1:SettingsCard>
             <!-- 圆角半径 -->
             <controls1:SettingsCard IconGlyph="BorderRoundCorners" Header="圆角半径"
-                                    Description="主界面圆角半径，数值为20时左右边缘为半圆。">
+                                    Description="主界面圆角半径，调至最大数值时左右边缘为半圆。">
                 <controls1:SettingsCard.Switcher>
                     <Slider Grid.Column="1" Grid.Row="0" Width="180" Minimum="0" Maximum="20"
                             Value="{Binding SettingsService.Settings.RadiusX}"
@@ -221,7 +221,7 @@
                             <!-- 自动提取主题色间隔 -->
                             <controls1:SettingsControl IconGlyph="ClockOutline"
                                                                               Header="自动提取主题色间隔"
-                                                                              Description="自动从壁纸提取主题色时间隔的时间，建议以动态壁纸更新速度按需设置，不宜低于10秒。">
+                                                                              Description="自动从壁纸提取主题色时间隔的时间，建议根据动态壁纸更新速度按需设置，不宜低于10秒。">
                                 <controls1:SettingsControl.Switcher>
                                     <controls1:NumbericTextBox MaxValue="36000" MinValue="0"
                                                                 Width="150"
@@ -237,7 +237,7 @@
 
                 <!-- 兼容模式 -->
                 <controls1:SettingsCard IconGlyph="CogOutline" Header="启用兼容模式"
-                                                               Description="若启用，将从注册表提取壁纸，而非桌面句柄，不兼容动态壁纸。可能可以解决一些壁纸提取中的玄学问题。"
+                                                               Description="若启用，将从注册表提取壁纸，而非桌面句柄。不兼容动态壁纸。可能会解决一些与壁纸提取相关的玄学问题。"
                                                                IsOn="{Binding SettingsService.Settings.IsFallbackModeEnabled, Mode=TwoWay}" />
                 <!-- 壁纸层窗口类名 -->
                 <controls1:SettingsCard IconGlyph="WindowMaximize" Header="壁纸层窗口类名"
@@ -481,8 +481,9 @@
                                              xml:space="preserve">送给你纯白色的花 塞西莉亚 塞西莉亚
 盛开在起风的地方 沐浴九月的骄阳
 语文 数学 英语 历史 物理 政治 化学 生物 地理
-The quick brown fox jumps over a lazy dog
-:1:234567890 +-*/:</TextBox>
+the quick brown fox jumps over a lazy dog
+THE QUICK BROWN FOX JUMPS OVER A LAZY DOG
+8:00-12:00 1234567890 +-*/</TextBox>
         </StackPanel>
     </ScrollViewer>
 </controls:SettingsPageBase>

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
@@ -40,11 +40,11 @@
                                                            IsOn="{Binding SettingsService.Settings.IsAutoStartEnabled, Mode=TwoWay}" />
             <!-- 注册 Url 协议 -->
             <controls1:SettingsCard IconGlyph="Code" Header="注册 Url 协议"
-                                    Description="注册 Url 协议后，可以从外部通过 classisland:// 协议调用本应用内的功能。"
+                                    Description="允许第三方应用或网页通过 Url 协议调用本应用的部分功能，详见帮助文档。"
                                     IsOn="{Binding SettingsService.Settings.IsUrlProtocolRegistered, Mode=TwoWay}" />
             <!-- 学期开始时间 -->
             <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
-                                    Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算，应设为一周的第一天。">
+                                    Description="此时间将作为学期的第一天，用于多周轮换课表的计算。应设为一周的第一天。">
                 <controls1:SettingsCard.Switcher>
                     <StackPanel Orientation="Horizontal">
                         <DatePicker SelectedDate="{Binding SettingsService.Settings.SingleWeekStartTime}"
@@ -118,7 +118,7 @@
             <!-- 点击托盘图标行为 -->
             <controls1:SettingsCard IconGlyph="CursorDefaultClickOutline"
                                                            Header="点击托盘图标行为"
-                                                           Description="鼠标左键点击本应用托盘图标时应用进行的操作。无论此设置设置为什么选项，右键点击/触屏长按托盘图标仍会打开主菜单。"
+                                                           Description="鼠标左键点击/触屏单击本应用托盘图标时进行的操作。无论此设置处于何种选项，鼠标右键点击/触屏长按托盘图标总是会打开主菜单。"
                                                            IsOn="{Binding SettingsService.Settings.ShowExtraInfoOnTimePoint, Mode=TwoWay}">
                 <controls1:SettingsCard.Switcher>
                     <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
@@ -220,7 +220,7 @@
                         <controls1:SettingsControl IconGlyph="TimerSyncOutline"
                                                                           Foreground="{DynamicResource MaterialDesignBody}"
                                                                           Header="使用精确时间"
-                                                                          Description="启用后，应用将自动从指定的服务器上同步精确时间。此设置不影响系统时间。"
+                                                                          Description="启用后，应用将使用从指定服务器同步的精确时间，而不是使用系统时间。"
                                                                           IsOn="{Binding SettingsService.Settings.IsExactTimeEnabled, Mode=TwoWay}"
                                                                           Margin="-12 0" />
                     </Expander.Header>
@@ -273,7 +273,7 @@
                         <controls1:SettingsControl IconGlyph="ClockArrow"
                                                                           Header="时间偏移"
                                                                           Foreground="{DynamicResource MaterialDesignBody}"
-                                                                          Description="设定应用内时间与系统时间的偏移值。如果您需要更精确地同步时间，建议您同时开启【使用精确时间】选项。"
+                                                                          Description="设定课程时间与实际时间的偏移值。如果您需要更精确地同步时间，建议您同时开启【使用精确时间】选项。"
                                                                           IsOn="{Binding SettingsService.Settings.IsExactTimeEnabled, Mode=TwoWay}"
                                                                           Margin="-12 0">
                             <controls1:SettingsControl.Switcher>
@@ -289,7 +289,7 @@
                     <StackPanel Margin="36 0 48 12">
                         <!-- 自动时间偏移 -->
                         <controls1:SettingsControl IconGlyph="ClockAutoOutline" Header="自动时间偏移"
-                                                                       Description="若启用，每天自动以设定的增量值调整时间偏移量">
+                                                                       Description="若启用，每天自动以设定的增量值调整时间偏移量。">
                             <controls1:SettingsControl.Switcher>
                                 <DockPanel Width="150">
                                     <ToggleButton DockPanel.Dock="Right"

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
@@ -40,7 +40,7 @@
                                                            IsOn="{Binding SettingsService.Settings.IsAutoStartEnabled, Mode=TwoWay}" />
             <!-- 注册 Url 协议 -->
             <controls1:SettingsCard IconGlyph="Code" Header="注册 Url 协议"
-                                    Description="允许第三方应用或网页通过 Url 协议调用本应用的部分功能，详见帮助文档。"
+                                    Description="允许第三方应用或网页通过 Url 协议 classisland:// 调用本应用的部分功能，详见帮助文档。"
                                     IsOn="{Binding SettingsService.Settings.IsUrlProtocolRegistered, Mode=TwoWay}" />
             <!-- 学期开始时间 -->
             <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
@@ -359,7 +359,7 @@
             <!-- 教学安全模式 -->
             <controls1:SettingsCard IconGlyph="CarBrakeAlert"
                                     Header="教学安全模式"
-                                    Description="启用后，如果 ClassIsland 发生严重错误，将会自动退出而不弹出错误窗口，以确保教学不受到影响。"
+                                    Description="启用后，ClassIsland 会在崩溃时自动退出而不弹出崩溃窗口，以确保教学不受到影响。"
                                     IsOn="{Binding SettingsService.Settings.IsCriticalSafeMode, Mode=TwoWay}"
                                     Margin="0 0 0 6" />
         </StackPanel>

--- a/ClassIsland/Views/SettingPages/PluginsSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/PluginsSettingsPage.xaml
@@ -634,7 +634,7 @@
                                HorizontalAlignment="Center"
                                TextWrapping="Wrap"
                                Width="320">
-                        <Run Text="欢迎使用插件。您可以通过插件扩展 ClassIsland 的功能，比如添加一个组件，或者和其它软件联动，等等。" />
+                        <Run Text="欢迎使用插件！插件可以扩展 ClassIsland 的功能，比如添加一个组件，或者和其它软件联动，等等。" />
 
                     </TextBlock>
                     <Border Width="320"
@@ -648,7 +648,7 @@
                             <TextBlock TextAlignment="Center"
                                        HorizontalAlignment="Center"
                                        TextWrapping="Wrap"
-                                       Text="需要注意，插件可以以 ClassIsland 的身份进行各项活动，使用各项系统资源，并自由地访问此设备上的文件。出于安全考虑，不要安装来路不明的插件。即使是插件市场的插件，也无法完全保证安全。使用插件造成的一切后果，ClassIsland 开发团队概不负责。" />
+                                       Text="需要注意，插件可以以 ClassIsland 的身份使用各项系统资源并请求任意权限，还可以自由访问设备上的所有文件。请不要安装来路不明的插件，开发者也无法保证市场所提供的插件都是绝对安全的。ClassIsland 开发团队对使用插件造成的一切后果概不负责。" />
                         </StackPanel>
                     </Border>
 

--- a/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml
@@ -149,7 +149,7 @@
                                     <DataTrigger
                                         Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}"
                                         Value="UpToDate">
-                                        <Setter Property="Text" Value="您已是最新。" />
+                                        <Setter Property="Text" Value="您已更新到最新版本。" />
                                     </DataTrigger>
                                     <DataTrigger
                                         Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}"
@@ -159,7 +159,7 @@
                                     <DataTrigger
                                         Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}"
                                         Value="UpdateDownloaded">
-                                        <Setter Property="Text" Value="您已准备好安装更新。" />
+                                        <Setter Property="Text" Value="已准备好安装更新。" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -232,7 +232,7 @@
                                     <DataTrigger
                                         Binding="{Binding UpdateService.CurrentWorkingStatus, Mode=OneWay}"
                                         Value="NetworkError">
-                                        <Setter Property="Text" Value="网络错误。请检查网络连接，然后再试一遍。" />
+                                        <Setter Property="Text" Value="网络错误，请检查网络连接后重试。" />
                                     </DataTrigger>
                                     <DataTrigger
                                         Binding="{Binding UpdateService.CurrentWorkingStatus, Mode=OneWay}"
@@ -322,7 +322,7 @@
                     </materialDesign:Snackbar.Style>
                     <materialDesign:Snackbar.Message>
                         <materialDesign:SnackbarMessage ActionContent="确定"
-                                                        Content="网络错误，请检查网络连接，然后再试一遍。"
+                                                        Content="网络错误，请检查网络连接后重试。"
                                                         ActionClick="UpdateErrorMessage_OnActionClick" />
                     </materialDesign:Snackbar.Message>
                 </materialDesign:Snackbar>
@@ -419,7 +419,7 @@
                                 <Setter Property="Visibility" Value="Collapsed" />
                             </Style>
                         </Button.Style>
-                        <controls1:IconText Kind="MonitorDownload" Text="重启并安装更新" />
+                        <controls1:IconText Kind="MonitorDownload" Text="重启应用并安装更新" />
                     </Button>
                     <!-- 取消更新  -->
                     <Button Margin="0 0 6 0" Click="ButtonCancelUpdate_OnClick">
@@ -528,7 +528,7 @@
                             <Image Source="/Assets/HoYoStickers/光辉矢愿_遨游.png" Width="81"
                                    Height="81"
                                    ToolTip="光辉矢愿_遨游" />
-                            <TextBlock Text="你已是最新，真棒，夸夸你哦♪" TextWrapping="Wrap"
+                            <TextBlock Text="已经是最新版啦，真棒，夸夸你哦♪" TextWrapping="Wrap"
                                        Margin="0 8 0 0" />
                             <Button HorizontalAlignment="Center" Margin="0 8 0 0"
                                     Style="{StaticResource MaterialDesignFlatButton}"
@@ -586,7 +586,7 @@
                                                     Value="1">
                                                     <Setter Property="Kind" Value="RefreshAuto" />
                                                     <Setter Property="Text"
-                                                            Value="自动检查更新，并在有更新时提醒我。" />
+                                                            Value="自动检查更新，并在有更新时发出提醒。" />
                                                 </DataTrigger>
                                                 <DataTrigger
                                                     Binding="{Binding SettingsService.Settings.UpdateMode, Mode=OneWay}"
@@ -617,7 +617,7 @@
                             <StackPanel Margin="12">
                                 <controls1:SettingsControl IconGlyph="DownloadOutline"
                                                            Header="更新通道"
-                                                           Description="控制应用从何处获取更新。">
+                                                           Description="控制应用的更新目标版本。">
                                     <controls1:SettingsControl.Switcher>
                                         <ComboBox Width="150"
                                                   Foreground="{DynamicResource MaterialDesignBody}"

--- a/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml
@@ -118,7 +118,8 @@
                 <!-- 更新状态图标 -->
                 <materialDesign:PackIcon Grid.Column="0" Grid.Row="0"
                                          Width="48" Height="48"
-                                         Margin="0 0 8 0">
+                                         Margin="0 0 8 0"
+                                         MouseDoubleClick="IconUpdateStatus_OnMouseDoubleClick">
                     <materialDesign:PackIcon.Style>
                         <Style TargetType="materialDesign:PackIcon">
                             <Style.Triggers>
@@ -146,11 +147,32 @@
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Style.Triggers>
-                                    <DataTrigger
-                                        Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}"
-                                        Value="UpToDate">
-                                        <Setter Property="Text" Value="您已更新到最新版本。" />
-                                    </DataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition 
+                                                Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}" 
+                                                Value="UpToDate"/>
+                                            <Condition
+                                                Binding="{Binding IsEasterEggTriggered}" 
+                                                Value="false"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="Text" Value="您已更新到最新版本。" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition 
+                                                Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}" 
+                                                Value="UpToDate"/>
+                                            <Condition
+                                                Binding="{Binding IsEasterEggTriggered}" 
+                                                Value="true"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="Text" Value="您已是最新。" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
                                     <DataTrigger
                                         Binding="{Binding SettingsService.Settings.LastUpdateStatus, Mode=OneWay}"
                                         Value="UpdateAvailable">
@@ -528,8 +550,38 @@
                             <Image Source="/Assets/HoYoStickers/光辉矢愿_遨游.png" Width="81"
                                    Height="81"
                                    ToolTip="光辉矢愿_遨游" />
+
                             <TextBlock Text="已经是最新版啦，真棒，夸夸你哦♪" TextWrapping="Wrap"
-                                       Margin="0 8 0 0" />
+                                       Margin="0 8 0 0" >
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger
+                                                Binding="{Binding IsEasterEggTriggered}"
+                                                Value="false">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                            <TextBlock Text="头抬起，请坐和放宽，好东西就要来了" TextWrapping="Wrap"
+                                       Margin="0 8 0 0" >
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger
+                                                Binding="{Binding IsEasterEggTriggered}"
+                                                Value="true">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
                             <Button HorizontalAlignment="Center" Margin="0 8 0 0"
                                     Style="{StaticResource MaterialDesignFlatButton}"
                                     Click="ButtonChangelogs_OnClick">

--- a/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/UpdatesSettingsPage.xaml.cs
@@ -22,11 +22,13 @@ using ClassIsland.Core.Helpers;
 using ClassIsland.Models;
 using ClassIsland.Services;
 using ClassIsland.Services.AppUpdating;
+using ClassIsland.Services.Logging;
 using ClassIsland.Shared.Enums;
 using ClassIsland.ViewModels.SettingsPages;
 using MaterialDesignThemes.Wpf;
 using MdXaml;
 using Sentry;
+using WebSocketSharp;
 
 namespace ClassIsland.Views.SettingPages;
 
@@ -41,6 +43,16 @@ public partial class UpdatesSettingsPage : SettingsPageBase
     public UpdateService UpdateService { get; }
 
     public UpdateSettingsViewModel ViewModel { get; } = new();
+
+    public static readonly DependencyProperty IsEasterEggTriggeredProperty =
+    DependencyProperty.Register(nameof(IsEasterEggTriggered), typeof(bool), typeof(UpdatesSettingsPage),
+        new PropertyMetadata(false));
+
+    public bool IsEasterEggTriggered
+    {
+        get => (bool)GetValue(IsEasterEggTriggeredProperty);
+        set => SetValue(IsEasterEggTriggeredProperty, value);
+    }
 
     public UpdatesSettingsPage(SettingsService settingsService, UpdateService updateService)
     {
@@ -192,5 +204,10 @@ public partial class UpdatesSettingsPage : SettingsPageBase
     {
         CloseDrawer();
         await UpdateService.CheckUpdateAsync(isForce: true);
+    }
+
+    private void IconUpdateStatus_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        IsEasterEggTriggered = true;
     }
 }

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
@@ -246,7 +246,7 @@
             <!-- 兼容透明模式 -->
             <ci:SettingsCard IconGlyph="CogOutline"
                                    Header="兼容透明模式"
-                                   Description="若启用，应用将使用资源占用更高的备选方法（AllowTransparency）而非默认方法（WindowChrome）实现窗口透明，且不支持全屏提醒特效等功能。可以解决叠加异常、黑底等显示问题。"
+                                   Description="若启用，应用将使用资源占用更高的备选方法（AllowTransparency）而非默认方法（WindowChrome）实现窗口透明，且不支持全屏提醒特效等功能。可能会解决叠加异常、黑底等部分显示问题。"
                                    IsOn="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Mode=TwoWay}"
                                    Margin="0 0 0 6" />
 

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
@@ -213,7 +213,7 @@
                             <ci:SettingsControl IconGlyph="Input"
                                                     IsCompact="True"
                                                    Header="使用原始输入"
-                                                   Description="启用后，ClassIsland 将使用 RawInput 接收鼠标/触屏事件，可以辨别鼠标和触摸事件，并分别做出更适宜的响应。如果出现不兼容的问题，请尝试禁用此选项。"
+                                                   Description="启用后，ClassIsland 将使用 RawInput 接收鼠标/触屏事件，而不是轮询获取光标位置。这允许应用辨别鼠标和触摸事件，并分别做出更适宜的响应。如果出现不兼容的问题，请尝试禁用此选项。"
                                                    IsOn="{Binding SettingsService.Settings.UseRawInput, Mode=TwoWay}"
                                                    Margin="0 0 0 6" />
                             <!-- 触屏点击后自动恢复 -->
@@ -246,7 +246,7 @@
             <!-- 兼容透明模式 -->
             <ci:SettingsCard IconGlyph="CogOutline"
                                    Header="兼容透明模式"
-                                   Description="默认情况下主界面使用性能较好的 WindowChrome 实现窗口透明。如果出现显示异常（如叠加异常、黑底等问题），可以开启此选项。启用后将使用兼容性较好的 AllowTransparency 实现透明，但资源占用可能略高，且部分功能（如全屏提醒特效等）将不可用。"
+                                   Description="若启用，应用将使用资源占用更高的备选方法（AllowTransparency）而非默认方法（WindowChrome）实现窗口透明，且不支持全屏提醒特效等功能。可以解决叠加异常、黑底等显示问题。"
                                    IsOn="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Mode=TwoWay}"
                                    Margin="0 0 0 6" />
 

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
@@ -213,7 +213,7 @@
                             <ci:SettingsControl IconGlyph="Input"
                                                     IsCompact="True"
                                                    Header="使用原始输入"
-                                                   Description="启用后，ClassIsland 使用 RawInput 接受鼠标/触屏事件，将可以辨别鼠标和触摸事件，做出更适合鼠标/触屏的响应。如果出现不兼容的问题，请尝试禁用此选项。禁用后将采用1.4及以前版本中轮询判断光标位置的行为。"
+                                                   Description="启用后，ClassIsland 将使用 RawInput 接收鼠标/触屏事件，可以辨别鼠标和触摸事件，并分别做出更适宜的响应。如果出现不兼容的问题，请尝试禁用此选项。"
                                                    IsOn="{Binding SettingsService.Settings.UseRawInput, Mode=TwoWay}"
                                                    Margin="0 0 0 6" />
                             <!-- 触屏点击后自动恢复 -->

--- a/ClassIsland/Views/SettingsWindowNew.xaml
+++ b/ClassIsland/Views/SettingsWindowNew.xaml
@@ -296,7 +296,7 @@
                                 </StackPanel.Resources>
                                 <materialDesign:Chip
                                     Visibility="{Binding ViewModel.IsRequestedRestart, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                    ToolTip="部分设置需要重启以应用"
+                                    ToolTip="部分设置需要重启应用后生效。"
                                     Click="ButtonRestartApp_OnClick"
                                     Icon="{materialDesign:PackIcon Restart}">
                                     <TextBlock>

--- a/ClassIsland/Views/WelcomeWindow.xaml
+++ b/ClassIsland/Views/WelcomeWindow.xaml
@@ -262,7 +262,7 @@
 
                                     <controls1:SettingsCard IconGlyph="CalendarOutline" Header="学期开始时间"
                                                            Margin="0 6 0 0"
-                                                           Description="此时间将作为学期的第一天，用于应用对多周轮换课表的计算。">
+                                                           Description="此时间将作为学期的第一天，用于多周轮换课表的计算。">
                                         <controls1:SettingsCard.Switcher>
                                             <DatePicker
                                                 SelectedDate="{Binding ViewModel.Settings.SingleWeekStartTime}"
@@ -442,15 +442,15 @@
                                                 <controls1:SettingsControl HasSwitcher="False"
                                                                            IconGlyph="Code"
                                                                            Header="注册 Url 协议"
-                                                                           Description="注册 Url 协议后，可以从外部通过 classisland:// 协议调用应用的功能。" />
+                                                                           Description="允许第三方应用或网页通过 Url 协议调用本应用的部分功能，详见帮助文档。" />
                                             </CheckBox>
                                             <CheckBox Margin="22 0 0 0"
                                                       IsChecked="{Binding ViewModel.CreateClassSwapShortcut}"
                                                       IsEnabled="{Binding ViewModel.RegisterUrlScheme}">
                                                 <controls1:SettingsControl HasSwitcher="False"
                                                                            IconGlyph="SwapHorizontal"
-                                                                           Header="在桌面创建快捷换课快捷方式"
-                                                                           Description="创建快捷方式后，可以在桌面点击快捷方式一键开始换课。" />
+                                                                           Header="在桌面创建换课快捷方式"
+                                                                           Description="打开此快捷方式可以一键开始换课。" />
                                             </CheckBox>
                                         </StackPanel>
                                     </StackPanel>
@@ -516,13 +516,18 @@
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition/>
                                                             <ColumnDefinition/>
-                                                            <ColumnDefinition/>
                                                         </Grid.ColumnDefinitions>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition/>
+                                                            <RowDefinition/>
+                                                        </Grid.RowDefinitions>
                                                         <controls1:InfoCard Grid.Column="0"
+                                                                            Grid.Row="0"
                                                                             IconKind="HelpCircleOutline"
                                                                             Margin="4 0"
                                                                             VerticalAlignment="Top"
-                                                                            Content="您可以阅读帮助文档来了解更多有关 ClassIsland 的信息。">
+                                                                            Title="阅读文档"
+                                                                            Content="阅读帮助文档来了解有关 ClassIsland 的更多信息。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
@@ -534,10 +539,12 @@
                                                             </controls1:InfoCard.ActionButton>
                                                         </controls1:InfoCard>
                                                         <controls1:InfoCard Grid.Column="1"
+                                                                            Grid.Row="0"
                                                                             IconKind="Youtube"
                                                                             Margin="4 0"
                                                                             VerticalAlignment="Top"
-                                                                            Content="您可以观看入门教程视频快速上手 ClassIsland。">
+                                                                            Title="观看教程视频"
+                                                                            Content="通过视频，10 分钟快速上手 ClassIsland。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
@@ -548,24 +555,43 @@
                                                                 </WrapPanel>
                                                             </controls1:InfoCard.ActionButton>
                                                         </controls1:InfoCard>
-                                                        <controls1:InfoCard Grid.Column="2"
+                                                        <controls1:InfoCard Grid.Column="0"
+                                                                            Grid.Row="1"
+                                                                            IconKind="BookEdit"
+                                                                            Margin="4 0"
+                                                                            VerticalAlignment="Top"
+                                                                            Title="创建档案"
+                                                                            Content="开始编辑您的第一份时间表和课表。">
+                                                            <controls1:InfoCard.ActionButton>
+                                                                <WrapPanel>
+                                                                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                                                                            Command="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"
+                                                                            CommandParameter="classisland://app/profile/">
+                                                                        <commands:IconText Kind="LeadPencil" Text="打开编辑档案界面…"/>
+                                                                    </Button>
+                                                                </WrapPanel>
+                                                            </controls1:InfoCard.ActionButton>
+                                                        </controls1:InfoCard>
+                                                        <controls1:InfoCard Grid.Column="1"
+                                                                            Grid.Row="1"
                                                                             IconKind="ApplicationImport"
                                                                             VerticalAlignment="Top"
                                                                             Margin="4 0"
-                                                                            Content="ClassIsland 也支持从其它课表显示软件导入课表信息。">
+                                                                            Title="从其他软件导入"
+                                                                            Content="从其他课表显示软件导入课表信息。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     
                                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
                                                                             Command="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"
                                                                             CommandParameter="https://migrate.classisland.tech/">
-                                                                        <commands:IconText Kind="ApplicationImport" Text="从其它课表软件导入…"/>
+                                                                        <commands:IconText Kind="Internet" Text="打开导入工具网页…"/>
                                                                     </Button>
                                                                 </WrapPanel>
                                                             </controls1:InfoCard.ActionButton>
                                                         </controls1:InfoCard>
                                                     </Grid>
-                                                    <TextBlock Text="点击【完成】即可完成设置向导。"/>
+                                                    <TextBlock Text="点击【完成】即可结束设置向导。"/>
                                                 </StackPanel>
                                             </materialDesign:TransitionerSlide>
                                         </materialDesign:Transitioner>

--- a/ClassIsland/Views/WelcomeWindow.xaml
+++ b/ClassIsland/Views/WelcomeWindow.xaml
@@ -442,7 +442,7 @@
                                                 <controls1:SettingsControl HasSwitcher="False"
                                                                            IconGlyph="Code"
                                                                            Header="注册 Url 协议"
-                                                                           Description="允许第三方应用或网页通过 Url 协议调用本应用的部分功能，详见帮助文档。" />
+                                                                           Description="允许第三方应用或网页通过 Url 协议 classisland:// 调用本应用的部分功能，详见帮助文档。" />
                                             </CheckBox>
                                             <CheckBox Margin="22 0 0 0"
                                                       IsChecked="{Binding ViewModel.CreateClassSwapShortcut}"
@@ -527,7 +527,7 @@
                                                                             Margin="4 0"
                                                                             VerticalAlignment="Top"
                                                                             Title="阅读文档"
-                                                                            Content="阅读帮助文档来了解有关 ClassIsland 的更多信息。">
+                                                                            Content="阅读帮助文档来了解有关 ClassIsland 的更多信息和技术细节。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
@@ -544,7 +544,7 @@
                                                                             Margin="4 0"
                                                                             VerticalAlignment="Top"
                                                                             Title="观看教程视频"
-                                                                            Content="通过视频，10 分钟快速上手 ClassIsland。">
+                                                                            Content="只需十分钟，带您快速上手 ClassIsland。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
@@ -578,7 +578,7 @@
                                                                             VerticalAlignment="Top"
                                                                             Margin="4 0"
                                                                             Title="从其他软件导入"
-                                                                            Content="从其他课表显示软件导入课表信息。">
+                                                                            Content="从其他课表软件导入课表信息。">
                                                             <controls1:InfoCard.ActionButton>
                                                                 <WrapPanel>
                                                                     


### PR DESCRIPTION
原 #301 ，现在改为向master分支合并，除了原有的改动外还新增了以下修改：
- 进一步优化显示文本，尽量让可读性和技术细节并存
- 下课时显示的课间时间会以自然语言显示（例如“15分钟”或“1小时2分钟34秒”）
  ![image](https://github.com/user-attachments/assets/a67233ea-2264-41b4-96b3-6acaf74cb60d)
- 保留了设置中更新页面的文本更改，但是新增了一个彩蛋，双击左上角的图标可以把整个更新设置页变成微软式中文 ~~（虽然好像还变得不够彻底？）~~
  ![demo](https://github.com/user-attachments/assets/496e73dc-307c-483e-b5e2-bc5b0659a949)