### PR TITLE
行动：编写进度报告

### DIFF
--- a/ClassIsland.Core/Abstractions/Controls/ActionSettingsControlBase.cs
+++ b/ClassIsland.Core/Abstractions/Controls/ActionSettingsControlBase.cs
@@ -1,0 +1,88 @@
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Windows.Controls;
+
+using ClassIsland.Core.Attributes;
+using ClassIsland.Core.Models;
+using ClassIsland.Core.Models.Action;
+using ClassIsland.Shared;
+using ClassIsland.Shared.Interfaces;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClassIsland.Core.Abstractions.Controls;
+
+/// <summary>
+/// 可附加设置的控件
+/// </summary>
+public abstract class ActionSettingsControlBase : UserControl, INotifyPropertyChanged
+{
+    [NotNull] internal object? SettingsInternal { get; set; }
+
+    /// <summary>
+    /// 从设置对象获取控件实例。
+    /// </summary>
+    /// <param name="info">控件信息</param>
+    /// <param name="settings">要附加的设置对象</param>
+    /// <returns>初始化的控件对象。</returns>
+    public static ActionSettingsControlBase? GetInstance(ActionRegistryInfo info, ref object? settings)
+    {
+        var control = IAppHost.Host?.Services.GetKeyedService<ActionSettingsControlBase>(info.Id);
+        if (control == null || info.SettingsControlType == null)
+        {
+            return null;
+        }
+
+        var baseType = info.SettingsControlType.BaseType;
+        if (baseType?.GetGenericArguments().Length > 0)
+        {
+            var settingsType = baseType.GetGenericArguments().First();
+            var settingsReal = settings ?? Activator.CreateInstance(settingsType);
+            if (settingsReal is JsonElement json)
+            {
+                settingsReal = json.Deserialize(settingsType);
+            }
+
+            if (settingsReal?.GetType() != settingsType)
+            {
+                settingsReal = Activator.CreateInstance(settingsType);
+            }
+            settings = settingsReal;
+
+            control.SettingsInternal = settingsReal;
+        }
+        return control;
+    }
+
+    #region PropertyChanged
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// 可附加设置的控件
+/// </summary>
+public abstract class ActionSettingsControlBase<T> : ActionSettingsControlBase where T : class
+{
+    /// <summary>
+    /// 当前控件的设置
+    /// </summary>
+    public T Settings => (SettingsInternal as T)!;
+}

--- a/ClassIsland.Core/Abstractions/Services/IActionService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IActionService.cs
@@ -1,0 +1,35 @@
+﻿using ClassIsland.Shared;
+using ClassIsland.Core.Models.Action;
+using Action = ClassIsland.Core.Models.Action.Action;
+namespace ClassIsland.Core.Abstractions.Services;
+
+/// <summary>
+/// 行动服务。
+/// </summary>
+public interface IActionService
+{
+    /// <summary>
+    /// 已经注册的行动列表。
+    /// </summary>
+    static ObservableDictionary<string, ActionRegistryInfo> Actions { get; } = [];
+
+    /// <summary>
+    /// 注册指定行动的处理方法。
+    /// </summary>
+    void RegisterActionHandler(string id, ActionRegistryInfo.HandleDelegate handler);
+
+    /// <summary>
+    /// 注册指定行动的恢复方法。
+    /// </summary>
+    void RegisterActionBackHandler(string id, ActionRegistryInfo.HandleDelegate handler);
+
+    /// <summary>
+    /// 触发行动。
+    /// </summary>
+    void InvokeAction(List<Action> actions);
+
+    /// <summary>
+    /// 触发恢复行动。
+    /// </summary>
+    void InvokeBackAction(List<Action> actions);
+}

--- a/ClassIsland.Core/Abstractions/Services/IActionService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IActionService.cs
@@ -23,12 +23,14 @@ public interface IActionService
     void RegisterActionBackHandler(string id, ActionRegistryInfo.HandleDelegate handler);
 
     /// <summary>
-    /// 触发行动。
+    /// 触发行动列表。
     /// </summary>
     void InvokeActionList(ActionList actionList);
 
     /// <summary>
-    /// 触发恢复行动。
+    /// 触发恢复行动列表。
     /// </summary>
     void InvokeBackActionList(ActionList actionList);
+
+    internal void DebugInvokeActionListSync(ActionList actionList);
 }

--- a/ClassIsland.Core/Abstractions/Services/IActionService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IActionService.cs
@@ -1,6 +1,5 @@
 ﻿using ClassIsland.Shared;
 using ClassIsland.Core.Models.Action;
-using Action = ClassIsland.Core.Models.Action.Action;
 namespace ClassIsland.Core.Abstractions.Services;
 
 /// <summary>
@@ -26,10 +25,10 @@ public interface IActionService
     /// <summary>
     /// 触发行动。
     /// </summary>
-    void InvokeAction(List<Action> actions);
+    void InvokeActionList(ActionList actionList);
 
     /// <summary>
     /// 触发恢复行动。
     /// </summary>
-    void InvokeBackAction(List<Action> actions);
+    void InvokeBackActionList(ActionList actionList);
 }

--- a/ClassIsland.Core/Controls/Action/ActionControl.xaml
+++ b/ClassIsland.Core/Controls/Action/ActionControl.xaml
@@ -1,0 +1,55 @@
+﻿<UserControl x:Class="ClassIsland.Core.Controls.Action.ActionControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ClassIsland.Core.Controls.Action"
+             xmlns:controls="clr-namespace:ClassIsland.Core.Controls"
+             xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.CommandBindings>
+        <CommandBinding Command="{x:Static local:ActionControl.RemoveActionCommand}" Executed="CommandRemoveActionCommand_OnExecuted"/>
+    </UserControl.CommandBindings>
+    <StackPanel DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:ActionControl}}">
+        <Button Style="{StaticResource MaterialDesignFlatButton}" Click="ButtonAddAction_OnClick" HorizontalAlignment="Left">
+            <controls:IconText Kind="Plus" Text="添加行动"/>
+        </Button>
+        <ItemsControl ItemsSource="{Binding Actions}"
+                 HorizontalContentAlignment="Stretch">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="{DynamicResource MaterialDesignToolBarBackground}"
+                            CornerRadius="2"
+                            Margin="3">
+                        <StackPanel Margin="0 10" Orientation="Horizontal">
+                            <Button Grid.Column="2"
+                                    Content="{materialDesign:PackIcon Remove}"
+                                    Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                    ToolTip="删除"
+                                    Command="{x:Static local:ActionControl.RemoveActionCommand}"
+                                    CommandParameter="{Binding}"/>
+                            <WrapPanel>
+                                <ComboBox SelectedValue="{Binding Id}"
+                                          SelectedValuePath="Key"
+                                          ItemsSource="{x:Static services:IActionService.Actions}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <controls:IconText Kind="{Binding Value.IconKind}"
+                                                               Text="{Binding Value.Name}"/>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                                <local:ActionSettingsControlPresenter
+                                    Action="{Binding Mode=OneWay}"
+                                    ActionId="{Binding Id, Mode=OneWay}"/>
+                            </WrapPanel>
+                        </StackPanel>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </StackPanel>
+</UserControl>

--- a/ClassIsland.Core/Controls/Action/ActionControl.xaml
+++ b/ClassIsland.Core/Controls/Action/ActionControl.xaml
@@ -17,7 +17,7 @@
         <Button Style="{StaticResource MaterialDesignFlatButton}" Click="ButtonAddAction_OnClick" HorizontalAlignment="Left">
             <controls:IconText Kind="Plus" Text="添加行动"/>
         </Button>
-        <ItemsControl ItemsSource="{Binding Actions}"
+        <ItemsControl ItemsSource="{Binding ActionList.Actions}"
                  HorizontalContentAlignment="Stretch">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>

--- a/ClassIsland.Core/Controls/Action/ActionControl.xaml
+++ b/ClassIsland.Core/Controls/Action/ActionControl.xaml
@@ -8,6 +8,7 @@
              xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services"
+             xmlns:dd="urn:gong-wpf-dragdrop"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.CommandBindings>
@@ -18,23 +19,40 @@
             <controls:IconText Kind="Plus" Text="添加行动"/>
         </Button>
         <ItemsControl ItemsSource="{Binding ActionList.Actions}"
-                 HorizontalContentAlignment="Stretch">
+                      MinHeight="10"
+                      HorizontalContentAlignment="Stretch"
+                      dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True"
+                      dd:DragDrop.DropTargetAdornerBrush="{DynamicResource PrimaryHueMidBrush}"
+                      HorizontalAlignment="Stretch">
+            <dd:DragDrop.EffectMoveAdornerTemplate>
+                <DataTemplate>
+                    <materialDesign:ColorZone Mode="PrimaryMid" Height="24" CornerRadius="12">
+                        <controls:IconText Kind="ArrowUpDown" Text="调整行动顺序"
+                                     Margin="4 0"
+                                     IconMargin="2"
+                                     TextElement.FontWeight="Medium"
+                                     VerticalAlignment="Center"/>
+                    </materialDesign:ColorZone>
+                </DataTemplate>
+            </dd:DragDrop.EffectMoveAdornerTemplate>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Border Background="{DynamicResource MaterialDesignToolBarBackground}"
-                            CornerRadius="2"
-                            Margin="3">
-                        <StackPanel Margin="0 10" Orientation="Horizontal">
+                    <Border BorderThickness="1"
+                            BorderBrush="{DynamicResource MaterialDesignDivider}"
+                            Background="{DynamicResource MaterialDesignPaper}"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Margin="0 8" Orientation="Horizontal">
                             <Button Grid.Column="2"
                                     Content="{materialDesign:PackIcon Remove}"
                                     Style="{StaticResource MaterialDesignToolForegroundButton}"
                                     ToolTip="删除"
                                     Command="{x:Static local:ActionControl.RemoveActionCommand}"
                                     CommandParameter="{Binding}"/>
-                            <WrapPanel>
+                            <WrapPanel VerticalAlignment="Center">
                                 <ComboBox SelectedValue="{Binding Id}"
                                           SelectedValuePath="Key"
-                                          ItemsSource="{x:Static services:IActionService.Actions}">
+                                          ItemsSource="{x:Static services:IActionService.Actions}"
+                                          MinWidth="100">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <controls:IconText Kind="{Binding Value.IconKind}"
@@ -44,7 +62,8 @@
                                 </ComboBox>
                                 <local:ActionSettingsControlPresenter
                                     Action="{Binding Mode=OneWay}"
-                                    ActionId="{Binding Id, Mode=OneWay}"/>
+                                    ActionId="{Binding Id, Mode=OneWay}"
+                                    Margin="6 0"/>
                             </WrapPanel>
                         </StackPanel>
                     </Border>

--- a/ClassIsland.Core/Controls/Action/ActionControl.xaml.cs
+++ b/ClassIsland.Core/Controls/Action/ActionControl.xaml.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.ObjectModel;
+﻿using ClassIsland.Core.Models.Action;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+
 using A = ClassIsland.Core.Models.Action;
 namespace ClassIsland.Core.Controls.Action;
 
@@ -10,34 +11,28 @@ namespace ClassIsland.Core.Controls.Action;
 /// </summary>
 public partial class ActionControl : UserControl
 {
-    /// <summary>
-    /// 删除行动命令。
-    /// </summary>
-    public static readonly ICommand RemoveActionCommand = new RoutedUICommand();
-
-    public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(nameof(Actions), typeof(ObservableCollection<A.Action>), typeof(ActionControl), new PropertyMetadata(default(ObservableCollection<A.Action>)));
-    /// <summary>
-    /// 该规则集绑定的行动集合。
-    /// </summary>
-    public ObservableCollection<A.Action> Actions
-    {
-        get { return (ObservableCollection<A.Action>)GetValue(ActionsProperty); }
-        set { SetValue(ActionsProperty, value); }
-    }
-
     public ActionControl()
     {
         InitializeComponent();
     }
 
+    public static readonly ICommand RemoveActionCommand = new RoutedUICommand();
+
+    public static readonly DependencyProperty ActionListProperty = DependencyProperty.Register(nameof(ActionList), typeof(ActionList), typeof(ActionControl), new PropertyMetadata(default(ActionList)));
+    public ActionList ActionList
+    {
+        get { return (ActionList)GetValue(ActionListProperty); }
+        set { SetValue(ActionListProperty, value); }
+    }
+
     private void ButtonAddAction_OnClick(object sender, RoutedEventArgs e)
     {
-        Actions.Add(new());
+        ActionList.Actions.Add(new());
     }
 
     private void CommandRemoveActionCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
         if (e.Parameter is not A.Action action) return;
-        Actions.Remove(action);
+        ActionList.Actions.Remove(action);
     }
 }

--- a/ClassIsland.Core/Controls/Action/ActionControl.xaml.cs
+++ b/ClassIsland.Core/Controls/Action/ActionControl.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using A = ClassIsland.Core.Models.Action;
+namespace ClassIsland.Core.Controls.Action;
+
+/// <summary>
+/// ActionControl.xaml 的交互逻辑
+/// </summary>
+public partial class ActionControl : UserControl
+{
+    /// <summary>
+    /// 删除行动命令。
+    /// </summary>
+    public static readonly ICommand RemoveActionCommand = new RoutedUICommand();
+
+    public static readonly DependencyProperty ActionsProperty = DependencyProperty.Register(nameof(Actions), typeof(ObservableCollection<A.Action>), typeof(ActionControl), new PropertyMetadata(default(ObservableCollection<A.Action>)));
+    /// <summary>
+    /// 该规则集绑定的行动集合。
+    /// </summary>
+    public ObservableCollection<A.Action> Actions
+    {
+        get { return (ObservableCollection<A.Action>)GetValue(ActionsProperty); }
+        set { SetValue(ActionsProperty, value); }
+    }
+
+    public ActionControl()
+    {
+        InitializeComponent();
+    }
+
+    private void ButtonAddAction_OnClick(object sender, RoutedEventArgs e)
+    {
+        Actions.Add(new());
+    }
+
+    private void CommandRemoveActionCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not A.Action action) return;
+        Actions.Remove(action);
+    }
+}

--- a/ClassIsland.Core/Controls/Action/ActionSettingsControlPresenter.xaml
+++ b/ClassIsland.Core/Controls/Action/ActionSettingsControlPresenter.xaml
@@ -1,0 +1,13 @@
+<UserControl 
+    x:Class="ClassIsland.Core.Controls.Action.ActionSettingsControlPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:local="clr-namespace:ClassIsland.Core.Controls.Action"
+    xmlns:controls="clr-namespace:ClassIsland.Core.Controls"
+    xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services">
+    <ContentPresenter x:Name="RootContentPresenter"/>
+</UserControl>

--- a/ClassIsland.Core/Controls/Action/ActionSettingsControlPresenter.xaml.cs
+++ b/ClassIsland.Core/Controls/Action/ActionSettingsControlPresenter.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Core.Abstractions.Services;
+using A = ClassIsland.Core.Models.Action;
+
+namespace ClassIsland.Core.Controls.Action;
+
+/// <summary>
+/// 行动设置控件显示控件。
+/// </summary>
+public partial class ActionSettingsControlPresenter : UserControl
+{
+    public static readonly DependencyProperty ActionIdProperty = DependencyProperty.Register(
+        nameof(ActionId), typeof(string), typeof(ActionSettingsControlPresenter), new PropertyMetadata(default(string), (o, args) =>
+        {
+            if (o is ActionSettingsControlPresenter control)
+            {
+                control.UpdateContent();
+            }
+        }));
+
+    public string ActionId
+    {
+        get { return (string)GetValue(ActionIdProperty); }
+        set { SetValue(ActionIdProperty, value); }
+    }
+
+    public static readonly DependencyProperty ActionProperty = DependencyProperty.Register(
+        nameof(Action), typeof(A.Action), typeof(ActionSettingsControlPresenter), new PropertyMetadata(default(A.Action), (o, args) =>
+        {
+            if (o is ActionSettingsControlPresenter control)
+            {
+                control.UpdateContent();
+            }
+        }));
+
+    public A.Action? Action
+    {
+        get { return (A.Action)GetValue(ActionProperty); }
+        set { SetValue(ActionProperty, value); }
+    }
+
+    public ActionSettingsControlPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private void UpdateContent()
+    {
+        if (Action == null || ActionId == null)
+        {
+            return;
+        }
+        if (!IActionService.Actions.TryGetValue(ActionId, out var info))
+        {
+            return;
+        }
+
+        var ActionSettings = Action.Settings;
+        RootContentPresenter.Content = ActionSettingsControlBase.GetInstance(info, ref ActionSettings);
+        Action.Settings = ActionSettings;
+    }
+}

--- a/ClassIsland.Core/Controls/Ruleset/RulesetControl.xaml
+++ b/ClassIsland.Core/Controls/Ruleset/RulesetControl.xaml
@@ -28,7 +28,7 @@
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0">
             <TextBlock Text="规则集" Style="{StaticResource MaterialDesignHeadline5TextBlock}"
-                           Margin="0 0 0 8" />
+                           Margin="0 0 0 8" Visibility="{Binding ShowTitle, Converter={StaticResource BooleanToVisibilityConverter}}"/>
             <WrapPanel Orientation="Horizontal">
                 <ComboBox SelectedIndex="{Binding Ruleset.Mode, Converter={StaticResource RuleLogicalModeToIntConverter}}"
                           Style="{StaticResource MaterialDesignFloatingHintComboBox}"

--- a/ClassIsland.Core/Controls/Ruleset/RulesetControl.xaml.cs
+++ b/ClassIsland.Core/Controls/Ruleset/RulesetControl.xaml.cs
@@ -52,6 +52,15 @@ public partial class RulesetControl : UserControl
         set { SetValue(RulesetProperty, value); }
     }
 
+    public static readonly DependencyProperty ShowTitleProperty = DependencyProperty.Register(
+        nameof(ShowTitle), typeof(bool), typeof(RulesetControl), new PropertyMetadata(true));
+
+    public bool ShowTitle
+    {
+        get { return (bool)GetValue(ShowTitleProperty); }
+        set { SetValue(ShowTitleProperty, value); }
+    }
+
     /// <inheritdoc />
     public RulesetControl()
     {

--- a/ClassIsland.Core/Converters/RuleLogicalModeToBooleanConverter.cs
+++ b/ClassIsland.Core/Converters/RuleLogicalModeToBooleanConverter.cs
@@ -1,0 +1,19 @@
+﻿using ClassIsland.Core.Enums;
+
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ClassIsland.Core.Converters;
+
+public class RuleLogicalModeToBooleanConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return (RulesetLogicalMode)value == RulesetLogicalMode.And;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return (bool)value ? RulesetLogicalMode.And : RulesetLogicalMode.Or;
+    }
+}

--- a/ClassIsland.Core/Extensions/Registry/ActionRegistryExtensions.cs
+++ b/ClassIsland.Core/Extensions/Registry/ActionRegistryExtensions.cs
@@ -1,0 +1,80 @@
+﻿using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Models.Action;
+
+using MaterialDesignThemes.Wpf;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClassIsland.Core.Extensions.Registry;
+
+/// <summary>
+/// 注册行动的<see cref="IServiceCollection"/>扩展。
+/// </summary>
+public static class ActionRegistryExtensions
+{
+    /// <summary>
+    /// 注册无设置行动。
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/>对象。</param>
+    /// <param name="id">行动ID，例如“classisland.example”。</param>
+    /// <param name="name">行动名称。/</param>
+    /// <param name="iconKind">行动图标。</param>
+    /// <param name="onHandle">行动处理程序。</param>
+    /// <returns><see cref="IServiceCollection"/>对象。</returns>
+    public static IServiceCollection AddAction
+        (this IServiceCollection services,
+         string id,
+         string name = "",
+         PackIconKind iconKind = PackIconKind.BacteriaOutline,
+         ActionRegistryInfo.HandleDelegate? onHandle = null)
+    {
+        Register(id, name, iconKind, onHandle);
+        return services;
+    }
+
+    /// <summary>
+    /// 注册行动。
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/>对象。</param>
+    /// <param name="id">行动ID，例如“classisland.example”。</param>
+    /// <param name="name">行动名称。/</param>
+    /// <param name="iconKind">行动图标。</param>
+    /// <param name="onHandle">行动处理程序。</param>
+    /// <typeparam name="TSettings">行动设置类型。</typeparam>
+    /// <typeparam name="TSettingsControl">行动设置控件类型。</typeparam>
+    /// <returns><see cref="IServiceCollection"/>对象。</returns>
+    public static IServiceCollection AddAction<TSettings, TSettingsControl>
+        (this IServiceCollection services,
+         string id,
+         string name = "",
+         PackIconKind iconKind = PackIconKind.BacteriaOutline,
+         ActionRegistryInfo.HandleDelegate? onHandle = null)
+         where TSettingsControl : ActionSettingsControlBase
+    {
+        var info = Register(id, name, iconKind, onHandle);
+        services.AddKeyedTransient<ActionSettingsControlBase, TSettingsControl>(id);
+        info.SettingsType = typeof(TSettings);
+        info.SettingsControlType = typeof(TSettingsControl);
+        return services;
+    }
+
+
+    private static ActionRegistryInfo Register
+        (string id,
+         string name = "",
+         PackIconKind iconKind = PackIconKind.BacteriaOutline,
+         ActionRegistryInfo.HandleDelegate? onHandle = null)
+    {
+        if (IActionService.Actions.ContainsKey(id))
+        {
+            throw new InvalidOperationException($"已注册ID为 {id} 的行动。");
+        }
+
+        var info = new ActionRegistryInfo(id, name, iconKind);
+        info.Handle += onHandle;
+        IActionService.Actions.Add(id, info);
+
+        return info;
+    }
+}

--- a/ClassIsland.Core/Models/Action/Action.cs
+++ b/ClassIsland.Core/Models/Action/Action.cs
@@ -2,7 +2,7 @@
 namespace ClassIsland.Core.Models.Action;
 
 /// <summary>
-/// 代表一个行动条目。
+/// 代表一个行动。
 /// </summary>
 public class Action : ObservableRecipient
 {

--- a/ClassIsland.Core/Models/Action/Action.cs
+++ b/ClassIsland.Core/Models/Action/Action.cs
@@ -1,0 +1,38 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+namespace ClassIsland.Core.Models.Action;
+
+/// <summary>
+/// 代表一个行动条目。
+/// </summary>
+public class Action : ObservableRecipient
+{
+    private string _id = "";
+    /// <summary>
+    /// 行动 ID。
+    /// </summary>
+    public string Id
+    {
+        get => _id;
+        set
+        {
+            if (value == _id) return;
+            _id = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private object? _settings;
+    /// <summary>
+    /// 行动设置。
+    /// </summary>
+    public object? Settings
+    {
+        get => _settings;
+        set
+        {
+            if (Equals(value, _settings)) return;
+            _settings = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland.Core/Models/Action/ActionList.cs
+++ b/ClassIsland.Core/Models/Action/ActionList.cs
@@ -33,4 +33,19 @@ public class ActionList : ObservableRecipient
             OnPropertyChanged();
         }
     }
+
+    private bool _isOn = false;
+    /// <summary>
+    /// 行动列表已被激活、还未恢复。
+    /// </summary>
+    public bool IsOn
+    {
+        get => _isOn;
+        set
+        {
+            if (value == _isOn) return;
+            _isOn = value;
+            OnPropertyChanged();
+        }
+    }
 }

--- a/ClassIsland.Core/Models/Action/ActionList.cs
+++ b/ClassIsland.Core/Models/Action/ActionList.cs
@@ -1,0 +1,36 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+namespace ClassIsland.Core.Models.Action;
+
+/// <summary>
+/// 代表一个行动列表。
+/// </summary>
+public class ActionList : ObservableRecipient
+{
+    private string _guid = System.Guid.NewGuid().ToString();
+    /// <summary>
+    /// 行动列表唯一Guid。
+    /// </summary>
+    public string Guid
+    {
+        get => _guid;
+        set
+        {
+            if (value == _guid) return;
+            _guid = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private ObservableCollection<Action> _actions = [];
+    public ObservableCollection<Action> Actions
+    {
+        get => _actions;
+        set
+        {
+            if (value == _actions) return;
+            _actions = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland.Core/Models/Action/ActionRegistryInfo.cs
+++ b/ClassIsland.Core/Models/Action/ActionRegistryInfo.cs
@@ -35,7 +35,7 @@ public class ActionRegistryInfo(string id, string name = "", PackIconKind iconKi
     /// </summary>
     public Type? SettingsType { get; internal set; }
 
-    public delegate void HandleDelegate(object? settings);
+    public delegate void HandleDelegate(object? settings, string guid);
 
     public HandleDelegate? Handle;
 

--- a/ClassIsland.Core/Models/Action/ActionRegistryInfo.cs
+++ b/ClassIsland.Core/Models/Action/ActionRegistryInfo.cs
@@ -1,0 +1,43 @@
+﻿using MaterialDesignThemes.Wpf;
+
+namespace ClassIsland.Core.Models.Action;
+
+/// <summary>
+/// 代表一个行动的注册信息。
+/// </summary>
+/// <param name="id">行动ID，例如“classisland.example”。</param>
+/// <param name="name">行动显示名称。</param>
+/// <param name="iconKind">行动图标。</param>
+public class ActionRegistryInfo(string id, string name = "", PackIconKind iconKind = PackIconKind.BacteriaOutline)
+{
+    /// <summary>
+    /// 行动 ID。
+    /// </summary>
+    public string Id { get; internal set; } = id;
+
+    /// <summary>
+    /// 行动显示图标类型。
+    /// </summary>
+    public PackIconKind IconKind { get; internal set; } = iconKind;
+
+    /// <summary>
+    /// 行动显示名称。
+    /// </summary>
+    public string Name { get; internal set; } = string.IsNullOrEmpty(name) ? id : name;
+
+    /// <summary>
+    /// 设置控件类型。
+    /// </summary>
+    public Type? SettingsControlType { get; internal set; }
+
+    /// <summary>
+    /// 设置类型。
+    /// </summary>
+    public Type? SettingsType { get; internal set; }
+
+    public delegate void HandleDelegate(object? settings);
+
+    public HandleDelegate? Handle;
+
+    public HandleDelegate? BackHandle;
+}

--- a/ClassIsland.Core/Models/RuleActionPair.cs
+++ b/ClassIsland.Core/Models/RuleActionPair.cs
@@ -1,0 +1,69 @@
+﻿using ClassIsland.Core.Models.Action;
+using CommunityToolkit.Mvvm.ComponentModel;
+namespace ClassIsland.Core.Models;
+
+/// <summary>
+/// 代表一个规则行动组。
+/// </summary>
+public class RuleActionPair : ObservableRecipient
+{
+    private bool _isEnabled = true;
+    /// <summary>
+    /// 是否启用
+    /// </summary>
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (value == _isEnabled) return;
+            _isEnabled = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private string _name = "";
+    /// <summary>
+    /// 名称
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (value == _name) return;
+            _name = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private Ruleset.Ruleset _ruleset = new();
+    /// <summary>
+    /// 规则集
+    /// </summary>
+    public Ruleset.Ruleset Ruleset
+    {
+        get => _ruleset;
+        set
+        {
+            if (value == _ruleset) return;
+            _ruleset = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private ActionList _actionList = new();
+    /// <summary>
+    /// 行动列表
+    /// </summary>
+    public ActionList ActionList
+    {
+        get => _actionList;
+        set
+        {
+            if (value == _actionList) return;
+            _actionList = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland/App.xaml.cs
+++ b/ClassIsland/App.xaml.cs
@@ -68,6 +68,7 @@ using ClassIsland.Shared.IPC.Abstractions.Services;
 using dotnetCampus.Ipc.CompilerServices.GeneratedProxies;
 using ControlzEx.Native;
 using ClassIsland.Controls.ActionSettingsControls;
+using ClassIsland.Services.ActionHandlers;
 
 namespace ClassIsland;
 /// <summary>
@@ -411,11 +412,14 @@ public partial class App : AppBase, IAppHost
                 services.AddAction<CurrentComponentConfigActionSettings, CurrentComponentConfigActionSettingsControl>("classisland.settings.currentComponentConfig", "组件配置方案", PackIconKind.WidgetsOutline);
                 services.AddAction<ThemeActionSettings, ThemeActionSettingsControl>("classisland.settings.theme", "应用主题", PackIconKind.ThemeLightDark);
                 services.AddAction<WindowDockingLocationActionSettings, WindowDockingLocationActionSettingsControl>("classisland.settings.windowDockingLocation", "窗口停靠位置", PackIconKind.Monitor);
-                //services.AddAction<AppSettingsActionSettings, AppSettingsActionSettingsControl>("classisland.os.run", "运行", PackIconKind.OpenInApp);
-                //services.AddAction<AppSettingsActionSettings, AppSettingsActionSettingsControl>("classisland.action.sleep", "等待时长", PackIconKind.TimerSand);
-                //services.AddAction("classisland.app.quit", "退出 ClassIsland", PackIconKind.ExitToApp);
-                // services.AddAction<, >("classisland.windows.minimize", "最小化窗口", PackIconKind.WindowMinimize);
-                // services.AddAction<, >("classisland.windows.close", "关闭窗口", PackIconKind.WindowClose);
+                services.AddAction<RunActionSettings, RunActionSettingsControl>("classisland.os.run", "运行", PackIconKind.OpenInApp);
+                services.AddAction<SleepActionSettings, SleepActionSettingsControl>("classisland.action.sleep", "等待时长", PackIconKind.TimerSand);
+                services.AddAction("classisland.app.quit", "退出 ClassIsland", PackIconKind.ExitToApp, onHandle: (_, _) => Current.Stop());
+                // services.AddAction<, >("classisland.window.minimize", "最小化窗口", PackIconKind.WindowMinimize);
+                // services.AddAction<, >("classisland.window.close", "关闭窗口", PackIconKind.WindowClose);
+                // 行动处理
+                //services.AddSingleton<RunActionHandler>();
+                //services.AddSingleton<AppSettingsActionHandler>();
                 // Plugins
                 PluginService.InitializePlugins(context, services);
             }).Build();

--- a/ClassIsland/App.xaml.cs
+++ b/ClassIsland/App.xaml.cs
@@ -57,14 +57,17 @@ using System.Xml.Linq;
 using ClassIsland.Core;
 using ClassIsland.Core.Abstractions.Controls;
 using ClassIsland.Core.Models.Ruleset;
+using ClassIsland.Core.Models.Action;
 using ClassIsland.Shared.IPC;
 using Sentry;
 using ClassIsland.Core.Controls.Ruleset;
 using ClassIsland.Models.Rules;
+using ClassIsland.Models.Actions;
 using ClassIsland.Controls.RuleSettingsControls;
 using ClassIsland.Shared.IPC.Abstractions.Services;
 using dotnetCampus.Ipc.CompilerServices.GeneratedProxies;
 using ControlzEx.Native;
+using ClassIsland.Controls.ActionSettingsControls;
 
 namespace ClassIsland;
 /// <summary>
@@ -296,6 +299,7 @@ public partial class App : AppBase, IAppHost
                 services.AddSingleton<IPluginMarketService, PluginMarketService>();
                 services.AddSingleton<IRulesetService, RulesetService>();
                 services.AddSingleton<IWindowRuleService, WindowRuleService>();
+                services.AddSingleton<IActionService, ActionService>();
                 try // 检测SystemSpeechService是否存在
                 {
                     var s = new SpeechSynthesizer();
@@ -348,6 +352,7 @@ public partial class App : AppBase, IAppHost
                 services.AddSettingsPage<WindowSettingsPage>();
                 services.AddSettingsPage<WeatherSettingsPage>();
                 services.AddSettingsPage<UpdatesSettingsPage>();
+                services.AddSettingsPage<RuleSettingsPage>();
                 services.AddSettingsPage<StorageSettingsPage>();
                 services.AddSettingsPage<PrivacySettingsPage>();
                 services.AddSettingsPage<PluginsSettingsPage>();
@@ -402,6 +407,15 @@ public partial class App : AppBase, IAppHost
                 services.AddRule<StringMatchingSettings, RulesetStringMatchingSettingsControl>("classisland.windows.processName", "前台窗口进程", PackIconKind.ApplicationCogOutline);
                 services.AddRule<CurrentSubjectRuleSettings, CurrentSubjectRuleSettingsControl>("classisland.lessons.currentSubject", "科目是", PackIconKind.BookOutline);
                 services.AddRule<TimeStateRuleSettings, TimeStateRuleSettingsControl>("classisland.lessons.timeState", "当前时间状态是", PackIconKind.ClockOutline);
+                // 行动
+                services.AddAction<CurrentComponentConfigActionSettings, CurrentComponentConfigActionSettingsControl>("classisland.settings.currentComponentConfig", "组件配置方案", PackIconKind.WidgetsOutline);
+                services.AddAction<ThemeActionSettings, ThemeActionSettingsControl>("classisland.settings.theme", "应用主题", PackIconKind.ThemeLightDark);
+                services.AddAction<WindowDockingLocationActionSettings, WindowDockingLocationActionSettingsControl>("classisland.settings.windowDockingLocation", "窗口停靠位置", PackIconKind.Monitor);
+                //services.AddAction<AppSettingsActionSettings, AppSettingsActionSettingsControl>("classisland.os.run", "运行", PackIconKind.OpenInApp);
+                //services.AddAction<AppSettingsActionSettings, AppSettingsActionSettingsControl>("classisland.action.sleep", "等待时长", PackIconKind.TimerSand);
+                //services.AddAction("classisland.app.quit", "退出 ClassIsland", PackIconKind.ExitToApp);
+                // services.AddAction<, >("classisland.windows.minimize", "最小化窗口", PackIconKind.WindowMinimize);
+                // services.AddAction<, >("classisland.windows.close", "关闭窗口", PackIconKind.WindowClose);
                 // Plugins
                 PluginService.InitializePlugins(context, services);
             }).Build();

--- a/ClassIsland/Controls/ActionSettingsControls/CurrentComponentConfigActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/CurrentComponentConfigActionSettingsControl.xaml
@@ -1,0 +1,21 @@
+﻿<ci:ActionSettingsControlBase
+    x:Class="ClassIsland.Controls.ActionSettingsControls.CurrentComponentConfigActionSettingsControl"
+    x:TypeArguments="actions:CurrentComponentConfigActionSettings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ci="http://classisland.tech/schemas/xaml/core"
+    xmlns:actions="clr-namespace:ClassIsland.Models.Actions"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ClassIsland.Controls.ActionSettingsControls"
+    mc:Ignorable="d" 
+    d:DesignHeight="450" d:DesignWidth="800">
+    <StackPanel Orientation="Horizontal">
+        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                  ItemsSource="{Binding ComponentsService.ComponentConfigs}"
+                  MinWidth="150"
+                  SelectedItem="{Binding Settings.Value}"/>
+    </StackPanel>
+</ci:ActionSettingsControlBase>

--- a/ClassIsland/Controls/ActionSettingsControls/CurrentComponentConfigActionSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/ActionSettingsControls/CurrentComponentConfigActionSettingsControl.xaml.cs
@@ -1,0 +1,15 @@
+﻿using ClassIsland.Core.Abstractions.Services;
+
+namespace ClassIsland.Controls.ActionSettingsControls;
+
+public partial class CurrentComponentConfigActionSettingsControl
+{
+    public CurrentComponentConfigActionSettingsControl(IComponentsService componentsService)
+    {
+        ComponentsService = componentsService;
+        InitializeComponent();
+        DataContext = this;
+    }
+
+    public IComponentsService ComponentsService { get; }
+};

--- a/ClassIsland/Controls/ActionSettingsControls/RunActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/RunActionSettingsControl.xaml
@@ -1,6 +1,7 @@
 ﻿<ci:ActionSettingsControlBase
-    x:Class="ClassIsland.Controls.ActionSettingsControls.CurrentComponentConfigActionSettingsControl"
-    x:TypeArguments="actions:CurrentComponentConfigActionSettings"
+    x:Class="ClassIsland.Controls.ActionSettingsControls.RunActionSettingsControl"
+    x:TypeArguments="actions:RunActionSettings"
+    d:DataContext="{d:DesignInstance Type=local:RunActionSettingsControl}"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ci="http://classisland.tech/schemas/xaml/core"
@@ -9,12 +10,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:ClassIsland.Controls.ActionSettingsControls"
+    xmlns:controls="clr-namespace:ClassIsland.Controls"
     mc:Ignorable="d" 
     d:DesignHeight="450" d:DesignWidth="800">
     <StackPanel Orientation="Horizontal">
-        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="0 0 4 0"/>
-        <ComboBox ItemsSource="{Binding ComponentsService.ComponentConfigs}"
-                  materialDesign:HintAssist.Hint="配置方案"
-                  SelectedItem="{Binding Settings.Value}"/>
+        <TextBox Text="{Binding Settings.Value, Mode=TwoWay}" MinWidth="150" MaxWidth="300" VerticalAlignment="Center"
+                 materialDesign:HintAssist.Hint="应用程序、网址 或 cmd 命令"/>
+        <controls:FileBrowserButton CurrentPath="{Binding Settings.Value, Mode=TwoWay}"/>
     </StackPanel>
 </ci:ActionSettingsControlBase>

--- a/ClassIsland/Controls/ActionSettingsControls/RunActionSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/ActionSettingsControls/RunActionSettingsControl.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassIsland.Controls.ActionSettingsControls;
+
+public partial class RunActionSettingsControl
+{
+    public RunActionSettingsControl()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+};

--- a/ClassIsland/Controls/ActionSettingsControls/SleepActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/SleepActionSettingsControl.xaml
@@ -1,6 +1,7 @@
 ﻿<ci:ActionSettingsControlBase
-    x:Class="ClassIsland.Controls.ActionSettingsControls.CurrentComponentConfigActionSettingsControl"
-    x:TypeArguments="actions:CurrentComponentConfigActionSettings"
+    x:Class="ClassIsland.Controls.ActionSettingsControls.SleepActionSettingsControl"
+    x:TypeArguments="actions:SleepActionSettings"
+    d:DataContext="{d:DesignInstance Type=local:SleepActionSettingsControl}"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ci="http://classisland.tech/schemas/xaml/core"
@@ -9,12 +10,14 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:ClassIsland.Controls.ActionSettingsControls"
+    xmlns:controls="clr-namespace:ClassIsland.Controls"
     mc:Ignorable="d" 
     d:DesignHeight="450" d:DesignWidth="800">
     <StackPanel Orientation="Horizontal">
-        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="0 0 4 0"/>
-        <ComboBox ItemsSource="{Binding ComponentsService.ComponentConfigs}"
-                  materialDesign:HintAssist.Hint="配置方案"
-                  SelectedItem="{Binding Settings.Value}"/>
+        <TextBox VerticalAlignment="Center"
+                 MinWidth="80"
+                 Foreground="{DynamicResource MaterialDesignBody}"
+                 materialDesign:TextFieldAssist.SuffixText="秒"
+                 Text="{Binding Settings.Value, Converter={StaticResource IntToStringConverter}}"/>
     </StackPanel>
 </ci:ActionSettingsControlBase>

--- a/ClassIsland/Controls/ActionSettingsControls/SleepActionSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/ActionSettingsControls/SleepActionSettingsControl.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassIsland.Controls.ActionSettingsControls;
+
+public partial class SleepActionSettingsControl
+{
+    public SleepActionSettingsControl()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+};

--- a/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml
@@ -1,0 +1,24 @@
+﻿<ci:ActionSettingsControlBase
+    x:Class="ClassIsland.Controls.ActionSettingsControls.ThemeActionSettingsControl"
+    x:TypeArguments="actions:ThemeActionSettings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ci="http://classisland.tech/schemas/xaml/core"
+    xmlns:actions="clr-namespace:ClassIsland.Models.Actions"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ClassIsland.Controls.ActionSettingsControls"
+    mc:Ignorable="d" 
+    d:DesignHeight="450" d:DesignWidth="800">
+    <StackPanel Orientation="Horizontal">
+        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
+                  SelectedIndex="{Binding Settings.Value}"
+                  HorizontalContentAlignment="Left">
+            <ComboBoxItem Visibility="Collapsed"/>
+            <ci:IconText Kind="WhiteBalanceSunny" Text="明亮" />
+            <ci:IconText Kind="WeatherNight" Text="黑暗" />
+        </ComboBox>
+    </StackPanel>
+</ci:ActionSettingsControlBase>

--- a/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d" 
     d:DesignHeight="450" d:DesignWidth="800">
     <StackPanel Orientation="Horizontal">
-        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <TextBlock Text="临时改为" VerticalAlignment="Center" Margin="0 0 4 0"/>
         <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
                   SelectedIndex="{Binding Settings.Value}"
                   HorizontalContentAlignment="Left">

--- a/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/ActionSettingsControls/ThemeActionSettingsControl.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassIsland.Controls.ActionSettingsControls;
+
+public partial class ThemeActionSettingsControl
+{
+    public ThemeActionSettingsControl()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+};

--- a/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
@@ -16,7 +16,7 @@
     </ci:ActionSettingsControlBase.Resources>
     <StackPanel Orientation="Horizontal"
                 DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:WindowDockingLocationActionSettingsControl}}">
-        <TextBlock Text="临时移动到屏幕" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <TextBlock Text="临时移动到" VerticalAlignment="Center" Margin="6 0 4 0"/>
         <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
                   SelectedIndex="{Binding Settings.Value}"
                   HorizontalContentAlignment="Left">

--- a/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
@@ -16,7 +16,7 @@
     </ci:ActionSettingsControlBase.Resources>
     <StackPanel Orientation="Horizontal"
                 DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:WindowDockingLocationActionSettingsControl}}">
-        <TextBlock Text="临时移动到" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <TextBlock Text="临时移动到" VerticalAlignment="Center" Margin="0 0 4 0"/>
         <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
                   SelectedIndex="{Binding Settings.Value}"
                   HorizontalContentAlignment="Left">

--- a/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
+++ b/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml
@@ -1,0 +1,51 @@
+﻿<ci:ActionSettingsControlBase
+    x:Class="ClassIsland.Controls.ActionSettingsControls.WindowDockingLocationActionSettingsControl"
+    x:TypeArguments="actions:WindowDockingLocationActionSettings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ci="http://classisland.tech/schemas/xaml/core"
+    xmlns:actions="clr-namespace:ClassIsland.Models.Actions"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:ClassIsland.Controls.ActionSettingsControls"
+    mc:Ignorable="d" 
+    d:DesignHeight="450" d:DesignWidth="800">
+    <ci:ActionSettingsControlBase.Resources>
+        <ci:IntToRadioButtonSelectionConverter x:Key="IntToRadioButtonSelectionConverter" />
+    </ci:ActionSettingsControlBase.Resources>
+    <StackPanel Orientation="Horizontal"
+                DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:WindowDockingLocationActionSettingsControl}}">
+        <TextBlock Text="临时移动到屏幕" VerticalAlignment="Center" Margin="6 0 4 0"/>
+        <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
+                  SelectedIndex="{Binding Settings.Value}"
+                  HorizontalContentAlignment="Left">
+            <ci:IconText Kind="ArrowTopLeft" Text="左上角" />
+            <ci:IconText Kind="FormatVerticalAlignTop" Text="中上侧" />
+            <ci:IconText Kind="ArrowTopRight" Text="右上角" />
+            <ci:IconText Kind="ArrowBottomLeft" Text="左下角" />
+            <ci:IconText Kind="FormatVerticalAlignBottom" Text="中下侧" />
+            <ci:IconText Kind="ArrowBottomRight" Text="右下角" />
+        </ComboBox>
+        <!--<materialDesign:ColorZone
+                        BorderBrush="{DynamicResource MaterialDesignBody}"
+                        BorderThickness="6" CornerRadius="4"
+                        VerticalAlignment="Center"
+                        Width="100" Height="70">
+            <Grid>
+                <RadioButton VerticalAlignment="Top" HorizontalAlignment="Left"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=0}" />
+                <RadioButton VerticalAlignment="Top" HorizontalAlignment="Center"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=1}" />
+                <RadioButton VerticalAlignment="Top" HorizontalAlignment="Right"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=2}" />
+                <RadioButton VerticalAlignment="Bottom" HorizontalAlignment="Left"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=3}" />
+                <RadioButton VerticalAlignment="Bottom" HorizontalAlignment="Center"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=4}" />
+                <RadioButton VerticalAlignment="Bottom" HorizontalAlignment="Right"
+                         IsChecked="{Binding Settings.Value, Converter={StaticResource IntToRadioButtonSelectionConverter}, ConverterParameter=5}" />
+            </Grid>
+        </materialDesign:ColorZone>-->
+    </StackPanel>
+</ci:ActionSettingsControlBase>

--- a/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml.cs
+++ b/ClassIsland/Controls/ActionSettingsControls/WindowDockingLocationActionSettingsControl.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace ClassIsland.Controls.ActionSettingsControls;
+
+public partial class WindowDockingLocationActionSettingsControl
+{
+    public WindowDockingLocationActionSettingsControl()
+    {
+        InitializeComponent();
+        DataContext = this;
+    }
+};

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -685,7 +685,7 @@ public partial class MainWindow : Window
     public void SaveSettings()
     {
         UpdateTheme();
-        SettingsService.SaveSettings(ToString() + " 的 SaveSettings()");
+        SettingsService.SaveSettings(ToString() + ".SaveSettings()");
     }
 
     protected override void OnInitialized(EventArgs e)

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -679,13 +679,13 @@ public partial class MainWindow : Window
     {
         var r = SettingsService.Settings;
         ViewModel.Settings = r;
-        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings();
+        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings(args.PropertyName);
     }
 
-    public void SaveSettings()
+    public void SaveSettings(string note = "")
     {
         UpdateTheme();
-        SettingsService.SaveSettings(ToString() + ".SaveSettings()");
+        SettingsService.SaveSettings($"{note} (MainWindow)");
     }
 
     protected override void OnInitialized(EventArgs e)
@@ -695,7 +695,7 @@ public partial class MainWindow : Window
         if (DesignerProperties.GetIsInDesignMode(this))
             return;
         ViewModel.Profile.PropertyChanged += (sender, args) => SaveProfile();
-        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings();
+        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings(args.PropertyName);
         LoadSettings();
         //ViewModel.CurrentProfilePath = ViewModel.Settings.SelectedProfile;
         LoadProfile();

--- a/ClassIsland/Models/Actions/AppSettingsActionSettings.cs
+++ b/ClassIsland/Models/Actions/AppSettingsActionSettings.cs
@@ -1,0 +1,47 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+namespace ClassIsland.Models.Actions;
+
+public class CurrentComponentConfigActionSettings : ObservableRecipient
+{
+    string _value = "Default";
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (value == _value) return;
+            _value = value;
+            OnPropertyChanged();
+        }
+    }
+}
+
+public class ThemeActionSettings : ObservableRecipient
+{
+    int _value = 2;
+    public int Value
+    {
+        get => _value;
+        set
+        {
+            if (value == _value) return;
+            _value = value;
+            OnPropertyChanged();
+        }
+    }
+}
+
+public class WindowDockingLocationActionSettings : ObservableRecipient
+{
+    int _value = 1;
+    public int Value
+    {
+        get => _value;
+        set
+        {
+            if (value == _value) return;
+            _value = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland/Models/Actions/RunActionSettings.cs
+++ b/ClassIsland/Models/Actions/RunActionSettings.cs
@@ -1,0 +1,17 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+namespace ClassIsland.Models.Actions;
+
+public class RunActionSettings : ObservableRecipient
+{
+    string _value = "";
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (value == _value) return;
+            _value = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland/Models/Actions/SleepActionSettings.cs
+++ b/ClassIsland/Models/Actions/SleepActionSettings.cs
@@ -1,0 +1,17 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+namespace ClassIsland.Models.Actions;
+
+public class SleepActionSettings : ObservableRecipient
+{
+    double _value = 5;
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            if (value == _value) return;
+            _value = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -32,6 +32,7 @@ using WindowsShortcutFactory;
 
 using File = System.IO.File;
 using System.Runtime.InteropServices;
+using ClassIsland.Core.Models;
 
 namespace ClassIsland.Models;
 
@@ -183,7 +184,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private double _radiusY = 0.0;
     private int _hideMode = 0;
     private Ruleset _hiedRules = new();
-    private ObservableCollection<Ruleset> _rules = new();
+    private ObservableCollection<RuleActionPair> _ruleActionPairs = new();
     private bool _isAutoBackupEnabled = true;
     private DateTime _lastAutoBackupTime = DateTime.Now;
     private int _autoBackupLimit = 16;
@@ -403,13 +404,13 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         }
     }
 
-    public ObservableCollection<Ruleset> Rules
+    public ObservableCollection<RuleActionPair> RuleActionPairs
     {
-        get => _rules;
+        get => _ruleActionPairs;
         set
         {
-            if (Equals(value, _rules)) return;
-            _rules = value;
+            if (Equals(value, _ruleActionPairs)) return;
+            _ruleActionPairs = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -183,6 +183,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private double _radiusY = 0.0;
     private int _hideMode = 0;
     private Ruleset _hiedRules = new();
+    private ObservableCollection<Ruleset> _rules = new();
     private bool _isAutoBackupEnabled = true;
     private DateTime _lastAutoBackupTime = DateTime.Now;
     private int _autoBackupLimit = 16;
@@ -205,12 +206,23 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private double _scheduleSpacing = 1;
     private bool _showCurrentLessonOnlyOnClass = false;
     private bool _isSwapMode = true;
+    private Dictionary<string, Dictionary<string, dynamic>> _settingsOverlay = [];
 
     public void NotifyPropertyChanged(string propertyName)
     {
         OnPropertyChanged(propertyName);
     }
- 
+
+    public Dictionary<string, Dictionary<string, dynamic>> SettingsOverlay
+    {
+        get => _settingsOverlay;
+        set
+        {
+            if (value == _settingsOverlay) return;
+            _settingsOverlay = value;
+            OnPropertyChanged();
+        }
+    }
     public string SelectedProfile
     {
         get => _selectedProfile;
@@ -387,6 +399,17 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         {
             if (Equals(value, _hiedRules)) return;
             _hiedRules = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public ObservableCollection<Ruleset> Rules
+    {
+        get => _rules;
+        set
+        {
+            if (Equals(value, _rules)) return;
+            _rules = value;
             OnPropertyChanged();
         }
     }
@@ -2064,6 +2087,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
             OnPropertyChanged();
         }
     }
+
     public bool IsSwapMode
     {
         get => _isSwapMode;
@@ -2074,5 +2098,4 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
             OnPropertyChanged();
         }
     }
-
 }

--- a/ClassIsland/Properties/launchSettings.json
+++ b/ClassIsland/Properties/launchSettings.json
@@ -21,6 +21,10 @@
     "ClassIsland (禁用集控) Sentry dbg": {
       "commandName": "Project",
       "commandLineArgs": "-dm -esd"
+    },
+    "ClassIsland (Uri 启动)": {
+      "commandName": "Project",
+      "commandLineArgs": "--uri classisland://app/settings/rules"
     }
   }
 }

--- a/ClassIsland/Properties/launchSettings.json
+++ b/ClassIsland/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "commandName": "Project",
       "commandLineArgs": "-dm -esd"
     },
-    "ClassIsland (Uri 启动)": {
+    "ClassIsland (启动指定 Uri)": {
       "commandName": "Project",
       "commandLineArgs": "--uri classisland://app/settings/rules"
     }

--- a/ClassIsland/Services/ActionHandlers/AppSettingsActionHandler.cs
+++ b/ClassIsland/Services/ActionHandlers/AppSettingsActionHandler.cs
@@ -1,0 +1,32 @@
+﻿using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Models.Actions;
+using System.Threading.Tasks;
+
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+namespace ClassIsland.Services.ActionHandlers;
+
+internal class AppSettingsActionHandler
+{
+    internal AppSettingsActionHandler(SettingsService SettingsService, IActionService ActionService)
+    {
+        var RegisterActionHandler = ActionService.RegisterActionHandler;
+        var RegisterActionBackHandler = ActionService.RegisterActionBackHandler;
+        var AddSettingsOverlay = SettingsService.AddSettingsOverlay;
+        var RemoveSettingsOverlay = SettingsService.RemoveSettingsOverlay;
+
+        RegisterActionHandler("classisland.settings.currentComponentConfig",
+            (s, g) => AddSettingsOverlay(g, "CurrentComponentConfig", ((CurrentComponentConfigActionSettings) s!).Value));
+        RegisterActionHandler("classisland.settings.theme",
+            (s, g) => AddSettingsOverlay(g, "Theme", ((ThemeActionSettings) s!).Value));
+        RegisterActionHandler("classisland.settings.windowDockingLocation",
+            (s, g) => AddSettingsOverlay(g, "WindowDockingLocation", ((WindowDockingLocationActionSettings) s!).Value));
+
+        RegisterActionBackHandler("classisland.settings.currentComponentConfig",
+            (s, g) => RemoveSettingsOverlay(g, "CurrentComponentConfig"));
+        RegisterActionBackHandler("classisland.settings.theme",
+            (s, g) => RemoveSettingsOverlay(g, "Theme"));
+        RegisterActionBackHandler("classisland.settings.windowDockingLocation",
+            (s, g) => RemoveSettingsOverlay(g, "WindowDockingLocation"));
+    }
+}

--- a/ClassIsland/Services/ActionHandlers/RunActionHandler.cs
+++ b/ClassIsland/Services/ActionHandlers/RunActionHandler.cs
@@ -1,0 +1,88 @@
+﻿using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Models.Actions;
+
+using Microsoft.Extensions.Hosting;
+
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text.Encodings.Web;
+using System.Windows.Controls;
+using System.Security.Policy;
+using System.Text.RegularExpressions;
+using System.Windows.Shapes;
+using Path = System.IO.Path;
+using WebSocketSharp;
+namespace ClassIsland.Services.ActionHandlers;
+
+internal class RunActionHandler
+{
+    public ILogger<RunActionHandler> Logger { get; }
+
+    internal RunActionHandler(IActionService ActionService, ILogger<RunActionHandler> logger)
+    {
+        Logger = logger;
+        ActionService.RegisterActionHandler("classisland.os.run",
+            (s, g) => Run(((RunActionSettings)s!).Value));
+    }
+
+    private bool Run(string value)
+    {
+        // 文件(夹)
+        if (File.Exists(value) || Directory.Exists(value))
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo()
+                {
+                    FileName = Path.GetFullPath(value), // TODO: 允许参数
+                    UseShellExecute = true
+                });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "打开文件(夹)失败。");
+            }
+        }
+
+        // cmd 命令
+        try {
+            Process process = new()
+            {
+                StartInfo = new()
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c {value}",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+            process.Start();
+            Logger.LogTrace("cmd 命令输出：{}", process.StandardOutput.ReadToEnd());
+
+            if (string.IsNullOrEmpty(process.StandardError.ReadToEnd()))
+                return true;
+        } catch { }
+
+        // 网页
+        if (value.Contains('.'))
+        {
+            var path = value;
+            if (!Regex.IsMatch(value, @"^https?:\/\/", RegexOptions.IgnoreCase))
+            {
+                path = "http://" + path;
+            }
+            if (Uri.TryCreate(path, UriKind.Absolute, out Uri uri))
+            {
+                Process.Start("explorer.exe", uri.AbsoluteUri);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/ClassIsland/Services/ActionHandlers/SleepActionHandler.cs
+++ b/ClassIsland/Services/ActionHandlers/SleepActionHandler.cs
@@ -1,0 +1,17 @@
+﻿using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Models.Actions;
+using System.Threading.Tasks;
+using System;
+namespace ClassIsland.Services.ActionHandlers;
+
+internal class SleepActionHandler
+{
+    internal SleepActionHandler(IActionService ActionService)
+    {
+        ActionService.RegisterActionHandler("classisland.action.sleep",
+            (s, g) => {
+                Task.Delay(TimeSpan.FromSeconds(((SleepActionSettings)s!).Value))
+                    .Wait();
+            });
+    }
+}

--- a/ClassIsland/Services/ActionService.cs
+++ b/ClassIsland/Services/ActionService.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Models.Action;
+using System.Text.Json;
+using Action = ClassIsland.Core.Models.Action.Action;
+
+namespace ClassIsland.Services;
+
+public class ActionService(ILogger<ActionService> logger) : IActionService
+{
+    public ILogger<ActionService> Logger { get; } = logger;
+
+    public void RegisterActionHandler(string id, ActionRegistryInfo.HandleDelegate handler)
+    {
+        if (!IActionService.Actions.TryGetValue(id, out var actionRegistryInfo))
+            throw new KeyNotFoundException($"找不到行动 {id}。");
+
+        actionRegistryInfo.Handle += handler;
+    }
+
+    public void RegisterActionBackHandler(string id, ActionRegistryInfo.HandleDelegate handler)
+    {
+        if (!IActionService.Actions.TryGetValue(id, out var actionRegistryInfo))
+            throw new KeyNotFoundException($"找不到行动 {id}。");
+
+        actionRegistryInfo.BackHandle += handler;
+    }
+
+    public void InvokeAction(List<Action> actions)
+    {
+        foreach (var action in actions)
+        {
+            InvokeAction(action, isBack: false);
+        }
+    }
+
+    public void InvokeBackAction(List<Action> actions)
+    {
+        foreach (var action in actions)
+        {
+            InvokeAction(action, isBack: true);
+        }
+    }
+
+    private void InvokeAction(Action action, bool isBack = false)
+    {
+        if (!IActionService.Actions.TryGetValue(action.Id, out var actionRegistryInfo))
+        {
+            Logger.LogWarning($"找不到行动 {action.Id} 的注册信息。");
+            return;
+        }
+
+        object? settings = null;
+        var settingsType = actionRegistryInfo.SettingsType;
+        if (settingsType != null)
+        {
+            settings = action.Settings ?? Activator.CreateInstance(settingsType);
+            if (settings is JsonElement json)
+            {
+                settings = json.Deserialize(settingsType);
+            }
+        }
+        if (isBack)
+        {
+            actionRegistryInfo.BackHandle?.Invoke(settings);
+        }
+        else
+        {
+            if (actionRegistryInfo.Handle != null)
+            {
+                actionRegistryInfo.Handle(settings);
+            }
+            else
+            {
+                Logger.LogWarning($"行动 {action.Id} 的处理程序没有注册。");
+            }
+        }
+    }
+}

--- a/ClassIsland/Services/TaskBarIconService.cs
+++ b/ClassIsland/Services/TaskBarIconService.cs
@@ -19,19 +19,10 @@ public class TaskBarIconService : IHostedService, ITaskBarIconService
     {
         SettingsService = settingsService;
         SettingsService.Settings.PropertyChanged += SettingsOnPropertyChanged;
-        UpdateMenuAction();
-    }
-
-    private void UpdateMenuAction()
-    {
-        // 由于 ClassIsland 现在会自行处理左键抬起事件来显示菜单，
-        // 所以只保留默认的右键打开菜单方式。
-        MainTaskBarIcon.MenuActivation = PopupActivationMode.RightClick;
     }
 
     private void SettingsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        UpdateMenuAction();
     }
 
     public TaskbarIcon MainTaskBarIcon

--- a/ClassIsland/ViewModels/SettingsPages/RuleSettingsPageViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/RuleSettingsPageViewModel.cs
@@ -1,0 +1,7 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ClassIsland.ViewModels.SettingsPages;
+
+public class RulesetSettingsViewModel : ObservableRecipient
+{
+}

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
@@ -1,0 +1,264 @@
+﻿<ci:SettingsPageBase x:Class="ClassIsland.Views.SettingPages.RuleSettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:ClassIsland.Views.SettingPages"
+      xmlns:ci="http://classisland.tech/schemas/xaml/core"
+      xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+      xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters;assembly=ClassIsland.Core"
+      xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services;assembly=ClassIsland.Core"
+      xmlns:actions="clr-namespace:ClassIsland.Core.Controls.Action;assembly=ClassIsland.Core"
+      mc:Ignorable="d"
+      d:DesignHeight="450" d:DesignWidth="800"
+      TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+      Background="{DynamicResource MaterialDesignPaper}"
+      FontFamily="{StaticResource HarmonyOsSans}"
+      TextElement.FontWeight="Regular"
+      TextElement.FontSize="14"
+      TextOptions.TextFormattingMode="Ideal"
+      TextOptions.TextRenderingMode="Auto"
+      d:DataContext="{d:DesignInstance local:RuleSettingsPage}"
+      Title="RuleSettingsPage">
+    <ci:SettingsPageBase.CommandBindings>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.AddRuleCommand}" Executed="CommandAddRule_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveRuleCommand}" Executed="CommandRemoveRuleCommand_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveRulesetCommand}" Executed="CommandRemoveRulesetCommand_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.DuplicateRulesetCommand}" Executed="CommandDuplicateRuleset_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" Executed="CommandDebugInvokeAction_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" Executed="CommandDebugInvokeBackAction_OnExecuted"/>
+    </ci:SettingsPageBase.CommandBindings>
+    <ci:SettingsPageBase.Resources>
+        <converters:RuleLogicalModeToIntConverter x:Key="RuleLogicalModeToIntConverter"/>
+        <ci:RuleLogicalModeToBooleanConverter x:Key="RuleLogicalModeToBooleanConverter"/>
+    </ci:SettingsPageBase.Resources>
+    <ScrollViewer>
+        <StackPanel>
+            <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:RuleSettingsPage}}">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <!-- 规则编辑 -->
+                <ItemsControl Grid.Row="0" ItemsSource="{Binding Rulesets}"
+                         HorizontalContentAlignment="Stretch">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <materialDesign:Card Padding="5" Margin="5">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition/>
+                                        <RowDefinition/>
+                                    </Grid.RowDefinitions>
+                                    <!--规则编辑-->
+                                    <!--<DockPanel  Grid.Column="0" VerticalAlignment="Stretch" LastChildFill="False">
+                                        <StackPanel DockPanel.Dock="Top">
+                                            <StackPanel Orientation="Horizontal" Grid.Row="0" x:Name="OpacityBindingPanel">
+                                                <StackPanel.Style>
+                                                    <Style TargetType="StackPanel">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Groups[0].IsEnabled}" Value="False">
+                                                                <Setter Property="Opacity" Value="0.56"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Groups[0].Rules.Count}" Value="1">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Groups[0].Rules.Count}" Value="0">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+
+
+                                                --><!--<ToggleButton
+                                                    Margin="8 0"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    Content="{materialDesign:PackIcon SelectMultiple}"
+                                                    materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon SelectGroup}"
+                                                    IsChecked="{Binding Groups[0].Mode, Converter={StaticResource RuleLogicalModeToBooleanConverter}}">
+                                                    <ToggleButton.Style>
+                                                        <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
+                                                            <Style.Triggers>
+                                                                <Trigger Property="IsChecked" Value="False">
+                                                                    <Setter Property="ToolTip" Value="任一条件满足。" />
+                                                                    <Setter Property="Foreground" Value="White" />
+                                                                    <Setter Property="Background" Value="Gray" />
+                                                                </Trigger>
+                                                                <Trigger Property="IsChecked" Value="True">
+                                                                    <Setter Property="ToolTip" Value="所有条件满足。" />
+                                                                    <Setter Property="Background" Value="Black" />
+                                                                    <Setter Property="Foreground" Value="White" />
+                                                                </Trigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </ToggleButton.Style>
+                                                </ToggleButton>-->
+
+                                                <!--<CheckBox Content="反转" IsChecked="{Binding Groups[0].IsReversed}"/>--><!--
+
+
+                                                <ToggleButton
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Center"
+                                                                        Content="{materialDesign:PackIcon ArrowRight}"
+                                                                        materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon CompareHorizontal}"
+                                                                        IsChecked="{Binding Groups[0].IsReversed}">
+                                                    <ToggleButton.Style>
+                                                        <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
+                                                            <Style.Triggers>
+                                                                <Trigger Property="IsChecked" Value="True">
+                                                                    <Setter Property="ToolTip" Value="反转此规则判断结果。" />
+                                                                    <Setter Property="Background" Value="Black"/>
+                                                                    <Setter Property="Foreground" Value="White"/>
+                                                                </Trigger>
+                                                                <Trigger Property="IsChecked" Value="False">
+                                                                    <Setter Property="ToolTip" Value="判断此规则。" />
+                                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                                    <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                                                                </Trigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </ToggleButton.Style>
+                                                </ToggleButton>
+
+                                                <ComboBox SelectedIndex="{Binding Groups[0].Mode, Converter={StaticResource RuleLogicalModeToIntConverter}}"
+                                                            Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                                                            materialDesign:HintAssist.Hint="模式" Margin="4 0 10 0">
+                                                    <ComboBoxItem>
+                                                        <ci:IconText Kind="SelectMultiple" Text="任意条件满足时"/>
+                                                    </ComboBoxItem>
+                                                    <ComboBoxItem>
+                                                        <ci:IconText Kind="SelectGroup" Text="所有条件满足时"/>
+                                                    </ComboBoxItem>
+                                                </ComboBox>
+                                                
+                                            </StackPanel>
+                                            <ItemsControl Grid.Row="1" ItemsSource="{Binding Groups[0].Rules}" Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"
+                                                 HorizontalContentAlignment="Stretch">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid Margin="0 5">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <StackPanel Margin="0 4">
+                                                                <StackPanel Orientation="Horizontal">
+                                                                    <ToggleButton
+                                                                        Margin="0 0 8 0"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Center"
+                                                                        Content="{materialDesign:PackIcon ArrowRight}"
+                                                                        materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon CompareHorizontal}"
+                                                                        IsChecked="{Binding IsReversed}">
+                                                                        <ToggleButton.Style>
+                                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
+                                                                                <Style.Triggers>
+                                                                                    <Trigger Property="IsChecked" Value="True">
+                                                                                        <Setter Property="ToolTip" Value="反转此规则判断结果。" />
+                                                                                        <Setter Property="Background" Value="Black"/>
+                                                                                        <Setter Property="Foreground" Value="White"/>
+                                                                                    </Trigger>
+                                                                                    <Trigger Property="IsChecked" Value="False">
+                                                                                        <Setter Property="ToolTip" Value="正常判断此规则。" />
+                                                                                        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                                                                                    </Trigger>
+                                                                                </Style.Triggers>
+                                                                            </Style>
+                                                                        </ToggleButton.Style>
+                                                                    </ToggleButton>
+                                                                    <ComboBox Grid.Column="2"
+                                                                        SelectedValue="{Binding Id}"
+                                                                        SelectedValuePath="Key"
+                                                                        ItemsSource="{x:Static services:IRulesetService.Rules}">
+                                                                        <ComboBox.ItemTemplate>
+                                                                            <DataTemplate>
+                                                                                <ci:IconText Kind="{Binding Value.IconKind}" Text="{Binding Value.Name}"/>
+                                                                            </DataTemplate>
+                                                                        </ComboBox.ItemTemplate>
+                                                                    </ComboBox>
+                                                                    --><!--<CheckBox Grid.Column="1"
+                                                                        Content="反转" IsChecked="{Binding IsReversed}"
+                                                                        Margin="0 0 5 0"/>--><!--
+                                                                </StackPanel>
+                                                                <ci:RulesetSettingsControlPresenter Rule="{Binding Mode=OneWay}"
+                                                                                            RuleId="{Binding Id, Mode=OneWay}"
+                                                                                            HorizontalAlignment="Left" MinWidth="200"
+                                                                                                Margin="22 0 0 0"/>
+                                                            </StackPanel>
+                                                            <Button Grid.Column="1"
+                                                                        Content="{materialDesign:PackIcon Remove}" ToolTip="删除"
+                                                                        Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                                        Command="{x:Static local:RuleSettingsPage.RemoveRuleCommand}" CommandParameter="{Binding}"/>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+
+                                        <Button Style="{StaticResource MaterialDesignFlatButton}" Padding="8 0"
+                                                DockPanel.Dock="Bottom"
+                                                    Command="{x:Static local:RuleSettingsPage.AddRuleCommand}" CommandParameter="{Binding}"
+                                                    VerticalAlignment="Top"
+                                                Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}">
+                                            <ci:IconText Kind="TagPlusOutline" Text="添加规则"/>
+                                        </Button>
+                                    </DockPanel>-->
+                                    <ci:RulesetControl Ruleset="{Binding}"/>
+
+                                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" Width="5" Margin="4 0"
+                                                Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"/>
+
+                                    <!--行动编辑-->
+                                    <actions:ActionControl Actions="{Binding Actions}" Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"
+                                                           Grid.Column="2"/>
+
+
+                                    <!--规则组操作-->
+                                    <WrapPanel Orientation="Horizontal" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Right">
+                                        <Button Content="{materialDesign:PackIcon Kind=Close}" ToolTip="删除"
+                                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                                Command="{x:Static local:RuleSettingsPage.RemoveRulesetCommand}" CommandParameter="{Binding}"
+                                                                Margin="0 0 4 0"/>
+
+                                        <Button Content="{materialDesign:PackIcon Kind=ContentCopy}" ToolTip="复制"
+                                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                                Command="{x:Static local:RuleSettingsPage.DuplicateRulesetCommand}" CommandParameter="{Binding}"
+                                                                Margin="0 0 4 0"/>
+
+                                        <Button Content="(Debug)触发"
+                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" CommandParameter="{Binding}"
+                                                Margin="0 0 4 0"/>
+
+                                        <Button Content="(Debug)恢复"
+                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" CommandParameter="{Binding}"
+                                                Margin="0 0 4 0"/>
+
+                                        <ToggleButton ToolTip="启用" IsChecked="{Binding Groups[0].IsEnabled}" Margin="0 0 4 0"/>
+                                    </WrapPanel>
+                                </Grid>
+                            </materialDesign:Card>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <StackPanel Grid.Row="1">
+                    <WrapPanel Orientation="Horizontal">
+                        <Button Style="{StaticResource MaterialDesignFlatButton}" Click="ButtonAddRule_OnClick">
+                            <ci:IconText Kind="Add" Text="添加条件触发"/>
+                        </Button>
+                    </WrapPanel>
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>
+</ci:SettingsPageBase>

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
@@ -8,7 +8,8 @@
       xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
       xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters;assembly=ClassIsland.Core"
       xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services;assembly=ClassIsland.Core"
-      xmlns:actions="clr-namespace:ClassIsland.Core.Controls.Action;assembly=ClassIsland.Core"
+      xmlns:action="clr-namespace:ClassIsland.Core.Controls.Action;assembly=ClassIsland.Core"
+      xmlns:ruleset="clr-namespace:ClassIsland.Core.Controls.Ruleset;assembly=ClassIsland.Core"
       xmlns:models="clr-namespace:ClassIsland.Core.Models;assembly=ClassIsland.Core"
       mc:Ignorable="d"
       d:DesignHeight="450" d:DesignWidth="800"
@@ -25,6 +26,7 @@
         <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveCommand}" Executed="CommandRemoveCommand_OnExecuted"/>
         <CommandBinding Command="{x:Static local:RuleSettingsPage.DuplicateCommand}" Executed="CommandDuplicate_OnExecuted"/>
         <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" Executed="CommandDebugInvokeAction_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeActionSyncCommand}" Executed="CommandDebugInvokeActionSync_OnExecuted"/>
         <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" Executed="CommandDebugInvokeBackAction_OnExecuted"/>
     </ci:SettingsPageBase.CommandBindings>
     <ci:SettingsPageBase.Resources>
@@ -39,11 +41,14 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <!-- 规则编辑 -->
-                <ItemsControl Grid.Row="0" ItemsSource="{Binding RuleActionPairs}"
-                         HorizontalContentAlignment="Stretch">
+                <ItemsControl Grid.Row="0" ItemsSource="{Binding RuleActionPairs}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <materialDesign:Card Padding="5" Margin="5">
+                            <Border BorderThickness="2"
+                                    BorderBrush="{DynamicResource MaterialDesignDivider}"
+                                    CornerRadius="6"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="0 0 0 10">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
@@ -64,47 +69,56 @@
                                             </Style.Triggers>
                                         </Style>
                                     </Grid.Style>
-                                        
-                                        
-                                    <!--规则编辑-->
-                                    <ci:RulesetControl Ruleset="{Binding Ruleset}" Grid.Row="1"/>
-
-                                    <!--分栏-->
-                                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" Width="5" Margin="4 0" Grid.Row="1"/>
-
-                                    <!--行动编辑-->
-                                    <actions:ActionControl ActionList="{Binding ActionList}"
-                                                           Grid.Column="2" Grid.Row="1"/>
-
-
+                                    
                                     <!--规则组操作-->
-                                    <WrapPanel Orientation="Horizontal" Grid.ColumnSpan="3">
-                                        <TextBox Text="{Binding Name}" MinWidth="150"/>
+                                    <StackPanel Orientation="Horizontal" Grid.ColumnSpan="3" HorizontalAlignment="Left" Panel.ZIndex="1">
+                                        <TextBox Text="{Binding Name}" MinWidth="200" Padding="8 5"
+                                                 Style="{StaticResource MaterialDesignFilledTextBox}"
+                                                 materialDesign:HintAssist.Hint="备注"
+                                                 materialDesign:HintAssist.IsFloating="False"/>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Grid.ColumnSpan="3" HorizontalAlignment="Right" Panel.ZIndex="1"
+                                                Background="{DynamicResource MaterialDesignPaper}">
 
-                                        <Button Content="{materialDesign:PackIcon Kind=Close}" ToolTip="删除"
-                                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                                Command="{x:Static local:RuleSettingsPage.RemoveCommand}" CommandParameter="{Binding}"
-                                                                Margin="0 0 4 0"/>
+                                        <Button Content="(Debug)触发" Foreground="Blue"
+                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" CommandParameter="{Binding}"
+                                                Margin="0 0 4 0"/>
+
+                                        <Button Content="(Debug)恢复" Foreground="Blue"
+                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" CommandParameter="{Binding}"
+                                                Margin="0 0 4 0"/>
+
+                                        <Button Content="(dbg)触发2" Foreground="Blue"
+                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeActionSyncCommand}" CommandParameter="{Binding}"
+                                                Margin="0 0 4 0"/>
+
+                                        <ToggleButton ToolTip="启用" IsChecked="{Binding IsEnabled}" Margin="0 0 4 0"/>
 
                                         <Button Content="{materialDesign:PackIcon Kind=ContentCopy}" ToolTip="复制"
                                                                 Style="{StaticResource MaterialDesignToolForegroundButton}"
                                                                 Command="{x:Static local:RuleSettingsPage.DuplicateCommand}" CommandParameter="{Binding}"
                                                                 Margin="0 0 4 0"/>
 
-                                        <Button Content="(Debug)触发"
-                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" CommandParameter="{Binding}"
-                                                Margin="0 0 4 0"/>
+                                        <Button Content="{materialDesign:PackIcon Kind=Close}" ToolTip="删除"
+                                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                                Command="{x:Static local:RuleSettingsPage.RemoveCommand}" CommandParameter="{Binding}"
+                                                                Margin="0 0 4 0"/>
+                                    </StackPanel>
 
-                                        <Button Content="(Debug)恢复"
-                                                Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" CommandParameter="{Binding}"
-                                                Margin="0 0 4 0"/>
+                                    <!--规则编辑-->
+                                    <ruleset:RulesetControl Ruleset="{Binding Ruleset}" ShowTitle="False" Grid.Column="0" Grid.Row="1"/>
 
-                                        <ToggleButton ToolTip="启用" IsChecked="{Binding IsEnabled}" Margin="0 0 4 0"/>
-                                    </WrapPanel>
+                                    <!--分栏-->
+                                    <GridSplitter HorizontalAlignment="Stretch" Width="5" Margin="4 0" Grid.Column="1" Grid.RowSpan="2" Panel.ZIndex="0"/>
+
+                                    <!--行动编辑-->
+                                    <action:ActionControl ActionList="{Binding ActionList}" Grid.Column="2" Grid.Row="1"/>
+                                    
                                 </Grid>
-                            </materialDesign:Card>
+                            </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml
@@ -9,6 +9,7 @@
       xmlns:converters="clr-namespace:ClassIsland.Core.Abstractions.Converters;assembly=ClassIsland.Core"
       xmlns:services="clr-namespace:ClassIsland.Core.Abstractions.Services;assembly=ClassIsland.Core"
       xmlns:actions="clr-namespace:ClassIsland.Core.Controls.Action;assembly=ClassIsland.Core"
+      xmlns:models="clr-namespace:ClassIsland.Core.Models;assembly=ClassIsland.Core"
       mc:Ignorable="d"
       d:DesignHeight="450" d:DesignWidth="800"
       TextElement.Foreground="{DynamicResource MaterialDesignBody}"
@@ -21,10 +22,8 @@
       d:DataContext="{d:DesignInstance local:RuleSettingsPage}"
       Title="RuleSettingsPage">
     <ci:SettingsPageBase.CommandBindings>
-        <CommandBinding Command="{x:Static local:RuleSettingsPage.AddRuleCommand}" Executed="CommandAddRule_OnExecuted"/>
-        <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveRuleCommand}" Executed="CommandRemoveRuleCommand_OnExecuted"/>
-        <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveRulesetCommand}" Executed="CommandRemoveRulesetCommand_OnExecuted"/>
-        <CommandBinding Command="{x:Static local:RuleSettingsPage.DuplicateRulesetCommand}" Executed="CommandDuplicateRuleset_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.RemoveCommand}" Executed="CommandRemoveCommand_OnExecuted"/>
+        <CommandBinding Command="{x:Static local:RuleSettingsPage.DuplicateCommand}" Executed="CommandDuplicate_OnExecuted"/>
         <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeActionCommand}" Executed="CommandDebugInvokeAction_OnExecuted"/>
         <CommandBinding Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" Executed="CommandDebugInvokeBackAction_OnExecuted"/>
     </ci:SettingsPageBase.CommandBindings>
@@ -40,7 +39,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <!-- 规则编辑 -->
-                <ItemsControl Grid.Row="0" ItemsSource="{Binding Rulesets}"
+                <ItemsControl Grid.Row="0" ItemsSource="{Binding RuleActionPairs}"
                          HorizontalContentAlignment="Stretch">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
@@ -55,183 +54,41 @@
                                         <RowDefinition/>
                                         <RowDefinition/>
                                     </Grid.RowDefinitions>
+
+                                    <Grid.Style>
+                                        <Style TargetType="Grid">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                    <Setter Property="Opacity" Value="0.56"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Grid.Style>
+                                        
+                                        
                                     <!--规则编辑-->
-                                    <!--<DockPanel  Grid.Column="0" VerticalAlignment="Stretch" LastChildFill="False">
-                                        <StackPanel DockPanel.Dock="Top">
-                                            <StackPanel Orientation="Horizontal" Grid.Row="0" x:Name="OpacityBindingPanel">
-                                                <StackPanel.Style>
-                                                    <Style TargetType="StackPanel">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Groups[0].IsEnabled}" Value="False">
-                                                                <Setter Property="Opacity" Value="0.56"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Groups[0].Rules.Count}" Value="1">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Groups[0].Rules.Count}" Value="0">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </StackPanel.Style>
+                                    <ci:RulesetControl Ruleset="{Binding Ruleset}" Grid.Row="1"/>
 
-
-                                                --><!--<ToggleButton
-                                                    Margin="8 0"
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    Content="{materialDesign:PackIcon SelectMultiple}"
-                                                    materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon SelectGroup}"
-                                                    IsChecked="{Binding Groups[0].Mode, Converter={StaticResource RuleLogicalModeToBooleanConverter}}">
-                                                    <ToggleButton.Style>
-                                                        <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
-                                                            <Style.Triggers>
-                                                                <Trigger Property="IsChecked" Value="False">
-                                                                    <Setter Property="ToolTip" Value="任一条件满足。" />
-                                                                    <Setter Property="Foreground" Value="White" />
-                                                                    <Setter Property="Background" Value="Gray" />
-                                                                </Trigger>
-                                                                <Trigger Property="IsChecked" Value="True">
-                                                                    <Setter Property="ToolTip" Value="所有条件满足。" />
-                                                                    <Setter Property="Background" Value="Black" />
-                                                                    <Setter Property="Foreground" Value="White" />
-                                                                </Trigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </ToggleButton.Style>
-                                                </ToggleButton>-->
-
-                                                <!--<CheckBox Content="反转" IsChecked="{Binding Groups[0].IsReversed}"/>--><!--
-
-
-                                                <ToggleButton
-                                                                        HorizontalAlignment="Center"
-                                                                        VerticalAlignment="Center"
-                                                                        Content="{materialDesign:PackIcon ArrowRight}"
-                                                                        materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon CompareHorizontal}"
-                                                                        IsChecked="{Binding Groups[0].IsReversed}">
-                                                    <ToggleButton.Style>
-                                                        <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
-                                                            <Style.Triggers>
-                                                                <Trigger Property="IsChecked" Value="True">
-                                                                    <Setter Property="ToolTip" Value="反转此规则判断结果。" />
-                                                                    <Setter Property="Background" Value="Black"/>
-                                                                    <Setter Property="Foreground" Value="White"/>
-                                                                </Trigger>
-                                                                <Trigger Property="IsChecked" Value="False">
-                                                                    <Setter Property="ToolTip" Value="判断此规则。" />
-                                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
-                                                                    <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
-                                                                </Trigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </ToggleButton.Style>
-                                                </ToggleButton>
-
-                                                <ComboBox SelectedIndex="{Binding Groups[0].Mode, Converter={StaticResource RuleLogicalModeToIntConverter}}"
-                                                            Style="{StaticResource MaterialDesignFloatingHintComboBox}"
-                                                            materialDesign:HintAssist.Hint="模式" Margin="4 0 10 0">
-                                                    <ComboBoxItem>
-                                                        <ci:IconText Kind="SelectMultiple" Text="任意条件满足时"/>
-                                                    </ComboBoxItem>
-                                                    <ComboBoxItem>
-                                                        <ci:IconText Kind="SelectGroup" Text="所有条件满足时"/>
-                                                    </ComboBoxItem>
-                                                </ComboBox>
-                                                
-                                            </StackPanel>
-                                            <ItemsControl Grid.Row="1" ItemsSource="{Binding Groups[0].Rules}" Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"
-                                                 HorizontalContentAlignment="Stretch">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Grid Margin="0 5">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                            </Grid.ColumnDefinitions>
-                                                            <StackPanel Margin="0 4">
-                                                                <StackPanel Orientation="Horizontal">
-                                                                    <ToggleButton
-                                                                        Margin="0 0 8 0"
-                                                                        HorizontalAlignment="Center"
-                                                                        VerticalAlignment="Center"
-                                                                        Content="{materialDesign:PackIcon ArrowRight}"
-                                                                        materialDesign:ToggleButtonAssist.OnContent="{materialDesign:PackIcon CompareHorizontal}"
-                                                                        IsChecked="{Binding IsReversed}">
-                                                                        <ToggleButton.Style>
-                                                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource MaterialDesignActionToggleButton}">
-                                                                                <Style.Triggers>
-                                                                                    <Trigger Property="IsChecked" Value="True">
-                                                                                        <Setter Property="ToolTip" Value="反转此规则判断结果。" />
-                                                                                        <Setter Property="Background" Value="Black"/>
-                                                                                        <Setter Property="Foreground" Value="White"/>
-                                                                                    </Trigger>
-                                                                                    <Trigger Property="IsChecked" Value="False">
-                                                                                        <Setter Property="ToolTip" Value="正常判断此规则。" />
-                                                                                        <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
-                                                                                        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
-                                                                                    </Trigger>
-                                                                                </Style.Triggers>
-                                                                            </Style>
-                                                                        </ToggleButton.Style>
-                                                                    </ToggleButton>
-                                                                    <ComboBox Grid.Column="2"
-                                                                        SelectedValue="{Binding Id}"
-                                                                        SelectedValuePath="Key"
-                                                                        ItemsSource="{x:Static services:IRulesetService.Rules}">
-                                                                        <ComboBox.ItemTemplate>
-                                                                            <DataTemplate>
-                                                                                <ci:IconText Kind="{Binding Value.IconKind}" Text="{Binding Value.Name}"/>
-                                                                            </DataTemplate>
-                                                                        </ComboBox.ItemTemplate>
-                                                                    </ComboBox>
-                                                                    --><!--<CheckBox Grid.Column="1"
-                                                                        Content="反转" IsChecked="{Binding IsReversed}"
-                                                                        Margin="0 0 5 0"/>--><!--
-                                                                </StackPanel>
-                                                                <ci:RulesetSettingsControlPresenter Rule="{Binding Mode=OneWay}"
-                                                                                            RuleId="{Binding Id, Mode=OneWay}"
-                                                                                            HorizontalAlignment="Left" MinWidth="200"
-                                                                                                Margin="22 0 0 0"/>
-                                                            </StackPanel>
-                                                            <Button Grid.Column="1"
-                                                                        Content="{materialDesign:PackIcon Remove}" ToolTip="删除"
-                                                                        Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                                        Command="{x:Static local:RuleSettingsPage.RemoveRuleCommand}" CommandParameter="{Binding}"/>
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </StackPanel>
-
-                                        <Button Style="{StaticResource MaterialDesignFlatButton}" Padding="8 0"
-                                                DockPanel.Dock="Bottom"
-                                                    Command="{x:Static local:RuleSettingsPage.AddRuleCommand}" CommandParameter="{Binding}"
-                                                    VerticalAlignment="Top"
-                                                Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}">
-                                            <ci:IconText Kind="TagPlusOutline" Text="添加规则"/>
-                                        </Button>
-                                    </DockPanel>-->
-                                    <ci:RulesetControl Ruleset="{Binding}"/>
-
-                                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" Width="5" Margin="4 0"
-                                                Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"/>
+                                    <!--分栏-->
+                                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" Width="5" Margin="4 0" Grid.Row="1"/>
 
                                     <!--行动编辑-->
-                                    <actions:ActionControl Actions="{Binding Actions}" Opacity="{Binding Opacity, ElementName=OpacityBindingPanel}"
-                                                           Grid.Column="2"/>
+                                    <actions:ActionControl ActionList="{Binding ActionList}"
+                                                           Grid.Column="2" Grid.Row="1"/>
 
 
                                     <!--规则组操作-->
-                                    <WrapPanel Orientation="Horizontal" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Right">
+                                    <WrapPanel Orientation="Horizontal" Grid.ColumnSpan="3">
+                                        <TextBox Text="{Binding Name}" MinWidth="150"/>
+
                                         <Button Content="{materialDesign:PackIcon Kind=Close}" ToolTip="删除"
                                                                 Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                                Command="{x:Static local:RuleSettingsPage.RemoveRulesetCommand}" CommandParameter="{Binding}"
+                                                                Command="{x:Static local:RuleSettingsPage.RemoveCommand}" CommandParameter="{Binding}"
                                                                 Margin="0 0 4 0"/>
 
                                         <Button Content="{materialDesign:PackIcon Kind=ContentCopy}" ToolTip="复制"
                                                                 Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                                Command="{x:Static local:RuleSettingsPage.DuplicateRulesetCommand}" CommandParameter="{Binding}"
+                                                                Command="{x:Static local:RuleSettingsPage.DuplicateCommand}" CommandParameter="{Binding}"
                                                                 Margin="0 0 4 0"/>
 
                                         <Button Content="(Debug)触发"
@@ -244,7 +101,7 @@
                                                 Command="{x:Static local:RuleSettingsPage.DebugInvokeBackActionCommand}" CommandParameter="{Binding}"
                                                 Margin="0 0 4 0"/>
 
-                                        <ToggleButton ToolTip="启用" IsChecked="{Binding Groups[0].IsEnabled}" Margin="0 0 4 0"/>
+                                        <ToggleButton ToolTip="启用" IsChecked="{Binding IsEnabled}" Margin="0 0 4 0"/>
                                     </WrapPanel>
                                 </Grid>
                             </materialDesign:Card>
@@ -253,8 +110,8 @@
                 </ItemsControl>
                 <StackPanel Grid.Row="1">
                     <WrapPanel Orientation="Horizontal">
-                        <Button Style="{StaticResource MaterialDesignFlatButton}" Click="ButtonAddRule_OnClick">
-                            <ci:IconText Kind="Add" Text="添加条件触发"/>
+                        <Button Style="{StaticResource MaterialDesignFlatButton}" Click="ButtonAdd_OnClick">
+                            <ci:IconText Kind="Add" Text="添加条件"/>
                         </Button>
                     </WrapPanel>
                 </StackPanel>

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
@@ -12,6 +12,7 @@ using MaterialDesignThemes.Wpf;
 using Microsoft.Extensions.Logging;
 using System.Collections.ObjectModel;
 using System.Linq;
+using ClassIsland.Core.Models;
 
 namespace ClassIsland.Views.SettingPages;
 
@@ -36,67 +37,47 @@ public partial class RuleSettingsPage
         InitializeComponent();
     }
 
-    public static readonly ICommand AddRuleCommand = new RoutedUICommand();
-    public static readonly ICommand RemoveRuleCommand = new RoutedUICommand();
-    public static readonly ICommand RemoveRulesetCommand = new RoutedUICommand();
-    public static readonly ICommand DuplicateRulesetCommand = new RoutedUICommand();
+    public static readonly ICommand RemoveCommand = new RoutedUICommand();
+    public static readonly ICommand DuplicateCommand = new RoutedUICommand();
     public static readonly ICommand DebugInvokeActionCommand = new RoutedUICommand();
     public static readonly ICommand DebugInvokeBackActionCommand = new RoutedUICommand();
 
-    public ObservableCollection<Ruleset> Rulesets
+    public ObservableCollection<RuleActionPair> RuleActionPairs
     {
-        get => SettingsService.Settings.Rules;
-        set => SettingsService.Settings.Rules = value;
+        get => SettingsService.Settings.RuleActionPairs;
+        set => SettingsService.Settings.RuleActionPairs = value;
     }
 
-    private void ButtonAddRule_OnClick(object sender, RoutedEventArgs e)
+    private void ButtonAdd_OnClick(object sender, RoutedEventArgs e)
     {
-        Rulesets.Add(new() { Groups = [new() { Rules = new() { new() } }] });
+        RuleActionPairs.Add(new());
     }
 
-    private void CommandAddRule_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    private void CommandRemoveCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Ruleset ruleset) return;
+        if (e.Parameter is not RuleActionPair ruleActionPair) return;
 
-        ruleset.Groups[0].Rules.Add(new Rule());
+        RuleActionPairs.Remove(ruleActionPair);
     }
 
-    private void CommandRemoveRuleCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    private void CommandDuplicate_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Rule rule) return;
+        if (e.Parameter is not RuleActionPair ruleActionPair) return;
 
-        foreach (var ruleset in Rulesets)
-        {
-            var isRemoved = ruleset.Groups[0].Rules.Remove(rule);
-            if (isRemoved) return;
-        }
-    }
-
-    private void CommandRemoveRulesetCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
-    {
-        if (e.Parameter is not Ruleset ruleset) return;
-
-        Rulesets.Remove(ruleset);
-    }
-
-    private void CommandDuplicateRuleset_OnExecuted(object sender, ExecutedRoutedEventArgs e)
-    {
-        if (e.Parameter is not Ruleset ruleset) return;
-
-        Rulesets.Add(ConfigureFileHelper.CopyObject(ruleset));
+        RuleActionPairs.Add(ConfigureFileHelper.CopyObject(ruleActionPair));
     }
 
     private void CommandDebugInvokeAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Ruleset ruleset) return;
+        if (e.Parameter is not RuleActionPair ruleActionPair) return;
 
-        App.GetService<IActionService>().InvokeAction([.. ruleset.Actions]);
+        App.GetService<IActionService>().InvokeActionList(ruleActionPair.ActionList);
     }
 
     private void CommandDebugInvokeBackAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Ruleset ruleset) return;
+        if (e.Parameter is not RuleActionPair ruleActionPair) return;
 
-        App.GetService<IActionService>().InvokeBackAction([.. ruleset.Actions]);
+        App.GetService<IActionService>().InvokeBackActionList(ruleActionPair.ActionList);
     }
 }

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
@@ -1,0 +1,102 @@
+﻿using System.Windows;
+using System.Windows.Input;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Attributes;
+using ClassIsland.Core.Enums.SettingsWindow;
+using ClassIsland.Core.Models.Ruleset;
+using ClassIsland.Core.Models.Action;
+using ClassIsland.Services;
+using ClassIsland.ViewModels.SettingsPages;
+using ClassIsland.Shared.Helpers;
+using MaterialDesignThemes.Wpf;
+using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace ClassIsland.Views.SettingPages;
+
+/// <summary>
+/// RuleSettingsPage.xaml 的交互逻辑
+/// </summary>
+[SettingsPageInfo("rules", "规则", PackIconKind.TagMultipleOutline, PackIconKind.TagMultiple, SettingsPageCategory.Internal)]
+public partial class RuleSettingsPage
+{
+    public RulesetSettingsViewModel ViewModel { get; } = new();
+
+    public IRulesetService RulesetService { get; }
+    public SettingsService SettingsService { get; }
+    public ILogger<RuleSettingsPage> Logger { get; }
+
+    public RuleSettingsPage(IRulesetService rulesetService, SettingsService settingsService, ILogger<RuleSettingsPage> logger)
+    {
+        RulesetService = rulesetService;
+        SettingsService = settingsService;
+        Logger = logger;
+        DataContext = this;
+        InitializeComponent();
+    }
+
+    public static readonly ICommand AddRuleCommand = new RoutedUICommand();
+    public static readonly ICommand RemoveRuleCommand = new RoutedUICommand();
+    public static readonly ICommand RemoveRulesetCommand = new RoutedUICommand();
+    public static readonly ICommand DuplicateRulesetCommand = new RoutedUICommand();
+    public static readonly ICommand DebugInvokeActionCommand = new RoutedUICommand();
+    public static readonly ICommand DebugInvokeBackActionCommand = new RoutedUICommand();
+
+    public ObservableCollection<Ruleset> Rulesets
+    {
+        get => SettingsService.Settings.Rules;
+        set => SettingsService.Settings.Rules = value;
+    }
+
+    private void ButtonAddRule_OnClick(object sender, RoutedEventArgs e)
+    {
+        Rulesets.Add(new() { Groups = [new() { Rules = new() { new() } }] });
+    }
+
+    private void CommandAddRule_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Ruleset ruleset) return;
+
+        ruleset.Groups[0].Rules.Add(new Rule());
+    }
+
+    private void CommandRemoveRuleCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Rule rule) return;
+
+        foreach (var ruleset in Rulesets)
+        {
+            var isRemoved = ruleset.Groups[0].Rules.Remove(rule);
+            if (isRemoved) return;
+        }
+    }
+
+    private void CommandRemoveRulesetCommand_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Ruleset ruleset) return;
+
+        Rulesets.Remove(ruleset);
+    }
+
+    private void CommandDuplicateRuleset_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Ruleset ruleset) return;
+
+        Rulesets.Add(ConfigureFileHelper.CopyObject(ruleset));
+    }
+
+    private void CommandDebugInvokeAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Ruleset ruleset) return;
+
+        App.GetService<IActionService>().InvokeAction([.. ruleset.Actions]);
+    }
+
+    private void CommandDebugInvokeBackAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not Ruleset ruleset) return;
+
+        App.GetService<IActionService>().InvokeBackAction([.. ruleset.Actions]);
+    }
+}

--- a/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/RuleSettingsPage.xaml.cs
@@ -41,6 +41,7 @@ public partial class RuleSettingsPage
     public static readonly ICommand DuplicateCommand = new RoutedUICommand();
     public static readonly ICommand DebugInvokeActionCommand = new RoutedUICommand();
     public static readonly ICommand DebugInvokeBackActionCommand = new RoutedUICommand();
+    public static readonly ICommand DebugInvokeActionSyncCommand = new RoutedUICommand();
 
     public ObservableCollection<RuleActionPair> RuleActionPairs
     {
@@ -79,5 +80,12 @@ public partial class RuleSettingsPage
         if (e.Parameter is not RuleActionPair ruleActionPair) return;
 
         App.GetService<IActionService>().InvokeBackActionList(ruleActionPair.ActionList);
+    }
+
+    private void CommandDebugInvokeActionSync_OnExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (e.Parameter is not RuleActionPair ruleActionPair) return;
+
+        App.GetService<IActionService>().DebugInvokeActionListSync(ruleActionPair.ActionList);
     }
 }


### PR DESCRIPTION
> 此 PR 还没做完，只是为了中途提问而发布。
> 正式发布将会在另一个 PR 中。

## 界面设计请求

这一页如何排版，各位有什么建议吗？
![image](https://github.com/user-attachments/assets/3dc52f58-4eb9-44ea-9791-f6ebdb24db45)
感觉放在应用设置窗口中 & 双栏有点拥挤，有没有必要专门建个窗口之类的（？）

## 命名请求

各位对于这些功能怎么命名有什么建议吗？尤其是最后三个，真的想不出什么好名字。

| 英文 | 中文 | 描述 |
|--------|--------|--------|
| Action | 行动| 可以自动执行操作的一种功能|
| ActionList | 行动列表| 依次执行的多个行动组成的列表|
| Action (Timetable) | 行动（时间表）| 一种时间表中的时间类型，在时间到达时执行自定义操作|
| InvokeAction | 触发行动| 执行一组行动|
| InvokeBackAction | 触发恢复行动| 执行一组行动的恢复操作| 
| RuleActionPair | **规则行动组**| 在规则集满足时自动执行行动的一种组合| 
| **Rule** (SettingPage) | **规则**（标签页）| 应用设置中的一个标签页，用于管理和编辑规则行动组| 
| AddRule | 【 **+ 添加条件** 】| 在规则（标签页）中添加一对规则和行动|

---

@HelloWRC

### 想问一下这些问题：

1. **如何制作做一个「等待 xx 秒执行下一步」的行动？**

目前我在 `SleepActionHandler` 中阻塞线程，以执行「等待」的行为
```csharp
Task.Delay(等待时长).Wait();
```
并在 `ActionService` 中逐步执行每一个行动
```csharp
Task.Run(() => {
    foreach (var action in actions) {
        InvokeAction(action);
    }
});
```
但是这会导致 \*修改应用设置\*的行动 被触发时报错（如图）

我应该如何新建线程来避免此问题？

![image](https://github.com/user-attachments/assets/1990be98-1013-4164-805e-43ee6fb1459a)

2. 见评论 https://github.com/ClassIsland/ClassIsland/pull/395#discussion_r1782934035

### `还有一大堆不是很必要的问题：`

3. 我想做一个行动：用户选择/输入应用设置变量名和目标值，来自动临时更改应用设置。

我想知道有没有办法：
- 在 ComboBox 中列出所有的\*应用设置变量名\*。
- 将用户输入的 String 转换为该设置的\*数据类型\*。

4. 有没有方法给 ComboBox 分二级菜单

这样能方便储存比较多的的行动。

5. `FileBrowserButton` 无法同时存在多个。

如果有一个新的，原来那个的图标会消失。

`我好奇这是什么原因。`

6. 为什么 RuleActionPair 不会在修改时自动保存。

作为一个 Observable 的列表，我觉得它应该会在发生变化时通知保存的。

7. `SettingsOverlay` 设置叠层

为图方便，我在 `SettingsOverlay` 设置叠层中大量使用了 dynamic 和 reflection。
我想知道这是否被允许，以及它们对性能的影响有多大？

最后，给大家看一只可爱的 BacteriaOutline（）

<img src="https://github.com/user-attachments/assets/4c8005ac-21a7-40fb-a60b-0eb4268cb0c5" width=50/>
