### PR TITLE
feat: 移除`文本`组件设置中的字体大小和字体颜色设置

### DIFF
--- a/ClassIsland/Controls/Components/TextComponent.xaml
+++ b/ClassIsland/Controls/Components/TextComponent.xaml
@@ -7,17 +7,10 @@
                         xmlns:local="clr-namespace:ClassIsland.Controls.Components"
                         xmlns:controls="clr-namespace:ClassIsland.Core.Abstractions.Controls;assembly=ClassIsland.Core"
                         xmlns:componentSettings="clr-namespace:ClassIsland.Models.ComponentSettings"
-                        xmlns:converters="clr-namespace:ClassIsland.Core.Converters;assembly=ClassIsland.Core"
                         mc:Ignorable="d" 
                         d:DesignHeight="450" d:DesignWidth="800">
-    <controls:ComponentBase.Resources>
-        <converters:ColorToColorPickerBrushConverter x:Key="ColorToColorPickerBrushConverter"/>
-    </controls:ComponentBase.Resources>
     <Grid VerticalAlignment="Center" 
           DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:TextComponent}}">
-        <TextBlock 
-                   Text="{Binding Settings.TextContent}"
-                   FontSize="{Binding Settings.FontSize}"
-                   Foreground="{Binding Settings.FontColor, Converter={StaticResource ColorToColorPickerBrushConverter}}"/>
+        <TextBlock Text="{Binding Settings.TextContent}"/>
     </Grid>
 </controls:ComponentBase>

--- a/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
@@ -13,15 +13,8 @@
         <StackPanel
             DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:TextComponentSettingsControl}}">
             <TextBlock Text="文本内容" />
-            <TextBox HorizontalAlignment="Left" MinWidth="200" Margin="10 4 0 0"
+            <TextBox HorizontalAlignment="Left" MinWidth="200" Margin="8 4 0 0"
                      Text="{Binding Settings.TextContent,UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="字体颜色" Margin="0 8 0 0" />
-            <ci:ColorPicker Width="auto" Margin="10 8 0 0" HorizontalAlignment="Left"
-                            Color="{Binding Settings.FontColor, Mode=TwoWay}" />
-            <TextBlock Text="字体大小" Margin="0 8 0 0" />
-            <Slider Width="200" Margin="10 8 0 0" HorizontalAlignment="Left"
-                    Maximum="30" Minimum="16" IsSnapToTickEnabled="True" AutoToolTipPlacement="BottomRight"
-                    Value="{Binding Settings.FontSize}" />
         </StackPanel>
     </ScrollViewer>
 </controls:ComponentBase>

--- a/ClassIsland/Models/ComponentSettings/TextComponentSettings.cs
+++ b/ClassIsland/Models/ComponentSettings/TextComponentSettings.cs
@@ -6,8 +6,6 @@ namespace ClassIsland.Models.ComponentSettings;
 public class TextComponentSettings : ObservableRecipient
 {
     private string _textContent = "";
-    private int _fontSize = 16;
-    private Color _fontColor = Color.FromRgb(255, 255, 255);
 
     public string TextContent
     {
@@ -16,28 +14,6 @@ public class TextComponentSettings : ObservableRecipient
         {
             if (value == _textContent) return;
             _textContent = value;
-            OnPropertyChanged();
-        }
-    }
-    public int FontSize
-    {
-        get => _fontSize;
-        set
-        {
-            if (value == null) return;
-            if (value.Equals(_fontSize)) return;
-            _fontSize = value;
-            OnPropertyChanged();
-        }
-    }
-    public Color FontColor
-    {
-        get => _fontColor;
-        set
-        {
-            if (value == null) return;
-            if (value.Equals(_fontColor)) return;
-            _fontColor = value;
             OnPropertyChanged();
         }
     }


### PR DESCRIPTION
主要原因有：
1. 使之能应用到`外观`，以及高级设置里对字体的相关设置
2. 引导用户使用高级设置对字体设置