### PR TITLE
docs(README): :art: 微调 README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,112 @@
+<!--markdownlint-disable MD001 MD033 MD041 MD051-->
+
 <div align="center">
 
 # <image src="ClassIsland/Assets/AppLogo_AppLogo.svg" height="28"/> ClassIsland
 
 <!-- ![软件截图-主界面](https://github.com/ClassIsland/ClassIsland/assets/55006226/65e2bdba-be83-444c-b42f-b893aaace9c3) -->
+
 ![Banner](https://github.com/user-attachments/assets/a815dd7d-8343-4da5-aee4-3f754aa297e4)
 
-[![stars](https://img.shields.io/github/stars/ClassIsland/ClassIsland?label=Stars)](https://github.com/ClassIsland/ClassIsland)
-[![Release](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?style=flat-square&color=%233fb950&label=正式版)](https://github.com/ClassIsland/ClassIsland/releases/latest) 
-[![Beta](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?include_prereleases&style=flat-square&label=测试版)](https://github.com/ClassIsland/ClassIsland/releases/)
-[![Downloads](https://img.shields.io/github/downloads/ClassIsland/ClassIsland/total?style=social&label=下载量&logo=github)](https://github.com/ClassIsland/ClassIsland/releases/latest)
+[![Stars](https://img.shields.io/github/stars/ClassIsland/ClassIsland?label=Stars)](https://github.com/ClassIsland/ClassIsland)
+[![正式版 Release](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?style=flat-square&color=%233fb950&label=正式版)](https://github.com/ClassIsland/ClassIsland/releases/latest)
+[![测试版 Release](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?include_prereleases&style=flat-square&label=测试版)](https://github.com/ClassIsland/ClassIsland/releases/)
+[![下载量](https://img.shields.io/github/downloads/ClassIsland/ClassIsland/total?style=social&label=下载量&logo=github)](https://github.com/ClassIsland/ClassIsland/releases/latest)
 
 ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具，可以在 Windows 屏幕上显示各种信息。<br/>
 本应用的名字灵感源于 iOS 灵动岛（Dynamic Island）功能。
 
-#### [点我进入 Classlsland 官方频道](https://classisland.tech/)
+#### [💬 点我进入 Classlsland 官方频道](https://pd.qq.com/s/grr6qwqwj)
 
-#### [ClassIsland 官方网站](https://classisland.tech/)｜[ClassIsland 官方文档](https://docs.classisland.tech)｜[Classlsland 功能投票](https://github.com/ClassIsland/voting/discussions?discussions_q=is%3Aopen+sort%3Atop)
+#### [🌐 ClassIsland 官方网站](https://classisland.tech/)｜[📚 ClassIsland 官方文档](https://docs.classisland.tech)｜[🗳 Classlsland 功能投票](https://github.com/ClassIsland/voting/discussions?discussions_q=is%3Aopen+sort%3Atop)
 
 ###### [观看介绍视频，快速了解突破创新 →](https://bilibili.com/video/BV1Lt421n7op/)
+
 </div>
 
 ## 功能
-💡 您可以点击下方链接或查看 [ClassIsland 文档](https://docs.classisland.tech) 了解更多。
+
+> [!TIP]
+>
+> 您可以点击下方链接或查看 [ClassIsland 文档](https://docs.classisland.tech) 了解更多。
 
 ### 课表显示
-- [X] 显示当天的课表、当前进行课程的信息
-- [X] 在上下课等重要时间点发出[提醒](https://docs.classisland.tech/app/notifications)，自选搭配音效、强调特效和语音[增强提醒](https://docs.classisland.tech/app/notifications#强调提醒)
-- [X] 自选课表隐藏条件、临时隐藏与鼠标穿透，不影响授课
+
+- [x] 显示当天的课表、当前进行课程的信息
+- [x] 在上下课等重要时间点发出 [提醒](https://docs.classisland.tech/app/notifications)，自选搭配音效、强调特效、语音和置顶效果的 [强调提醒](https://docs.classisland.tech/app/notifications#强调提醒)
+- [x] 自选课表隐藏条件、临时隐藏与鼠标穿透，不影响授课
 
 ### 课表编辑与管理
-- [X] 简洁直观的[课表编辑工具](https://docs.classisland.tech/app/classplan)
-- [X] 从 Excel 或其他软件[导入课表](https://docs.classisland.tech/app/profile/#%E4%BB%8E%E8%A1%A8%E6%A0%BC%E5%AF%BC%E5%85%A5)
-- [X] 多周轮换、快速录入时间表、自定义设置
-- [X] 临时换课、临时启用某个课表
+
+- [x] 简洁直观的 [课表编辑工具](https://docs.classisland.tech/app/classplan)
+- [x] 从 Excel 或其他软件 [导入课表](https://docs.classisland.tech/app/profile/#%E4%BB%8E%E8%A1%A8%E6%A0%BC%E5%AF%BC%E5%85%A5)
+- [x] 多周轮换、快速录入时间表、自定义设置
+- [x] 临时换课、临时启用某个课表
 
 ### 其它功能
-- [X] 自动同步软件时间、手动对齐铃声
-- [X] [天气](https://docs.classisland.tech/app/advanced#天气)、极端天气预警
-- [X] 通过[组件](https://docs.classisland.tech/app/basic#组件)（日期、时间、天气简报、倒计日等）和[插件](https://docs.classisland.tech/app/basic#组件)高度自定义 ClassIsland
-- [X] 丝滑、流畅的过渡动画
-- [X] 自动获取与系统配色搭配的主题色
-- [X] 自动软件更新
+
+- [x] 自动同步软件时间、手动对齐铃声
+- [x] [天气](https://docs.classisland.tech/app/advanced#天气)、极端天气预警
+- [x] 通过 [组件](https://docs.classisland.tech/app/basic#组件)（日期、时间、天气简报、倒计日等）和 [插件](https://docs.classisland.tech/app/basic#组件) 高度自定义 ClassIsland
+- [x] 丝滑、流畅的过渡动画
+- [x] 自动获取与系统配色搭配的主题色
+- [x] 自动软件更新
 - [ ] [集控管理](https://docs.classisland.tech/management)_（即将发布）_
 - [ ] ……
 
 ## 软件截图
-> 背景图片来自 [Pixiv＠辰暮sora](https://pixiv.net/artworks/110847880)
+
+> 背景图片来自 [Pixiv@辰暮 sora](https://pixiv.net/artworks/110847880)
 
 ### 主界面
 
-##### 1.软件效果
+##### 1. 软件效果
+
 ![软件截图-整体效果](https://github.com/ClassIsland/ClassIsland/assets/55006226/784a2f8c-a9e2-4656-b66d-9f8105f0600c)
-##### 2.演示上课提醒视频
+
+##### 2. 演示上课提醒视频
+
 <video src="https://github.com/ClassIsland/ClassIsland/assets/55006226/b797138a-84ef-4296-b69b-3989f331f289" loop label="软件截图-上课提醒" autoplay muted></video>
 
 <details>
-<summary>查看更多软件截图…</summary>
+<summary>查看更多软件截图……</summary>
 
 ### 提醒
 
-##### 1.上课提醒
+##### 1. 上课提醒
+
 ![上课](https://github.com/user-attachments/assets/965815a0-9e2a-49bb-85b2-18398e3a16bf)
-##### 2.下课提醒
+
+##### 2. 下课提醒
+
 ![下课](https://github.com/user-attachments/assets/c6059b99-f06e-442d-b73e-80d63b7e06aa)
-##### 3.天气预报
+
+##### 3. 天气预报
+
 ![天气预报](https://github.com/user-attachments/assets/d8b308d3-986f-4768-93ac-f6d634394f98)
 
 ### 档案编辑器
 
-##### 1.课表编辑
+##### 1. 课表编辑
+
 ![软件截图-课表编辑](https://github.com/ClassIsland/ClassIsland/assets/55006226/29d91bf2-4c8a-4cbd-a778-a9034e7d7420)
-##### 2.时间表编辑
+
+##### 2. 时间表编辑
+
 ![软件截图-时间表编辑](https://github.com/ClassIsland/ClassIsland/assets/55006226/2b3b5c87-c8bb-46f0-8470-01edf3ca52a2)
-##### 3.科目编辑
+
+##### 3. 科目编辑
+
 ![软件截图-科目编辑](https://github.com/ClassIsland/ClassIsland/assets/55006226/a2e64983-dfa0-4565-a45a-31c9f9c298a8)
 
 ### 设置界面
 
-##### 1.基本设置
+##### 1. 基本设置
+
 ![软件截图-应用设置](https://github.com/ClassIsland/ClassIsland/assets/55006226/063123a1-1bf2-4b41-bef7-1dc731631d08)
-##### 2.组件设置
+
+##### 2. 组件设置
+
 ![软件截图-组件设置](https://github.com/user-attachments/assets/e6185858-ae21-4fc4-8e08-2dc253075f66)
 
 </details>
@@ -87,24 +114,25 @@ ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具�
 ## 开始使用
 
 **首先，请确保您的设备满足以下推荐需求：**
+
 - Windows 10 及以上版本的系统，x64 架构
 - 安装 [.NET 8.0 桌面运行时](https://dotnet.microsoft.com/zh-cn/download/dotnet/thank-you/runtime-desktop-8.0.7-windows-x64-installer)
 
-> [!important]
+> [!IMPORTANT]
 > **详细安装说明请参阅 [ClassIsland 文档](https://docs.classisland.tech/app/setup)。**
-> 
-> 不建议在 Windows 10 以下的系统运行本应用。 在 Windows 7 中，.NET 运行时会产生**严重的内存泄漏问题**。如果您执意要在 Windows 7 中使用 ClassIsland，请参阅[在 Windows 7 中安装 ClassIsland](https://docs.classisland.tech/app/setup#检查系统需求)。
+>
+> 不建议在 Windows 10 以下的系统运行本应用。 在 Windows 7 中，.NET 运行时会产生**严重的内存泄漏问题**。如果您执意要在 Windows 7 中使用 ClassIsland，请参阅 [在 Windows 7 中安装 ClassIsland](https://docs.classisland.tech/app/setup#检查系统需求)。
 
 对于普通用户，可以在以下渠道下载到本软件，请根据自身网络环境选择合适的渠道。
 
 > 测试版包含最新的功能，但也可能包含未完善和不稳定的功能。
 
-| 下载渠道 | **🚀正式版**<br/>[![正式版](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?style=flat-square&color=%233fb950&label=)](https://github.com/ClassIsland/ClassIsland/releases/latest) | 🚧测试版<br/>[![测试版](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?include_prereleases&style=flat-square&label=)](https://github.com/ClassIsland/ClassIsland/releases/) |
-| :--: | :--: | :--: |
-| GitHub | [**GitHub下载**](https://github.com/ClassIsland/ClassIsland/releases/latest) | [GitHub下载](https://github.com/ClassIsland/ClassIsland/releases) |
-| AppCenter | [**AppCenter下载**](https://install.appcenter.ms/users/hellowrc/apps/classisland/distribution_groups/public/releases/latest) | [AppCenter下载](https://install.appcenter.ms/users/hellowrc/apps/classisland/distribution_groups/publicbeta/releases/latest) |
+| 下载渠道  | **🚀 正式版**<br/>[![正式版](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?style=flat-square&color=%233fb950&label=)](https://github.com/ClassIsland/ClassIsland/releases/latest) | 🚧 测试版<br/>[![测试版](https://img.shields.io/github/v/release/ClassIsland/ClassIsland?include_prereleases&style=flat-square&label=)](https://github.com/ClassIsland/ClassIsland/releases/) |
+| :-------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|  GitHub   |                                                            [**下载**](https://github.com/ClassIsland/ClassIsland/releases/latest)                                                            |                                                              [下载](https://github.com/ClassIsland/ClassIsland/releases)                                                               |
+| AppCenter |                                    [**下载**](https://install.appcenter.ms/users/hellowrc/apps/classisland/distribution_groups/public/releases/latest)                                    |                                 [下载](https://install.appcenter.ms/users/hellowrc/apps/classisland/distribution_groups/publicbeta/releases/latest)                                 |
 
-如果以上链接无法使用，可以从[镜像链接](https://docs.classisland.tech/app/setup#%E4%B8%8B%E8%BD%BD%E5%BA%94%E7%94%A8%E6%9C%AC%E4%BD%93)下载。
+如果以上链接无法使用，可以从 [镜像链接](https://docs.classisland.tech/app/setup#%E4%B8%8B%E8%BD%BD%E5%BA%94%E7%94%A8%E6%9C%AC%E4%BD%93) 下载。
 
 下载完成后，将软件压缩包解压到一个**独立的文件夹（运行路径不能有中文）**，运行软件即可开始使用。解压时请不要解压到网盘同步文件夹、【下载】文件夹中，否则可能会出现**文件无法读写、文件丢失**等问题。
 
@@ -129,18 +157,22 @@ ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具�
 - 正在 [`master`](https://github.com/ClassIsland/ClassIsland/tree/master) 分支上维护版本 [1.5 - Griseo](https://github.com/ClassIsland/ClassIsland/milestone/6)。
 
 要在本地编译应用，您需要安装以下负载和工具：
+
 - [.NET 8.0 SDK](https://dotnet.microsoft.com/zh-cn/download/dotnet/8.0)
 - [Visual Studio](https://visualstudio.microsoft.com/)
 
 对于 Visual Studio，您需要在安装时勾选以下工作负载：
+
 - .NET 桌面开发
 
-如果您有意愿为 ClassIsland 做出代码贡献，请先阅读[贡献指南](CONTRIBUTING.md)来了解如何为 ClassIsland 做代码贡献。我们欢迎想要为本应用实现新功能或进行改进的同学提交 [Pull Request](https://github.com/ClassIsland/ClassIsland/pulls)。
+如果您有意愿为 ClassIsland 做出代码贡献，请先阅读 [贡献指南](CONTRIBUTING.md) 来了解如何为 ClassIsland 做代码贡献。我们欢迎想要为本应用实现新功能或进行改进的同学提交 [Pull Request](https://github.com/ClassIsland/ClassIsland/pulls)。
 
 ## 致谢
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 本项目受到 [DuguSand/class_form](https://github.com/DuguSand/class_form) 的启发而开发。
@@ -180,8 +212,10 @@ ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具�
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+<!--markdownlint-disable MD001 MD033 MD041 MD051-->
 
 本项目使用到的第三方库和框架：
+
 - [.NET](https://github.com/microsoft/dotnet)
 - [CommunityToolkit.Mvvm](https://github.com/CommunityToolkit/dotnet)
 - [dotnetCampus.Ipc](https://github.com/dotnet-campus/dotnetCampus.Ipc)
@@ -217,7 +251,7 @@ ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具�
 
 ## 许可证
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FHelloWRC%2FClassIsland.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FHelloWRC%2FClassIsland?ref=badge_shield&style=flat-square) 
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FHelloWRC%2FClassIsland.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FHelloWRC%2FClassIsland?ref=badge_shield&style=flat-square)
 
 本项目基于 [MIT License](LICENSE.txt) 获得许可。
 
@@ -228,6 +262,7 @@ ClassIsland 是一款适用于班级多媒体屏幕的课表信息显示工具�
 [![Star 历史](https://starchart.cc/ClassIsland/ClassIsland.svg?variant=adaptive)](https://starchart.cc/ClassIsland/ClassIsland)
 
 <div align="center">
+
 如果这个项目对您有帮助，请点亮 Star ⭐
 
 </div>


### PR DESCRIPTION
- 添加了对 markdownlint 的支持
- 修改了部分图片不统一的 `alt text`
- 为数个超链接加入了图标
- 加入了 `[!TIP]` 等强调标签
- 修复了 QQ频道 的错误跳转
- 加入了超链接与普通文本间的空格
- 精简了「下载渠道」处较长的超链接名称
- 修复了部分行尾多余空格、部分行之间空行超过一行的问题

~~该修改可能较为激进。~~ 好吧其实并不是特别激进。以后有时间了再想想还能怎么优化这个 README。