### PR TITLE
时间使用实际时间；反转指针移入淡化；Bug 修复

### DIFF
--- a/ClassIsland.Core/Controls/LessonsControls/LessonControlExpanded.xaml
+++ b/ClassIsland.Core/Controls/LessonsControls/LessonControlExpanded.xaml
@@ -18,8 +18,8 @@
         <converters:SizeDoubleToCornerRadiusConverter x:Key="SizeDoubleToCornerRadiusConverter" />
     </local:LessonControlBase.Resources>
     <Grid DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:LessonControlExpanded}}}">
-        <StackPanel Orientation="Horizontal" Margin="4 0" VerticalAlignment="Center">
-            <Border Width="12">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <Border Width="16">
                 <Border.LayoutTransform>
                     <ScaleTransform ScaleX="{Binding DefaultLessonControlSettings.ScheduleSpacing, Mode=OneWay}"/>
                 </Border.LayoutTransform>
@@ -168,7 +168,7 @@
                                     CornerRadius="{Binding ActualHeight, RelativeSource={RelativeSource Self}, Converter={StaticResource SizeDoubleToCornerRadiusConverter}}">
                                 <Grid>
                                     <TextBlock FontSize="{DynamicResource MainWindowBodyFontSize}" VerticalAlignment="Center">
-                                        <Run Text="-" FontSize="{DynamicResource MainWindowSecondaryFontSize}">
+                                        <Run Text="-">
                                         </Run><Run Text="{Binding LeftSeconds,
                                                    Converter={StaticResource SecondsToFormatTimeConverter},
                                                    ConverterParameter={StaticResource TrueValue}}"/>
@@ -181,7 +181,7 @@
 
             </StackPanel>
 
-            <Border Width="12">
+            <Border Width="16">
                 <Border.LayoutTransform>
                     <ScaleTransform ScaleX="{Binding DefaultLessonControlSettings.ScheduleSpacing, Mode=OneWay}"/>
                 </Border.LayoutTransform>

--- a/ClassIsland.Core/Controls/LessonsControls/LessonsListBox.cs
+++ b/ClassIsland.Core/Controls/LessonsControls/LessonsListBox.cs
@@ -82,14 +82,14 @@ public class LessonsListBox : ListBox
     }
 
     public static readonly DependencyProperty DiscardHidingDefaultProperty = DependencyProperty.Register(
-        nameof(DiscardHidingDefault), typeof(bool), typeof(LessonsListBox), new PropertyMetadata(default(bool),
+        nameof(DiscardHidingDefault), typeof(bool), typeof(LessonsListBox), new PropertyMetadata(default(bool)/*,
             (o, args) =>
             {
                 var control = o as LessonsListBox;
                 if (control?.FindResource("LessonsListBoxItemTemplateMultiConverter") is not LessonsListBoxItemTemplateMultiConverter cv)
                     return;
 
-            }));
+            }*/));
 
     public bool DiscardHidingDefault
     {

--- a/ClassIsland.Core/Converters/SecondsToFormatTimeMultiConverter.cs
+++ b/ClassIsland.Core/Converters/SecondsToFormatTimeMultiConverter.cs
@@ -6,9 +6,6 @@ namespace ClassIsland.Core.Converters;
 /// <summary>
 /// 将两个秒数转换为格式化时长
 /// </summary>
-/// <returns>
-/// 形似 1h02m/1h12m，12m/1h12m，8/36min
-/// </returns>
 public class SecondsToFormatTimeMultiConverter : IMultiValueConverter
 {
     public object Convert(object[] value, Type targetType, object parameter, CultureInfo culture)
@@ -18,15 +15,15 @@ public class SecondsToFormatTimeMultiConverter : IMultiValueConverter
             return "";
         }
         var ceiling = (string?)parameter == "1";
-        var v0 = TimeSpan.FromMinutes(Round(TimeSpan.FromSeconds(value[0] as long? ?? 0).TotalMinutes)); // 已过时长或剩余时长
-        var v1 = TimeSpan.FromSeconds(value[1] as long? ?? 0); // 总时长
+        var v0 = TimeSpan.FromMinutes(Round((value[0] as long? ?? 0) / 60)); // 已过时长或剩余时长
+        var v1 = TimeSpan.FromMinutes(Math.Round((double)(value[1] as long? ?? 0) / 60)); // 总时长
 
-        var t0 = v0.TotalHours >= 1 ? // 0h03m -> 3m
+        var t0 = v0.TotalHours >= 1 ?
             $"{Math.Floor(v0.TotalHours)}h{v0.Minutes:00}m" :
-            $"{v0.TotalMinutes}m";
-        var t1 = v1.TotalHours >= 1 ? // 0h03m -> 3m
+            $"{v0.Minutes}m";
+        var t1 = v1.TotalHours >= 1 ?
             $"{Math.Floor(v1.TotalHours)}h{v1.Minutes:00}m" :
-            $"{v1.TotalMinutes}m";
+            $"{v1.Minutes}m";
         return $"{t0}/{t1}"; // 时分样式
 
         double Round(double x) => ceiling ? Math.Ceiling(x) : Math.Floor(x);

--- a/ClassIsland/Controls/Components/ClockComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/ClockComponentSettingsControl.xaml
@@ -3,19 +3,37 @@
                          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                          xmlns:local="clr-namespace:ClassIsland.Controls.Components"
                          xmlns:controls="clr-namespace:ClassIsland.Core.Controls;assembly=ClassIsland.Core"
                          xmlns:controls1="clr-namespace:ClassIsland.Core.Abstractions.Controls;assembly=ClassIsland.Core"
                          xmlns:componentSettings="clr-namespace:ClassIsland.Models.ComponentSettings"
-                         mc:Ignorable="d" 
-                         d:DesignHeight="450" d:DesignWidth="800">
+                         xmlns:ci="http://classisland.tech/schemas/xaml/core"
+                         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+                         xmlns:converters="clr-namespace:ClassIsland.Core.Converters;assembly=ClassIsland.Core"
+                         mc:Ignorable="d"
+                         d:DesignHeight="450"
+                         d:DesignWidth="800">
+    <controls1:ComponentBase.Resources>
+        <converters:BooleanToVisibilityReConverter x:Key="BooleanToVisibilityReConverter" />
+    </controls1:ComponentBase.Resources>
     <ScrollViewer DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:ClockComponentSettingsControl}}">
         <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
+            <controls:SettingsCard IconGlyph="ClockCheckOutline"
+                                   Header="使用实际时间"
+                                   Description="显示不经过时间偏移的系统时间。"
+                                   IsOn="{Binding Settings.ShowRealTime, Mode=TwoWay}" />
+
             <controls:SettingsCard IconGlyph="ClockDigital"
                                    Header="显示秒数"
                                    Description="启用后，时钟将显示精准到秒的时间。"
-                                   IsOn="{Binding Settings.ShowSeconds, Mode=TwoWay}"/>
+                                   IsOn="{Binding Settings.ShowSeconds, Mode=TwoWay}" />
+
+            <controls:SettingsCard IconGlyph="CameraTimer"
+                                   Header="闪动时间分隔符"
+                                   Description="模拟电子时钟的分隔符闪动效果。"
+                                   IsOn="{Binding Settings.FlashTimeSeparator, Mode=TwoWay}"
+                                   Visibility="{Binding Settings.ShowSeconds, Converter={StaticResource BooleanToVisibilityReConverter}}"/>
         </StackPanel>
     </ScrollViewer>
 </controls1:ComponentBase>

--- a/ClassIsland/Controls/Components/ScheduleComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/ScheduleComponentSettingsControl.xaml
@@ -200,9 +200,10 @@
                                  Description="使课程表显示更紧凑或宽松。"
                                  Margin="0 0 0 6">
                     <ci:SettingsCard.Switcher>
-                        <Slider Width="150" Minimum="0.2" Maximum="1"
+                        <Slider Width="150" Minimum="0.3" Maximum="1"
                                 Value="{Binding Settings.ScheduleSpacing}"
-                                TickFrequency="0.1" AutoToolTipPrecision="1"
+                                TickFrequency="0.05" IsSnapToTickEnabled="True"
+                                AutoToolTipPrecision="2"
                                 AutoToolTipPlacement="BottomRight"/>
                     </ci:SettingsCard.Switcher>
                 </ci:SettingsCard>

--- a/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
+++ b/ClassIsland/Controls/NotificationProviders/ClassNotificationProviderControl.xaml.cs
@@ -129,7 +129,7 @@ public partial class ClassNotificationProviderControl : UserControl, INotifyProp
             if (span.Minutes > 0) sb.Append($" {span.Minutes} 分钟");
             if (span.Seconds > 0) sb.Append($" {span.Seconds} 秒");
             var s = sb.ToString();
-            return s.StartsWith(" ") ? s[1..] : s;
+            return s.StartsWith(' ') ? s[1..] : s;
         }
     }
 }

--- a/ClassIsland/Controls/TimeLineListItemExpandingAdornerControl.xaml.cs
+++ b/ClassIsland/Controls/TimeLineListItemExpandingAdornerControl.xaml.cs
@@ -78,7 +78,7 @@ public partial class TimeLineListItemExpandingAdornerControl
         if (TimePoint.EndSecond.TimeOfDay > a + d && !(a + d < PrevTimePoint(0)?.EndSecond.TimeOfDay))
         {
             TimePoint.StartSecond += d;
-            if (b?.TimeType == 1 && b.StartSecond < TimePoint.StartSecond)
+            if (b?.TimeType == 1 && b.StartSecond < TimePoint.StartSecond && b.EndSecond.TimeOfDay == a)
                 b.EndSecond = TimePoint.StartSecond;
          // else if (b?.TimeType == 0)
          //     App.GetService<ProfileSettingsWindow>().AddTimeLayoutItem(1, TimePoint.StartSecond, b.EndSecond);
@@ -94,7 +94,7 @@ public partial class TimeLineListItemExpandingAdornerControl
         if (a + d > TimePoint.StartSecond.TimeOfDay && !(NextTimePoint(0)?.StartSecond.TimeOfDay < a + d))
         {
             TimePoint.EndSecond += d;
-            if (b?.TimeType == 1 && TimePoint.StartSecond < b.StartSecond)
+            if (b?.TimeType == 1 && TimePoint.StartSecond < b.StartSecond && b.StartSecond.TimeOfDay == a)
                 b.StartSecond = TimePoint.EndSecond;
          // else if (b?.TimeType == 0)
          //     App.GetService<ProfileSettingsWindow>().AddTimeLayoutItem(1, b.StartSecond, TimePoint.EndSecond);
@@ -113,11 +113,11 @@ public partial class TimeLineListItemExpandingAdornerControl
         var b2 = NextTimePoint();
         TimePoint.StartSecond += d;
         TimePoint.EndSecond   += d;
-        if (b1?.TimeType == 1 && b1.StartSecond < TimePoint.StartSecond)
+        if (b1?.TimeType == 1 && b1.StartSecond < TimePoint.StartSecond && b1.EndSecond.TimeOfDay == a1)
             b1.EndSecond = TimePoint.StartSecond;
      // else if (b1?.TimeType == 0)
      //     App.GetService<ProfileSettingsWindow>().AddTimeLayoutItem(1, b1.EndSecond, TimePoint.StartSecond);
-        if (b2?.TimeType == 1 && TimePoint.StartSecond < b2.StartSecond)
+        if (b2?.TimeType == 1 && TimePoint.StartSecond < b2.StartSecond && b2.StartSecond.TimeOfDay == a2)
             b2.StartSecond = TimePoint.EndSecond;
      // else if (b2?.TimeType == 0)
      //     App.GetService<ProfileSettingsWindow>().AddTimeLayoutItem(1, TimePoint.EndSecond, b2.StartSecond);

--- a/ClassIsland/Controls/WeatherPackIconControl.xaml.cs
+++ b/ClassIsland/Controls/WeatherPackIconControl.xaml.cs
@@ -60,9 +60,11 @@ public partial class WeatherPackIconControl : UserControl, INotifyPropertyChange
         {
             var c = (string)e.NewValue;
             WeatherName = App.GetService<IWeatherService>().GetWeatherTextByCode(c);
+            WeatherColor = "";
             if (AllowColor)
             {
-                if (WeatherName.Contains('雨')) WeatherColor = "Rainy";
+                if (WeatherName.Contains('雨') || WeatherName is "飑")
+                    WeatherColor = "Rainy";
             }
         }
         base.OnPropertyChanged(e);

--- a/ClassIsland/MainWindow.xaml
+++ b/ClassIsland/MainWindow.xaml
@@ -83,6 +83,7 @@
         </Style>
         <converters1:BooleanToVisibilityReConverter x:Key="BooleanToVisibilityReConverter"/>
         <ContextMenu FontFamily="{StaticResource HarmonyOsSans}" x:Key="AppContextMenu"
+                     StaysOpen="True"
                      IsEnabled="{Binding ViewModel.IsBusy, Converter={StaticResource InvertBooleanConverter}}">
             <ContextMenu.Resources>
                 <converters1:BooleanAndToVisibilityMultiConverter x:Key="BooleanAndToVisibilityMultiConverter" />

--- a/ClassIsland/MainWindow.xaml
+++ b/ClassIsland/MainWindow.xaml
@@ -371,18 +371,14 @@
         <Style TargetType="Window">
             <Style.Triggers>
                 <!-- 鼠标移入 -->
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ViewModel.IsMouseIn, Mode=OneWay}" Value="True"/>
-                        <Condition Binding="{Binding ViewModel.Settings.IsMouseInFadingEnabled, Mode=OneWay}" Value="True"/>
-                    </MultiDataTrigger.Conditions>
-                    <MultiDataTrigger.ExitActions>
-                        <BeginStoryboard Storyboard="{StaticResource WindowMouseOut}" Name="WindowMouseOut"/>
-                    </MultiDataTrigger.ExitActions>
-                    <MultiDataTrigger.EnterActions>
+                <DataTrigger Binding="{Binding ViewModel.IsMainWindowFaded, Mode=OneWay}" Value="True">
+                    <DataTrigger.EnterActions>
                         <BeginStoryboard Storyboard="{StaticResource WindowMouseIn}" Name="WindowMouseIn"/>
-                    </MultiDataTrigger.EnterActions>
-                </MultiDataTrigger>
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <BeginStoryboard Storyboard="{StaticResource WindowMouseOut}" Name="WindowMouseOut"/>
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
                 <!-- Debug -->
                 <DataTrigger Binding="{Binding ViewModel.Settings.IsMainWindowDebugEnabled, Mode=OneWay}" Value="True">
                     <Setter Property="Background" Value="#2FAA0000"/>

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -236,7 +236,10 @@ public partial class MainWindow : Window
         }
         //NotificationHostService.OnUpdateTimerTick(this, EventArgs.Empty);
 
-        SettingsService.Settings.TimeOffsetSeconds += (SettingsService.Settings.DebugTimeSpeed - 1) * 0.05;
+        if (SettingsService.Settings.DebugTimeSpeed != 0)
+        {
+            SettingsService.Settings.TimeOffsetSeconds += (SettingsService.Settings.DebugTimeSpeed - 1) * 0.05;
+        }
     }
 
     private void TaskBarIconOnTrayBalloonTipClicked(object sender, RoutedEventArgs e)

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -678,18 +678,17 @@ public partial class MainWindow : Window
     {
         var r = SettingsService.Settings;
         ViewModel.Settings = r;
-        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings(args.PropertyName);
+        ViewModel.Settings.PropertyChanged += SettingsOnPropertyChanged;
     }
 
-    public void SaveSettings(string note = "")
+    public void SettingsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         UpdateTheme();
-        if (note is nameof(ViewModel.Settings.IsMouseInFadingReversed)
-                 or nameof(ViewModel.Settings.IsMouseInFadingEnabled))
+        if (e.PropertyName is nameof(ViewModel.Settings.IsMouseInFadingReversed)
+                           or nameof(ViewModel.Settings.IsMouseInFadingEnabled))
         {
             UpdateFadeStatus();
         }
-        //SettingsService.SaveSettings($"{note} (MainWindow)");
     }
 
     private void ViewModelOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -714,7 +713,7 @@ public partial class MainWindow : Window
         if (DesignerProperties.GetIsInDesignMode(this))
             return;
         ViewModel.Profile.PropertyChanged += (sender, args) => SaveProfile();
-        ViewModel.Settings.PropertyChanged += (sender, args) => SaveSettings(args.PropertyName);
+        ViewModel.Settings.PropertyChanged += SettingsOnPropertyChanged;
         LoadSettings();
         //ViewModel.CurrentProfilePath = ViewModel.Settings.SelectedProfile;
         LoadProfile();
@@ -1027,7 +1026,6 @@ public partial class MainWindow : Window
     private void MenuItemDebugWelcomeWindow2_OnClick(object sender, RoutedEventArgs e)
     {
         ViewModel.Settings.IsWelcomeWindowShowed = false;
-        SaveSettings();
     }
 
     private void MenuItemHelps_OnClick(object sender, RoutedEventArgs e)

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -173,7 +173,7 @@ public partial class MainWindow : Window
         LessonsService.PreMainTimerTicked += LessonsServiceOnPreMainTimerTicked;
         LessonsService.PostMainTimerTicked += LessonsServiceOnPostMainTimerTicked;
         ViewModel = new MainViewModel();
-        //ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
+        ViewModel.PropertyChanged += ViewModelOnPropertyChanged;
         InitializeComponent();
         RulesetService.StatusUpdated += RulesetServiceOnStatusUpdated;
         TouchInFadingTimer.Tick += TouchInFadingTimerOnTick;
@@ -684,7 +684,27 @@ public partial class MainWindow : Window
     public void SaveSettings(string note = "")
     {
         UpdateTheme();
-        SettingsService.SaveSettings($"{note} (MainWindow)");
+        if (note is nameof(ViewModel.Settings.IsMouseInFadingReversed)
+                 or nameof(ViewModel.Settings.IsMouseInFadingEnabled))
+        {
+            UpdateFadeStatus();
+        }
+        //SettingsService.SaveSettings($"{note} (MainWindow)");
+    }
+
+    private void ViewModelOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ViewModel.IsMouseIn))
+        {
+            UpdateFadeStatus();
+        }
+    }
+
+    private void UpdateFadeStatus()
+    {
+        ViewModel.IsMainWindowFaded =
+            ViewModel.Settings.IsMouseInFadingEnabled &&
+           (ViewModel.IsMouseIn ^ ViewModel.Settings.IsMouseInFadingReversed);
     }
 
     protected override void OnInitialized(EventArgs e)

--- a/ClassIsland/Models/Actions/AppSettingsActionSettings.cs
+++ b/ClassIsland/Models/Actions/AppSettingsActionSettings.cs
@@ -33,7 +33,7 @@ public class ThemeActionSettings : ObservableRecipient
 
 public class WindowDockingLocationActionSettings : ObservableRecipient
 {
-    int _value = 1;
+    int _value = 2;
     public int Value
     {
         get => _value;

--- a/ClassIsland/Models/ComponentSettings/ClockComponentSettings.cs
+++ b/ClassIsland/Models/ComponentSettings/ClockComponentSettings.cs
@@ -16,4 +16,30 @@ public class ClockComponentSettings: ObservableRecipient
             OnPropertyChanged();
         }
     }
+
+    private bool _showRealTime = false;
+
+    public bool ShowRealTime
+    {
+        get => _showRealTime;
+        set
+        {
+            if (value == _showRealTime) return;
+            _showRealTime = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private bool _flashTimeSeparator = true;
+
+    public bool FlashTimeSeparator
+    {
+        get => _flashTimeSeparator;
+        set
+        {
+            if (value == _flashTimeSeparator) return;
+            _flashTimeSeparator = value;
+            OnPropertyChanged();
+        }
+    }
 }

--- a/ClassIsland/Models/Rules/WindowStatusRuleSettings.cs
+++ b/ClassIsland/Models/Rules/WindowStatusRuleSettings.cs
@@ -12,8 +12,8 @@ public class WindowStatusRuleSettings : ObservableRecipient
     /// <value>
     /// 0 - 正常
     /// 1 - 最大化
-    /// 2 - 全屏
-    /// 3 - 最小化
+    /// 2 - 最小化
+    /// 3 - 全屏
     /// </value>
     public int State
     {

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -2032,6 +2032,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         }
     }
 
+    [JsonIgnore]
     public double DebugTimeSpeed
     {
         get => _debugTimeSpeed;

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -194,6 +194,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private int _autoBackupIntervalDays = 7;
     private bool _useRawInput = false;
     private bool _isMouseInFadingEnabled = true;
+    private bool _isMouseInFadingReversed = false;
     private double _touchInFadingDurationMs = 0;
     private bool _isCompatibleWindowTransparentEnabled = false;
     private double _mainWindowSecondaryFontSize = 14;
@@ -1683,6 +1684,17 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         {
             if (value == _isMouseInFadingEnabled) return;
             _isMouseInFadingEnabled = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsMouseInFadingReversed
+    {
+        get => _isMouseInFadingReversed;
+        set
+        {
+            if (value == _isMouseInFadingReversed) return;
+            _isMouseInFadingReversed = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Services/ActionService.cs
+++ b/ClassIsland/Services/ActionService.cs
@@ -32,6 +32,7 @@ public class ActionService(ILogger<ActionService> Logger) : IActionService
     {
         foreach (var action in actionset.Actions)
             action.Exception = null;
+        actionset.IsOn = true;
         Task.Run(() =>
         {
             foreach (var action in actionset.Actions)
@@ -45,6 +46,7 @@ public class ActionService(ILogger<ActionService> Logger) : IActionService
     {
         foreach (var action in actionset.Actions)
             action.Exception = null;
+        actionset.IsOn = false;
         Task.Run(() =>
         {
             foreach (var action in actionset.Actions)

--- a/ClassIsland/Services/AutomationService.cs
+++ b/ClassIsland/Services/AutomationService.cs
@@ -50,7 +50,7 @@ public class AutomationService : ObservableRecipient, IAutomationService
             if (!a.Actionset.IsEnabled) continue;
             if (!a.Actionset.IsOn)
             {
-                if (WindowRuleService.IsForegroundWindowClassIsland()) continue;
+                //if (WindowRuleService.IsForegroundWindowClassIsland()) continue;
                 if (!RulesetService.IsRulesetSatisfied(a.Ruleset)) continue;
                 ActionService.Invoke(a.Actionset);
                 a.Actionset.IsOn = true;

--- a/ClassIsland/Services/ExactTimeService.cs
+++ b/ClassIsland/Services/ExactTimeService.cs
@@ -63,9 +63,11 @@ public class ExactTimeService : ObservableRecipient, IExactTimeService
             Logger.LogError(ex, "初始化NtpClient失败。");
             SyncStatusMessage = ex.Message;
         }
-        Sync();
-        UpdateTimerStatus();
-        SystemEvents.TimeChanged += SystemEventsOnTimeChanged;
+        Task.Run(() => {
+            Sync();
+            UpdateTimerStatus();
+            SystemEvents.TimeChanged += SystemEventsOnTimeChanged;
+        });
 
         if (SettingsService.Settings.IsTimeAutoAdjustEnabled)
         {

--- a/ClassIsland/Services/IpcService.cs
+++ b/ClassIsland/Services/IpcService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Models.Ipc;
@@ -43,10 +44,13 @@ public class IpcService : IIpcService
 
     public async Task BroadcastNotificationAsync(string id)
     {
-        foreach (var i in ConnectedPeers)
-        {
-            await i.JsonPeerProxy.NotifyAsync(id);
-        }
+        try {
+            foreach (var i in ConnectedPeers)
+            {
+                try { await i.JsonPeerProxy.NotifyAsync(id); }
+                catch (NullReferenceException e) { throw new NullReferenceException(e.Message, e); }
+            }}
+        catch (NullReferenceException e) { throw new NullReferenceException(e.Message, e); }
     }
 
     public async Task BroadcastNotificationAsync<T>(string id, T obj) where T : class

--- a/ClassIsland/Services/RulesetService.cs
+++ b/ClassIsland/Services/RulesetService.cs
@@ -20,8 +20,7 @@ public class RulesetService : IRulesetService
     public RulesetService(ILogger<RulesetService> logger)
     {
         Logger = logger;
-
-        
+        NotifyStatusChanged();
     }
 
     

--- a/ClassIsland/Services/RulesetService.cs
+++ b/ClassIsland/Services/RulesetService.cs
@@ -28,44 +28,54 @@ public class RulesetService : IRulesetService
     public event EventHandler? ForegroundWindowChanged;
 
     public event EventHandler? StatusUpdated;
-    private bool IsRulesetGroupSatisfied(RuleGroup ruleset)
+
+    private bool? IsRuleSatisfied(Rule i)
+    {
+        if (i.Id == string.Empty)
+            return null;
+
+        if (!IRulesetService.Rules.TryGetValue(i.Id, out var rule))
+        {
+            Logger.LogWarning("找不到规则 {} 的注册信息，已默认其结果为 false.", i.Id);
+            return false;
+        }
+
+        object? settings = null;
+        var settingsType = rule.SettingsType;
+        if (settingsType != null)
+        {
+            settings = i.Settings ?? Activator.CreateInstance(settingsType);
+            if (settings is JsonElement json)
+            {
+                settings = json.Deserialize(settingsType);
+            }
+        }
+        if (rule.Handle != null)
+        {
+            return rule.Handle(settings);
+        }
+        else
+        {
+            Logger.LogWarning("规则 {} 的处理程序没有注册，已默认其结果为 false.", rule.Id);
+            return false;
+        }
+
+    }
+
+    private bool? IsRulesetGroupSatisfied(RuleGroup ruleset)
     {
         var rulesetSatisfied = ruleset.Mode == RulesetLogicalMode.And;
-        if (ruleset.Rules.Count <= 0)
+        if (ruleset.Rules.Where(r => r.Id != "").ToList().Count <= 0)
         {
-            return false;
+            return null;
         }
         foreach (var i in ruleset.Rules)
         {
-            if (i.Id == string.Empty) continue;
-            if (!IRulesetService.Rules.TryGetValue(i.Id, out var rule))
-            {
-                Logger.LogWarning("找不到规则 {} 的注册信息。", i.Id);
+            bool? res = IsRuleSatisfied(i);
+            if (res == null)
                 continue;
-            }
 
-            bool result;
-            object? settings = null;
-            var settingsType = rule.SettingsType;
-            if (settingsType != null)
-            {
-                settings = i.Settings ?? Activator.CreateInstance(settingsType);
-                if (settings is JsonElement json)
-                {
-                    settings = json.Deserialize(settingsType);
-                }
-            }
-            if (rule.Handle != null)
-            {
-                result = rule.Handle(settings);
-            }
-            else
-            {
-                result = false;
-                Logger.LogWarning("规则 {} 的处理程序没有注册，已默认其结果为 false.", rule.Id);
-            }
-            
-
+            bool result = (bool)res;
             result ^= i.IsReversed;
             if (!result && ruleset.Mode == RulesetLogicalMode.And)
             {
@@ -91,7 +101,11 @@ public class RulesetService : IRulesetService
         }
         foreach (var group in ruleset.Groups.Where(x => x.IsEnabled))
         {
-            var result = IsRulesetGroupSatisfied(group);
+            bool? res = IsRulesetGroupSatisfied(group);
+            if (res == null)
+                continue;
+
+            bool result = (bool)res;
             result ^= group.IsReversed;
             if (!result && ruleset.Mode == RulesetLogicalMode.And)
             {

--- a/ClassIsland/Services/WindowRuleService.cs
+++ b/ClassIsland/Services/WindowRuleService.cs
@@ -89,7 +89,7 @@ public class WindowRuleService : IWindowRuleService
         return s.State switch
         {
             0 => !(fullscreen || maximize || minimize),
-            1 => maximize,
+            1 => maximize && !fullscreen,
             2 => minimize,
             3 => fullscreen,
             _ => false

--- a/ClassIsland/ViewModels/MainViewModel.cs
+++ b/ClassIsland/ViewModels/MainViewModel.cs
@@ -19,6 +19,7 @@ public class MainViewModel : ObservableRecipient
     private object? _currentOverlayElement;
     private bool _isOverlayOpened = false;
     private bool _isMouseIn = false;
+    private bool _isMainWindowFaded = false;
     private bool _isForegroundFullscreen = false;
     private bool _isForegroundMaxWindow = false;
     private string _currentProfilePath = "Profile.json";
@@ -96,6 +97,17 @@ public class MainViewModel : ObservableRecipient
         {
             if (value == _isMouseIn) return;
             _isMouseIn = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsMainWindowFaded
+    {
+        get => _isMainWindowFaded;
+        set
+        {
+            if (value == _isMainWindowFaded) return;
+            _isMainWindowFaded = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml
@@ -1242,8 +1242,8 @@
                                             <DataTemplate>
                                                 <Grid HorizontalAlignment="Stretch">
                                                     <TextBlock Text="{Binding Value.Name}" HorizontalAlignment="Left"/>
-                                                    <materialDesign:PackIcon Kind="Lock" HorizontalAlignment="Right"
-                                                                             ToolTip="已锁定活动的时间表。"
+                                                    <materialDesign:PackIcon Kind="MapMarkerRadiusOutline" HorizontalAlignment="Right"
+                                                                             ToolTip="此时间表正在活动。"
                                                                              Visibility="{Binding Value.IsActivated, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                                 </Grid>
                                             </DataTemplate>
@@ -1307,13 +1307,13 @@
                                     <ToolBar Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="3" ToolBarTray.IsLocked="True" 
                                              IsEnabled="{Binding ManagementService.Policy.DisableProfileTimeLayoutEditing, Converter={StaticResource InvertBooleanConverter}, RelativeSource={RelativeSource FindAncestor, AncestorType=local:ProfileSettingsWindow}}">
                                         <!--<TextBlock Text="{Binding Layouts}"/>-->
-                                        <Button Click="ButtonAddClassTime_OnClick" ToolTip="添加上课时间点。" IsEnabled="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}">
+                                        <Button Click="ButtonAddClassTime_OnClick" ToolTip="添加上课时间点。">
                                             <controls1:IconText Kind="NotePlusOutline" Text="上课"/>
                                         </Button>
-                                        <Button Click="ButtonAddBreakTime_OnClick" ToolTip="添加课间休息时间点。" IsEnabled="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}">
+                                        <Button Click="ButtonAddBreakTime_OnClick" ToolTip="添加课间休息时间点。">
                                             <controls1:IconText Kind="ClockPlusOutline" Text="课间"/>
                                         </Button>
-                                        <Button Click="ButtonAddSeparator_OnClick" ToolTip="添加分割线。" IsEnabled="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}">
+                                        <Button Click="ButtonAddSeparator_OnClick" ToolTip="添加分割线。">
                                             <controls1:IconText Kind="ArrowSplitHorizontal" Text="分割线"/>
                                         </Button>
                                         <Separator/>
@@ -1325,14 +1325,13 @@
                                                             <Setter Property="IsEnabled" Value="False"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>
-                                                    <Setter Property="IsEnabled" Value="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}"/>
                                                 </Style>
                                             </Button.Style>
                                             <controls1:IconText Kind="Remove" Text="删除"/>
                                         </Button>
                                         <Button Click="ButtonRefreshTimeLayout_OnClick"
                                                 ToolTip="重新排序该时间表中的时间点。"
-                                                IsEnabled="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}">
+                                               >
                                             <controls1:IconText Kind="Refresh" Text="刷新"/>
                                         </Button>
                                         <!--<Button  Click="ButtonEditTimePoint_OnClick"
@@ -1361,8 +1360,7 @@
                                             <controls1:IconText Kind="InfoOutline" Text="时间表信息"/>
                                         </Button>
                                         <Button Click="ButtonDeleteTimeLayout_OnClick"
-                                                ToolTip="删除该时间表。"
-                                                IsEnabled="{Binding IsActivated, Converter={StaticResource BooleanToBooleanReConverter}}">
+                                                ToolTip="删除该时间表。">
                                             <controls1:IconText Kind="Delete" Text="删除时间表"/>
                                         </Button>
                                     </ToolBar>
@@ -1458,10 +1456,7 @@
                                                                           IsPanningModeEnabled="True">
                                                 <!-- 回应我吧，爱莉希雅 -->
                                                 <controls:TimeLineListControl.IsReadOnly>
-                                                    <MultiBinding Converter="{StaticResource BooleanOrExpressionMultiConverter}" Mode="OneWay">
-                                                        <Binding Path="IsActivated" Mode="OneWay"/>
-                                                        <Binding Path="ManagementService.Policy.DisableProfileTimeLayoutEditing" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=local:ProfileSettingsWindow}" Mode="OneWay"/>
-                                                    </MultiBinding>
+                                                    <Binding Path="ManagementService.Policy.DisableProfileTimeLayoutEditing" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=local:ProfileSettingsWindow}" Mode="OneWay"/>
                                                 </controls:TimeLineListControl.IsReadOnly>
                                             </controls:TimeLineListControl>
                                         </TabItem>
@@ -1571,15 +1566,6 @@
                                         <materialDesign:PackIcon Kind="TimelineOutline" ToolTip="时间线视图"/>
                                     </ListBox>
 
-                                    <!-- 编辑警告 -->
-                                    <materialDesign:ColorZone Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
-                                                              Mode="PrimaryLight"
-                                                              Background="LightYellow"
-                                                              Visibility="{Binding IsActivated, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                        <controls1:IconText Kind="Warning" Text="当前时间表处于活动状态，部分设置无法编辑。"
-                                                           Margin="4"/>
-                                    </materialDesign:ColorZone>
-
                                     <GridSplitter Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" Grid.RowSpan="2"/>
 
                                     <!-- 时间点编辑 -->
@@ -1587,7 +1573,7 @@
                                         <StackPanel Margin="16" 
                                                     IsEnabled="{Binding ManagementService.Policy.DisableProfileTimeLayoutEditing, Converter={StaticResource InvertBooleanConverter}}"
                                                     DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:ProfileSettingsWindow}}">
-                                            <StackPanel IsEnabled="{Binding SelectedItem.Value.IsActivated, ElementName=ListViewTimeLayouts, Converter={StaticResource InvertBooleanConverter}}">
+                                            <StackPanel>
                                                 <TextBlock Text="编辑时间点"
                                                            Style="{StaticResource MaterialDesignHeadline5TextBlock}" />
                                                 <!--<TextBlock Text="{Binding}"/>-->
@@ -1662,7 +1648,8 @@
                                                 </ComboBox>
                                                 <WrapPanel Orientation="Horizontal" Margin="0 4 0 0">
                                                     <Button Style="{StaticResource MaterialDesignFlatButton}"
-                                                            Click="ButtonOverwriteClasses_OnClick">
+                                                            Click="ButtonOverwriteClasses_OnClick"
+                                                            IsEnabled="{Binding ManagementService.Policy.DisableProfileClassPlanEditing, Converter={StaticResource InvertBooleanConverter}}">
                                                         <controls1:IconText Kind="Upload" Text="覆盖现有课程"/>
                                                     </Button>
                                                 </WrapPanel>

--- a/ClassIsland/Views/ProfileSettingsWindow.xaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.xaml
@@ -1682,7 +1682,7 @@
                                                 </StackPanel.Style>
                                                 <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                     Margin="0 12 0 0"
-                                                    Text="{Binding ViewModel.SelectedTimePoint.BreakName}"
+                                                    Text="{Binding ViewModel.SelectedTimePoint.BreakName, UpdateSourceTrigger=PropertyChanged}"
                                                     materialDesign:HintAssist.Hint="课间名称" />
                                             </StackPanel>
                                             <Separator Margin="0 20 0 8" />

--- a/ClassIsland/Views/SettingPages/AutomationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/AutomationSettingsPage.xaml
@@ -25,14 +25,10 @@
                      d:DataContext="{d:DesignInstance local:AutomationSettingsPage}"
                      Title="AutomationSettingsPage">
     <ci:SettingsPageBase.CommandBindings>
-        <CommandBinding Command="{x:Static local:AutomationSettingsPage.RemoveCommand}"
-                        Executed="CommandRemove_OnExecuted" />
-        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DuplicateCommand}"
-                        Executed="CommandDuplicate_OnExecuted" />
-        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DebugInvokeActionCommand}"
-                        Executed="CommandDebugInvokeAction_OnExecuted" />
-        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DebugInvokeRevertActionCommand}"
-                        Executed="CommandDebugInvokeRevertAction_OnExecuted" />
+        <CommandBinding Command="{x:Static local:AutomationSettingsPage.RemoveCommand}" Executed="CommandRemove_OnExecuted" />
+        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DuplicateCommand}" Executed="CommandDuplicate_OnExecuted" />
+        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DebugInvokeActionCommand}" Executed="CommandDebugInvokeAction_OnExecuted" />
+        <CommandBinding Command="{x:Static local:AutomationSettingsPage.DebugInvokeRevertActionCommand}" Executed="CommandDebugInvokeRevertAction_OnExecuted" />
     </ci:SettingsPageBase.CommandBindings>
 
 
@@ -70,326 +66,353 @@
         </StackPanel>
     </ci:SettingsPageBase.Resources>
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition/>
-        </Grid.RowDefinitions>
-        <materialDesign:ColorZone Grid.Row="0" Background="#10FF0000">
-            <Grid>
-                <DockPanel Margin="8 4">
-                    <materialDesign:PackIcon Kind="ErrorOutline"
-                                             Height="20" Width="20"/>
-                    <TextBlock TextWrapping="Wrap"
-                               VerticalAlignment="Center"
-                               Margin="4 0 0 0" >
-                        <Run Text="你正在使用自动化的早期版本，此版本仅供尝鲜使用，不建议用于生产环境。此功能在未来可能会产生较大的变动，并且">
-                        </Run><Bold>可能无法保证配置文件完全向下兼容。
-                        </Bold><Run>欢迎在
-                        </Run><ci:NavHyperlink CommandParameter="https://github.com/ClassIsland/ClassIsland/issues/119">ClassIsland/ClassIsland#119
-                        </ci:NavHyperlink><Run>讨论此功能。</Run>
-                    </TextBlock>
-                </DockPanel>
-            </Grid>
-        </materialDesign:ColorZone>
-
-        <controls1:ListDetailView Grid.Row="1"
-                                  ShowTitleWhenNotCompressed="True"
-                                  IsPanelOpened="{Binding ViewModel.IsPanelOpened, Mode=TwoWay}"
-                                  Margin="6 6 0 0"
-                                  Visibility="{Binding SettingsService.Settings.IsAutomationWarningVisible, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
-            <controls1:ListDetailView.LeftContent>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <!--自动化实验性警告--> 
+            <materialDesign:ColorZone Background="#10FF0000" Panel.ZIndex="1" Margin="0 0 0 0">
                 <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    
-                    <!-- 自动化开关 -->
-                    <ci:SettingsCard IconGlyph="ScriptTextOutline"
-                                     Header="启用自动化"
-                                     IsOn="{Binding SettingsService.Settings.IsAutomationEnabled, Mode=TwoWay}"
-                                     Description="自动化是一种在自定义规则满足时作出行动的功能。"
-                                     Margin="6 12" />
-                    <Button HorizontalAlignment="Right"
-                            Content="{materialDesign:PackIcon HelpCircleOutline}"
-                            ToolTip="自动化帮助…"
-                            Margin="0 0 60 0"
-                            Command="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"
-                            CommandParameter="https://docs.classisland.tech/app/automatic"
-                            Style="{StaticResource MaterialDesignToolForegroundButton}" />
-
-                    <Grid Grid.Row="1">
-
-                        <!-- 添加自动化 -->
-                        <Button Style="{StaticResource MaterialDesignFlatButton}"
-                                Click="ButtonAdd_OnClick"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Bottom"
-                                Margin="6 6">
-                            <ci:IconText Kind="Add"
-                                         Text="添加自动化" />
-                        </Button>
-
-                        <!-- 自动化配置方案 -->
-                        <StackPanel Grid.Column="1"
-                                    Grid.Row="0"
-                                    Orientation="Horizontal"
-                                    HorizontalAlignment="Right"
+                    <DockPanel Margin="8 4">
+                        <materialDesign:PackIcon Kind="ErrorOutline"
+                                                    Height="20" Width="20"/>
+                        <TextBlock TextWrapping="Wrap"
                                     VerticalAlignment="Center"
-                                    Margin="0 0 4 0">
-                            <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}"
-                                      ItemsSource="{Binding AutomationService.Configs}"
-                                      MinWidth="150"
-                                      MaxWidth="300"
-                                      SelectedItem="{Binding SettingsService.Settings.CurrentAutomationConfig}"
-                                      materialDesign:HintAssist.Hint="配置方案" />
-                            <Button Content="{materialDesign:PackIcon Refresh}"
-                                    ToolTip="刷新配置方案"
-                                    VerticalAlignment="Center"
-                                    Margin="2 0"
-                                    Click="ButtonRefresh_OnClick"
-                                    Style="{StaticResource MaterialDesignToolForegroundButton}" />
-                            <Button Content="{materialDesign:PackIcon FileDocumentPlusOutline}"
-                                    ToolTip="新建配置方案…"
-                                    VerticalAlignment="Center"
-                                    Margin="2 0"
-                                    Click="ButtonCreateConfig_OnClick"
-                                    Style="{StaticResource MaterialDesignToolForegroundButton}" />
-                            <Button Content="{materialDesign:PackIcon FolderOpenOutline}"
-                                    ToolTip="打开配置文件夹…"
-                                    VerticalAlignment="Center"
-                                    Click="ButtonOpenConfigFolder_OnClick"
-                                    Margin="2 0"
-                                    Style="{StaticResource MaterialDesignToolForegroundButton}" />
-                        </StackPanel>
-                    </Grid>
-
-                    <!-- 左：自动化导航栏 -->
-                    <ScrollViewer Grid.Row="2">
-                        <ListBox ItemsSource="{Binding AutomationService.Automations}"
-                                 Style="{StaticResource MaterialDesignNavigationPrimaryListBox}"
-                                 SelectionChanged="ListBox_SelectionChanged"
-                                 SelectedItem="{Binding ViewModel.SelectedAutomation, Mode=TwoWay}"
-                                 HorizontalContentAlignment="Stretch"
-                                 PreviewMouseWheel="UIElement_OnPreviewMouseWheel"
-                                 dd:DragDrop.IsDragSource="True"
-                                 dd:DragDrop.IsDropTarget="True"
-                                 dd:DragDrop.DropTargetAdornerBrush="{DynamicResource PrimaryHueMidBrush}">
-                            <dd:DragDrop.EffectMoveAdornerTemplate>
-                                <DataTemplate>
-                                    <materialDesign:ColorZone Mode="PrimaryMid"
-                                                              Height="24"
-                                                              CornerRadius="12">
-                                        <ci:IconText Kind="ArrowUpDown"
-                                                     Text="排序"
-                                                     Margin="4 0"
-                                                     IconMargin="2"
-                                                     TextElement.FontWeight="Medium"
-                                                     VerticalAlignment="Center" />
-                                    </materialDesign:ColorZone>
-                                </DataTemplate>
-                            </dd:DragDrop.EffectMoveAdornerTemplate>
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <DockPanel HorizontalAlignment="Stretch">
-
-                                        <StackPanel Orientation="Horizontal"
-                                                    HorizontalAlignment="Right"
-                                                    DockPanel.Dock="Right">
-                                            <ToggleButton ToolTip="启用"
-                                                          IsChecked="{Binding Actionset.IsEnabled}" />
-                                            <Button Content="{materialDesign:PackIcon Kind=ContentCopy}"
-                                                    ToolTip="复制"
-                                                    Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                    Command="{x:Static local:AutomationSettingsPage.DuplicateCommand}"
-                                                    CommandParameter="{Binding}"
-                                                    Padding="15 0 10 0" />
-
-                                            <Button Content="{materialDesign:PackIcon Kind=Close}"
-                                                    ToolTip="删除"
-                                                    Style="{StaticResource MaterialDesignToolForegroundButton}"
-                                                    Command="{x:Static local:AutomationSettingsPage.RemoveCommand}"
-                                                    CommandParameter="{Binding}"
-                                                    Padding="5 0 5 0" />
-                                        </StackPanel>
-                                        <materialDesign:PackIcon Kind="ScriptTextOutline"
-                                                                 VerticalAlignment="Center"
-                                                                 HorizontalAlignment="Left"
-                                                                 DockPanel.Dock="Left"
-                                                                 Margin="3 2 0 0">
-                                            <materialDesign:PackIcon.Style>
-                                                <Style TargetType="materialDesign:PackIcon">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Actionset.Name}"
-                                                                     Value="">
-                                                            <Setter Property="Visibility"
-                                                                    Value="Visible" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                    <Setter Property="Visibility"
-                                                            Value="Collapsed" />
-                                                </Style>
-                                            </materialDesign:PackIcon.Style>
-                                        </materialDesign:PackIcon>
-                                        <TextBlock Text="{Binding Actionset.Name}"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   VerticalAlignment="Center"
-                                                   HorizontalAlignment="Left"
-                                                   DockPanel.Dock="Left"
-                                                   Margin="4 0 0 0" />
-                                    </DockPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </ScrollViewer>
+                                    Margin="4 0 0 0" >
+                                    <Run>你正在使用自动化的早期版本，此版本仅供尝鲜使用，不建议用于生产环境。此功能在未来可能会产生较大的变动，并且
+                                    </Run><Bold>可能无法保证配置文件完全向下兼容。
+                                    </Bold><Run>欢迎在
+                                    </Run><ci:NavHyperlink CommandParameter="https://github.com/ClassIsland/ClassIsland/issues/119">ClassIsland/ClassIsland#119
+                                    </ci:NavHyperlink><Run>讨论此功能。</Run>
+                        </TextBlock>
+                    </DockPanel>
                 </Grid>
-            </controls1:ListDetailView.LeftContent>
+            </materialDesign:ColorZone>
 
-            <!-- 右上：自动化重命名 -->
-            <controls1:ListDetailView.TitleElement>
-                <Grid>
-                    <Grid.Style>
-                        <Style TargetType="Grid">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding ViewModel.SelectedAutomation}"
-                                             Value="{x:Null}">
-                                    <Setter Property="Visibility"
-                                            Value="Collapsed" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Grid.Style>
-                    <TextBox materialDesign:HintAssist.Hint="名称"
-                             materialDesign:HintAssist.IsFloating="True"
-                             DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}"
-                             Text="{Binding Actionset.Name, UpdateSourceTrigger=PropertyChanged}"
-                             FontWeight="Medium"
-                             FontSize="15"
-                             VerticalAlignment="Center"
-                             Margin="0 12 12 12"
-                             MinWidth="200"
-                             HorizontalAlignment="Left" />
+            <!-- 自动化编辑 -->
+            <controls1:ListDetailView Grid.Row="1"
+                                      ShowTitleWhenNotCompressed="True"
+                                      IsPanelOpened="{Binding ViewModel.IsPanelOpened, Mode=TwoWay}"
+                                      Margin="4 0 0 0"
+                                      Visibility="{Binding SettingsService.Settings.IsAutomationWarningVisible, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                <controls1:ListDetailView.LeftContent>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
 
-                    <StackPanel Orientation="Horizontal"
-                                HorizontalAlignment="Right"
-                                Grid.Column="2"
-                                DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}"
-                                Visibility="{Binding SettingsService.Settings.IsDebugEnabled, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:AutomationSettingsPage}}">
-                        <Button Content="(Debug)触发"
-                                Style="{StaticResource MaterialDesignFlatSecondaryButton}"
-                                Command="{x:Static local:AutomationSettingsPage.DebugInvokeActionCommand}"
-                                CommandParameter="{Binding}"
-                                Padding="12 0" />
+                        <!-- 自动化开关 -->
+                        <ci:SettingsCard IconGlyph="ScriptTextOutline"
+                                         Header="启用自动化"
+                                         Description="自动化是一种在自定义规则满足时做出行动的功能。"
+                                         Margin="6 12">
+                            <ci:SettingsCard.Switcher>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Content="{materialDesign:PackIcon HelpCircleOutline}"
+                                            ToolTip="自动化帮助文档…"
+                                            Command="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"
+                                            CommandParameter="https://docs.classisland.tech/app/automation"
+                                            Style="{StaticResource MaterialDesignToolForegroundButton}"/>
+                                    <ToggleButton IsChecked="{Binding SettingsService.Settings.IsAutomationEnabled, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </ci:SettingsCard.Switcher>
+                        </ci:SettingsCard>
 
-                        <Button Content="(Debug)恢复"
-                                Style="{StaticResource MaterialDesignFlatSecondaryButton}"
-                                Command="{x:Static local:AutomationSettingsPage.DebugInvokeRevertActionCommand}"
-                                CommandParameter="{Binding}"
-                                Padding="12 0" />
-                    </StackPanel>
-                </Grid>
-            </controls1:ListDetailView.TitleElement>
+                        <Grid Grid.Row="1">
 
-            <controls1:ListDetailView.RightContent>
-                <Grid>
-                    <ScrollViewer>
-                        <Grid>
-                            <Grid.Style>
-                                <Style TargetType="Grid">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding ViewModel.SelectedAutomation}" Value="{x:Null}">
-                                            <Setter Property="Visibility" Value="Collapsed" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Grid.Style>
-                            <StackPanel DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}"
-                                        Margin="0 0 6 0">
-                                <StackPanel.Style>
-                                    <Style TargetType="StackPanel">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Actionset.IsEnabled}"
-                                                         Value="False">
-                                                <Setter Property="Opacity"
-                                                        Value="0.56" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </StackPanel.Style>
+                            <!-- 添加自动化 -->
+                            <Button Style="{StaticResource MaterialDesignFlatButton}"
+                                    Click="ButtonAdd_OnClick"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Bottom"
+                                    Margin="6 6">
+                                <ci:IconText Kind="Add"
+                                             Text="添加自动化" />
+                            </Button>
 
-                                <!--规则编辑-->
-                                <GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
-                                          Margin="2 2 2 10">
-                                    <GroupBox.HeaderTemplate>
-                                        <DataTemplate>
-                                            <ci:IconText Text="当以下规则满足时"
-                                                         Kind="TagMultipleOutline"/>
-                                        </DataTemplate>
-                                    </GroupBox.HeaderTemplate>
-                                    <ruleset:RulesetControl Ruleset="{Binding Ruleset}"
-                                                            ShowTitle="False" 
-                                                            />
-                                </GroupBox>
-
-                                <!--行动编辑-->
-                                <GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
-                                          Margin="2 2 2 10">
-                                    <GroupBox.HeaderTemplate>
-                                        <DataTemplate>
-                                            <ci:IconText Text="触发行动"
-                                                         Kind="Airplane"/>
-                                        </DataTemplate>
-                                    </GroupBox.HeaderTemplate>
-                                    <action:ActionControl Actionset="{Binding Actionset}" />
-                                </GroupBox>
-
-                                <!--TODO: 恢复行动编辑-->
-                                <!--<GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
-                                          Margin="2">
-                                    <GroupBox.HeaderTemplate>
-                                        <DataTemplate>
-                                            <ci:IconText Text="当规则不再满足时，恢复行动。"
-                                                         Kind="AirplaneLanding" />
-                                        </DataTemplate>
-                                    </GroupBox.HeaderTemplate>
-                                    <TextBlock Text="Coming S∞n" />
-                                </GroupBox>-->
-
-                                <ci:IconText Text="当规则不再满足时，将自动恢复行动。"
-                                             Kind="AirplaneLanding"
-                                             Margin="10 2 0 10"/>
+                            <!-- 自动化配置方案 -->
+                            <StackPanel Grid.Column="1"
+                                        Grid.Row="0"
+                                        Orientation="Horizontal"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center"
+                                        Margin="0 0 4 0">
+                                <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                                          ItemsSource="{Binding AutomationService.Configs}"
+                                          MinWidth="150"
+                                          MaxWidth="300"
+                                          SelectedItem="{Binding SettingsService.Settings.CurrentAutomationConfig}"
+                                          materialDesign:HintAssist.Hint="配置方案" />
+                                <Button Content="{materialDesign:PackIcon Refresh}"
+                                        ToolTip="刷新配置方案"
+                                        VerticalAlignment="Center"
+                                        Margin="2 0"
+                                        Click="ButtonRefresh_OnClick"
+                                        Style="{StaticResource MaterialDesignToolForegroundButton}" />
+                                <Button Content="{materialDesign:PackIcon FileDocumentPlusOutline}"
+                                        ToolTip="新建配置方案…"
+                                        VerticalAlignment="Center"
+                                        Margin="2 0"
+                                        Click="ButtonCreateConfig_OnClick"
+                                        Style="{StaticResource MaterialDesignToolForegroundButton}" />
+                                <Button Content="{materialDesign:PackIcon FolderOpenOutline}"
+                                        ToolTip="打开配置文件夹…"
+                                        VerticalAlignment="Center"
+                                        Click="ButtonOpenConfigFolder_OnClick"
+                                        Margin="2 0"
+                                        Style="{StaticResource MaterialDesignToolForegroundButton}" />
                             </StackPanel>
                         </Grid>
-                    </ScrollViewer>
 
-                    <!-- 右：未选择自动化时，显示占位符 -->
-                    <StackPanel VerticalAlignment="Center"
-                                HorizontalAlignment="Center">
-                        <StackPanel.Style>
-                            <Style TargetType="StackPanel">
+                        <!-- 左：自动化导航栏 -->
+                        <ScrollViewer Grid.Row="2">
+                            <ListBox ItemsSource="{Binding AutomationService.Automations}"
+                                     Style="{StaticResource MaterialDesignNavigationPrimaryListBox}"
+                                     SelectionChanged="ListBox_SelectionChanged"
+                                     SelectedItem="{Binding ViewModel.SelectedAutomation, Mode=TwoWay}"
+                                     HorizontalContentAlignment="Stretch"
+                                     PreviewMouseWheel="UIElement_OnPreviewMouseWheel"
+                                     dd:DragDrop.IsDragSource="True"
+                                     dd:DragDrop.IsDropTarget="True"
+                                     dd:DragDrop.DropTargetAdornerBrush="{DynamicResource PrimaryHueMidBrush}">
+                                <dd:DragDrop.EffectMoveAdornerTemplate>
+                                    <DataTemplate>
+                                        <materialDesign:ColorZone Mode="PrimaryMid"
+                                                                  Height="24"
+                                                                  CornerRadius="12">
+                                            <ci:IconText Kind="ArrowUpDown"
+                                                         Text="排序"
+                                                         Margin="4 0"
+                                                         IconMargin="2"
+                                                         TextElement.FontWeight="Medium"
+                                                         VerticalAlignment="Center" />
+                                        </materialDesign:ColorZone>
+                                    </DataTemplate>
+                                </dd:DragDrop.EffectMoveAdornerTemplate>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <DockPanel HorizontalAlignment="Stretch">
+
+                                            <StackPanel Orientation="Horizontal"
+                                                        HorizontalAlignment="Right"
+                                                        DockPanel.Dock="Right">
+                                                <ToggleButton ToolTip="启用"
+                                                              IsChecked="{Binding Actionset.IsEnabled}" />
+                                                <Button Content="{materialDesign:PackIcon Kind=ContentCopy}"
+                                                        ToolTip="复制"
+                                                        Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                        Command="{x:Static local:AutomationSettingsPage.DuplicateCommand}"
+                                                        CommandParameter="{Binding}"
+                                                        Padding="15 0 10 0" />
+
+                                                <Button Content="{materialDesign:PackIcon Kind=Close}"
+                                                        ToolTip="删除"
+                                                        Style="{StaticResource MaterialDesignToolForegroundButton}"
+                                                        Command="{x:Static local:AutomationSettingsPage.RemoveCommand}"
+                                                        CommandParameter="{Binding}"
+                                                        Padding="5 0 5 0" />
+                                            </StackPanel>
+                                            <materialDesign:PackIcon Kind="ScriptTextOutline"
+                                                                     VerticalAlignment="Center"
+                                                                     HorizontalAlignment="Left"
+                                                                     DockPanel.Dock="Left"
+                                                                     Margin="3 2 0 0">
+                                                <materialDesign:PackIcon.Style>
+                                                    <Style TargetType="materialDesign:PackIcon">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Actionset.Name}"
+                                                                         Value="">
+                                                                <Setter Property="Visibility"
+                                                                        Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                        <Setter Property="Visibility"
+                                                                Value="Collapsed" />
+                                                    </Style>
+                                                </materialDesign:PackIcon.Style>
+                                            </materialDesign:PackIcon>
+                                            <TextBlock Text="{Binding Actionset.Name}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       VerticalAlignment="Center"
+                                                       HorizontalAlignment="Left"
+                                                       DockPanel.Dock="Left"
+                                                       Margin="4 0 0 0" />
+                                        </DockPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </ScrollViewer>
+                    </Grid>
+                </controls1:ListDetailView.LeftContent>
+
+                <!-- 右上：自动化重命名 -->
+                <controls1:ListDetailView.TitleElement>
+                    <Grid>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding ViewModel.SelectedAutomation}"
                                                  Value="{x:Null}">
                                         <Setter Property="Visibility"
-                                                Value="Visible" />
+                                                Value="Collapsed" />
                                     </DataTrigger>
                                 </Style.Triggers>
-                                <Setter Property="Visibility"
-                                        Value="Collapsed" />
                             </Style>
-                        </StackPanel.Style>
-                        <Image Source="/Assets/HoYoStickers/光辉矢愿_瞄准.png"
-                               Width="72"
-                               Height="72"
-                               ToolTip="光辉矢愿_瞄准" />
-                        <TextBlock Text="在左侧选择或添加一个自动化，然后在此处进行设置。"
-                                   TextWrapping="Wrap"
-                                   Margin="0 4 0 0" />
-                    </StackPanel>
-                </Grid>
-            </controls1:ListDetailView.RightContent>
-        </controls1:ListDetailView>
+                        </Grid.Style>
+                        <TextBox materialDesign:HintAssist.Hint="名称"
+                                 materialDesign:HintAssist.IsFloating="True"
+                                 DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}"
+                                 Text="{Binding Actionset.Name, UpdateSourceTrigger=PropertyChanged}"
+                                 FontWeight="Medium"
+                                 FontSize="15"
+                                 VerticalAlignment="Center"
+                                 Margin="0 12 12 12"
+                                 MinWidth="200"
+                                 HorizontalAlignment="Left" />
+
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Right"
+                                    Grid.Column="2"
+                                    DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}">
+                            <Button Command="{x:Static local:AutomationSettingsPage.DebugInvokeActionCommand}"
+                                    CommandParameter="{Binding Actionset}"
+                                    Padding="12 0">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatButton}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Actionset.IsOn}" Value="True">
+                                                <Setter Property="Opacity" Value="0.56" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                                <ci:IconText Kind="MotionPlayOutline" Text="触发" />
+                            </Button>
+
+                            <Button Command="{x:Static local:AutomationSettingsPage.DebugInvokeRevertActionCommand}"
+                                    CommandParameter="{Binding Actionset}"
+                                    Padding="12 0"
+                                    Margin="0 0 8 0">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignFlatButton}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Actionset.IsOn}" Value="False">
+                                                <Setter Property="Opacity" Value="0.56" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                                <ci:IconText Kind="UndoVariant" Text="恢复" />
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                </controls1:ListDetailView.TitleElement>
+
+                <controls1:ListDetailView.RightContent>
+                    <Grid>
+                        <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                            <Grid>
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ViewModel.SelectedAutomation}"
+                                                         Value="{x:Null}">
+                                                <Setter Property="Visibility"
+                                                        Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                <StackPanel DataContext="{Binding ViewModel.SelectedAutomation, Mode=OneWay}"
+                                            Margin="0 0 6 0">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Actionset.IsEnabled}"
+                                                             Value="False">
+                                                    <Setter Property="Opacity"
+                                                            Value="0.56" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+
+                                    <!--规则编辑-->
+                                    <GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
+                                              Margin="2 2 2 10">
+                                        <GroupBox.HeaderTemplate>
+                                            <DataTemplate>
+                                                <ci:IconText Text="当以下规则满足时"
+                                                             Kind="TagMultipleOutline" />
+                                            </DataTemplate>
+                                        </GroupBox.HeaderTemplate>
+                                        <ruleset:RulesetControl Ruleset="{Binding Ruleset}"
+                                                                ShowTitle="False" />
+                                    </GroupBox>
+
+                                    <!--行动编辑-->
+                                    <GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
+                                              Margin="2 2 2 10">
+                                        <GroupBox.HeaderTemplate>
+                                            <DataTemplate>
+                                                <ci:IconText Text="触发行动"
+                                                             Kind="Airplane" />
+                                            </DataTemplate>
+                                        </GroupBox.HeaderTemplate>
+                                        <action:ActionControl Actionset="{Binding Actionset}" />
+                                    </GroupBox>
+
+                                    <!--TODO: 恢复行动编辑-->
+                                    <!--<GroupBox Style="{StaticResource MaterialDesignCardGroupBox}"
+                                                          Margin="2">
+                                                    <GroupBox.HeaderTemplate>
+                                                        <DataTemplate>
+                                                            <ci:IconText Text="当规则不再满足时，恢复行动。"
+                                                                         Kind="AirplaneLanding" />
+                                                        </DataTemplate>
+                                                    </GroupBox.HeaderTemplate>
+                                                    <TextBlock Text="Coming S∞n" />
+                                                </GroupBox>-->
+
+                                    <ci:IconText Text="当规则不再满足时，将自动恢复行动。"
+                                                 Kind="AirplaneLanding"
+                                                 Margin="10 2 0 10" />
+                                </StackPanel>
+                            </Grid>
+                        </ScrollViewer>
+
+                        <!-- 右：未选择自动化时，显示占位符 -->
+                        <StackPanel VerticalAlignment="Center"
+                                    HorizontalAlignment="Center">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ViewModel.SelectedAutomation}"
+                                                     Value="{x:Null}">
+                                            <Setter Property="Visibility"
+                                                    Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="Visibility"
+                                            Value="Collapsed" />
+                                </Style>
+                            </StackPanel.Style>
+                            <Image Source="/Assets/HoYoStickers/光辉矢愿_瞄准.png"
+                                   Width="72"
+                                   Height="72"
+                                   ToolTip="光辉矢愿_瞄准" />
+                            <TextBlock Text="在左侧选择或添加一个自动化，然后在此处进行设置。"
+                                       TextWrapping="Wrap"
+                                       Margin="0 4 0 0" />
+                        </StackPanel>
+                    </Grid>
+                </controls1:ListDetailView.RightContent>
+                </controls1:ListDetailView>
+        </Grid>
 
         <!-- 自动化使用前须知 -->
         <Border Background="{DynamicResource MaterialDesignPaper}"
@@ -426,22 +449,22 @@
                                TextAlignment="Center"
                                Margin="0 8 0 0"
                                Style="{StaticResource MaterialDesignHeadline5TextBlock}" />
-                    
+
                     <TextBlock Margin="0 10 0 0"
                                TextAlignment="Center"
                                HorizontalAlignment="Center"
                                TextWrapping="Wrap">
-                        　欢迎使用自动化！<LineBreak />
-                        自动化是 ClassIsland 1.6 (Himeko) 的新增功能，旨在<LineBreak />
-                        　提供简单快捷的自动操作。
+                        　    欢迎使用自动化！<LineBreak />
+                            自动化是 ClassIsland 1.6 (Himeko) 的新增功能，旨在<LineBreak />
+                        　    提供简单快捷的自动操作。
                     </TextBlock>
 
                     <Button HorizontalAlignment="Center"
                             Margin="0 6 0 0"
                             Command="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"
-                            CommandParameter="https://docs.classisland.tech/app/automatic"
+                            CommandParameter="https://docs.classisland.tech/app/automation"
                             Style="{StaticResource MaterialDesignFlatSecondaryButton}"
-                            ToolTip="docs.classisland.tech/app/automatic"
+                            ToolTip="docs.classisland.tech/app/automation"
                             ToolTipService.Placement="Right">
                         <ci:IconText Kind="ExternalLink"
                                      Text="阅读自动化帮助" />
@@ -453,14 +476,14 @@
                         <StackPanel>
                             <ci:IconText Kind="Warning"
                                          Text="警告"
-                                                     Margin="0 0 0 4"
-                                                     HorizontalAlignment="Center" />
+                                         Margin="0 0 0 4"
+                                         HorizontalAlignment="Center" />
                             <TextBlock TextAlignment="Center"
                                        HorizontalAlignment="Center"
                                        TextWrapping="Wrap">
-                                自动化允许自动修改 ClassIsland 的各项设置，并调用<LineBreak />
-                                　外部程序，可能有一定安全风险。<LineBreak />
-                                　不当的自动化编写可能对正常教学造成影响，请勿滥用。
+                                    自动化允许自动修改 ClassIsland 的各项设置，并调用<LineBreak />
+                                　    外部程序，可能有一定安全风险。<LineBreak />
+                                　    不当的自动化编写可能对正常教学造成影响，请勿滥用。
                             </TextBlock>
                         </StackPanel>
                     </Border>

--- a/ClassIsland/Views/SettingPages/AutomationSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/AutomationSettingsPage.xaml.cs
@@ -14,6 +14,7 @@ using ClassIsland.Core.Models;
 using System.Windows.Controls;
 using System.Diagnostics;
 using System.IO;
+using ClassIsland.Core.Models.Action;
 namespace ClassIsland.Views.SettingPages;
 
 /// <summary>
@@ -67,16 +68,16 @@ public partial class AutomationSettingsPage
 
     private void CommandDebugInvokeAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Automation automation) return;
+        if (e.Parameter is not Actionset actionset) return;
 
-        App.GetService<IActionService>().Invoke(automation.Actionset);
+        App.GetService<IActionService>().Invoke(actionset);
     }
 
     private void CommandDebugInvokeRevertAction_OnExecuted(object sender, ExecutedRoutedEventArgs e)
     {
-        if (e.Parameter is not Automation automation) return;
+        if (e.Parameter is not Actionset actionset) return;
 
-        App.GetService<IActionService>().Revert(automation.Actionset);
+        App.GetService<IActionService>().Revert(actionset);
     }
 
     private void ListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/ClassIsland/Views/SettingPages/DebugPage.xaml
+++ b/ClassIsland/Views/SettingPages/DebugPage.xaml
@@ -28,11 +28,15 @@
                     Visibility="{Binding ManagementService.Policy.DisableDebugMenu, Converter={StaticResource InverseBoolToVisConverter}}">
             <StackPanel.Resources>
                 <Style TargetType="MenuItem" BasedOn="{StaticResource MaterialDesignMenuItem}">
+                    <Setter Property="MinWidth" Value="2000" />
                     <Style.Resources>
                         <Style TargetType="materialDesign:PackIcon">
                             <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
                         </Style>
                     </Style.Resources>
+                </Style>
+                <Style TargetType="UniformGrid">
+                    <Setter Property="Columns" Value="2" />
                 </Style>
             </StackPanel.Resources>
             <TextBlock Text="调试" Style="{StaticResource MaterialDesignHeadline5TextBlock}" />
@@ -45,16 +49,14 @@
             <MenuItem Icon="{materialDesign:PackIcon LightningBoltOutline}"
                       Header="特性调试窗口"
                       Click="MenuItemFeatureDebugWindow_OnClick"/>
-            <UniformGrid Rows="1">
-                <MenuItem IsCheckable="True" Header="调试菜单"
-                      IsChecked="{Binding SettingsService.Settings.IsDebugEnabled}" />
-                <MenuItem IsCheckable="True" Header="主窗口调试界面" Width="1000"
-                      IsChecked="{Binding SettingsService.Settings.IsMainWindowDebugEnabled}" />
+            <UniformGrid>
+                <MenuItem IsCheckable="True" Header="调试菜单" IsChecked="{Binding SettingsService.Settings.IsDebugEnabled}" />
+                <MenuItem IsCheckable="True" Header="主窗口调试界面" IsChecked="{Binding SettingsService.Settings.IsMainWindowDebugEnabled}" />
             </UniformGrid>
 
-            <materialDesign:Card Margin="0 8 0 8" HorizontalAlignment="Stretch">
+            <materialDesign:Card Margin="0 4" HorizontalAlignment="Stretch">
                 <StackPanel>
-                    <Viewbox Stretch="Uniform" MaxWidth="600">
+                    <Viewbox Stretch="Uniform" MaxHeight="340">
                         <StackPanel Orientation="Horizontal">
                             <Calendar SelectedDate="{Binding ViewModel.TargetDate}"
                                       Style="{StaticResource MaterialDesignDatePickerCalendarPortrait}"
@@ -69,7 +71,7 @@
                                       Time="{Binding ViewModel.TargetTime}"/>
                         </StackPanel>
                     </Viewbox>
-                    <UniformGrid Rows="1">
+                    <UniformGrid>
                         <MenuItem Grid.Column="0" Grid.Row="1"
                                   Icon="{materialDesign:PackIcon ClockRemoveOutline}"
                                   Header="重置时间偏移"
@@ -88,61 +90,53 @@
             </materialDesign:Card>
 
             <UniformGrid>
-                <MenuItem Icon="{materialDesign:PackIcon FlashOutline}" Header="触发上课"
-                          Click="MenuItemDebugTriggerOnClass_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon PlayOutline}" Header="启动主计时器"
-                          Click="MenuItemStartMainTimer_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon FlashOutline}" Header="触发下课"
-                          Click="MenuItemDebugTriggerAfterClass_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon Pause}" Header="停止主计时器"
-                          Click="MenuItemStopMainTimer_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon RubbishBinOutline}" Header="垃圾回收"
-                          Click="MenuItemGcCollect_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon FlashOutline}" Header="触发上课" Click="MenuItemDebugTriggerOnClass_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon PlayOutline}" Header="启动主计时器" Click="MenuItemStartMainTimer_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon FlashOutline}" Header="触发下课" Click="MenuItemDebugTriggerAfterClass_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon Pause}" Header="停止主计时器" Click="MenuItemStopMainTimer_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon RubbishBinOutline}" Header="垃圾回收" Click="MenuItemGcCollect_OnClick" />
             </UniformGrid>
             <Separator />
 
-            <UniformGrid Columns="2" 
-                         IsEnabled="{Binding ManagementService.IsManagementEnabled, Converter={StaticResource BooleanToBooleanReConverter}, Mode=OneTime}">
-                <MenuItem Header="禁止编辑档案" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileEditing}" Width="1000"/>
-                <MenuItem IsCheckable="True" Header="正在集控管理" IsChecked="{Binding ManagementService.IsManagementEnabled}" Width="1000"/>
-                <MenuItem Header="禁止编辑课表" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileClassPlanEditing}" Width="1000"/>
-                <MenuItem IsCheckable="True" Header="允许退出集控" IsChecked="{Binding ManagementService.Policy.AllowExitManagement}" Width="1000"/>
-                <MenuItem Header="禁止编辑时间表" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileTimeLayoutEditing}" Width="1000"/>
-                <MenuItem IsCheckable="True" Header="禁止编辑应用设置" IsChecked="{Binding ManagementService.Policy.DisableSettingsEditing}" Width="1000"/>
-                <MenuItem Header="禁止编辑科目" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileSubjectsEditing}" Width="1000"/>
-                <MenuItem IsCheckable="True" Header="禁止自定义启动加载界面" IsChecked="{Binding ManagementService.Policy.DisableSplashCustomize}" Width="1000"/>
+            <UniformGrid IsEnabled="{Binding ManagementService.IsManagementEnabled, Converter={StaticResource BooleanToBooleanReConverter}, Mode=OneTime}">
+                <MenuItem Header="禁止编辑档案" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileEditing}"/>
+                <MenuItem IsCheckable="True" Header="正在集控管理" IsChecked="{Binding ManagementService.IsManagementEnabled}"/>
+                <MenuItem Header="禁止编辑课表" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileClassPlanEditing}"/>
+                <MenuItem IsCheckable="True" Header="允许退出集控" IsChecked="{Binding ManagementService.Policy.AllowExitManagement}"/>
+                <MenuItem Header="禁止编辑时间表" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileTimeLayoutEditing}"/>
+                <MenuItem IsCheckable="True" Header="禁止编辑应用设置" IsChecked="{Binding ManagementService.Policy.DisableSettingsEditing}"/>
+                <MenuItem Header="禁止编辑科目" IsCheckable="True" IsChecked="{Binding ManagementService.Policy.DisableProfileSubjectsEditing}"/>
+                <MenuItem IsCheckable="True" Header="禁止自定义启动加载界面" IsChecked="{Binding ManagementService.Policy.DisableSplashCustomize}"/>
             </UniformGrid>
             <Separator />
 
-            <UniformGrid Columns="2">
-                <MenuItem Icon="{materialDesign:PackIcon ArrowLeftRight}" Header="显示快速信息迁移提示" Width="1000"
-                          Click="MenuItemShowComponentsMigrateTips_OnClick"/>
-                <MenuItem Icon="{materialDesign:PackIcon CogOutline}" Header="覆盖设置版本" Width="1000"
-                          Click="MenuItemOverwriteSettingsVersion_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon ToyBrickOutline}" Header="显示插件使用须知" Width="1000"
-                          Click="MenuItemShowPluginMarketWarning_OnClick"/>
-                <MenuItem Icon="{materialDesign:PackIcon RelationManyToMany}" Header="转储课表关系图" Width="1000"
-                          Click="MenuItemDumpProfileRelations_OnClick" />
-                <MenuItem Icon="{materialDesign:PackIcon Kind=ScriptTextOutline}" Header="显示自动化使用须知" Width="1000"
-                          Click="MenuItemShowAutomationWarning_OnClick"/>
-                <MenuItem Icon="{materialDesign:PackIcon RelationManyToMany}" Header="测试课表找下级" Width="1000"
-                          Click="MenuItemFindNext_OnClick" />
+            <UniformGrid>
+                <MenuItem Icon="{materialDesign:PackIcon ArrowLeftRight}" Header="显示快速信息迁移提示" Click="MenuItemShowComponentsMigrateTips_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon CogOutline}" Header="覆盖设置版本" Click="MenuItemOverwriteSettingsVersion_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon ToyBrickOutline}" Header="显示插件使用须知" Click="MenuItemShowPluginMarketWarning_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon RelationManyToMany}" Header="转储课表关系图" Click="MenuItemDumpProfileRelations_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon ScriptTextOutline}" Header="显示自动化使用须知" Click="MenuItemShowAutomationWarning_OnClick" />
+                <MenuItem Icon="{materialDesign:PackIcon RelationManyToMany}" Header="测试课表找下级" Click="MenuItemFindNext_OnClick" />
             </UniformGrid>
 
             <!-- 动画缩放 -->
-            <controls2:SettingsControl IconGlyph="BugOutline" Header="动画缩放" Margin="0 13 0 0"
-                                                              Description="主界面缩放动画播放倍速。">
+            <controls2:SettingsControl IconGlyph="BugOutline"
+                                       Header="动画缩放"
+                                       Description="主界面缩放动画播放倍速。"
+                                       Margin="0 13 0 0">
                 <controls2:SettingsControl.Switcher>
                     <TextBox
-                                                Text="{Binding SettingsService.Settings.DebugAnimationScale, Mode=TwoWay, Converter={StaticResource IntToStringConverter}}"
-                                                MinWidth="150"
-                                                Foreground="{DynamicResource MaterialDesignBody}"/>
+                        Text="{Binding SettingsService.Settings.DebugAnimationScale, Mode=TwoWay, Converter={StaticResource IntToStringConverter}}"
+                        MinWidth="150"
+                        Foreground="{DynamicResource MaterialDesignBody}"/>
                 </controls2:SettingsControl.Switcher>
             </controls2:SettingsControl>
 
             <!-- 时间流速 -->
-            <controls2:SettingsControl IconGlyph="ClockFast" Header="时间流速" Margin="0 13 0 0"
-                                                             Description="持续调整时间偏移，以控制时间流速。">
+            <controls2:SettingsControl IconGlyph="ClockFast"
+                                       Header="时间流速"
+                                       Description="持续调整时间偏移，以控制时间流速。"
+                                       Margin="0 13 0 0">
                 <controls2:SettingsControl.Switcher>
                     <Grid HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
@@ -196,7 +190,7 @@
                     <MenuItem Icon="{materialDesign:PackIcon Bomb}"
                               Header="崩溃测试（Task）"
                               Click="MenuItemCrashOnTask_OnClick" />
-                    <MenuItem Header="集控：禁用调试菜单" Width="1000" IsCheckable="True"
+                    <MenuItem Header="集控：禁用调试菜单" IsCheckable="True"
                               IsChecked="{Binding ManagementService.Policy.DisableDebugMenu}"
                               IsEnabled="{Binding ManagementService.IsManagementEnabled, Converter={StaticResource BooleanToBooleanReConverter}, Mode=OneTime}"/>
                 </StackPanel>

--- a/ClassIsland/Views/SettingPages/DebugPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/DebugPage.xaml.cs
@@ -122,18 +122,21 @@ public partial class DebugPage : SettingsPageBase
     private void TargetDate_OnChanged(object sender, RoutedEventArgs e)
     {
         if (!ViewModel.IsTargetDateTimeLoaded) return;
-        var offset = SettingsService.Settings.TimeOffsetSeconds % (60 * 60 * 24); // 原时间偏移的时间
-        SettingsService.Settings.TimeOffsetSeconds = 0; // 重置偏移以便获取网络精确时间
-        SettingsService.Settings.TimeOffsetSeconds = (ViewModel.TargetDate - ExactTimeService.GetCurrentLocalDateTime().Date).TotalSeconds // 目标日期
-                                                   +  offset;
+
+        DateTime now = ExactTimeService.GetCurrentLocalDateTime().Date;
+        DateTime tar = ViewModel.TargetDate.Date;
+
+        SettingsService.Settings.TimeOffsetSeconds += Math.Round((tar - now).TotalSeconds);
     }
 
     private void TargetTime_OnChanged(object sender, RoutedEventArgs e)
     {
         if (!ViewModel.IsTargetDateTimeLoaded) return;
-        SettingsService.Settings.TimeOffsetSeconds = 0;
-        SettingsService.Settings.TimeOffsetSeconds = Math.Round(
-            (ViewModel.TargetDate + (ViewModel.TargetTime - ViewModel.TargetTime.Date) - ExactTimeService.GetCurrentLocalDateTime()).TotalSeconds);
+
+        DateTime now = ExactTimeService.GetCurrentLocalDateTime();
+        DateTime tar = new(DateOnly.FromDateTime(now), TimeOnly.FromDateTime(ViewModel.TargetTime));
+
+        SettingsService.Settings.TimeOffsetSeconds += Math.Round((tar - now).TotalSeconds);
     }
 
     private void MenuItemStartMainTimer_OnClick(object sender, RoutedEventArgs e)

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.xaml
@@ -273,18 +273,18 @@
                                                   TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
                     <Expander.Header>
                         <controls1:SettingsControl IconGlyph="ClockArrow"
-                                                                          Header="时间偏移"
-                                                                          Foreground="{DynamicResource MaterialDesignBody}"
-                                                                          Description="设定课程时间与实际时间的偏移值。如果您需要更精确地同步时间，建议您同时开启【使用精确时间】选项。"
-                                                                          IsOn="{Binding SettingsService.Settings.IsExactTimeEnabled, Mode=TwoWay}"
-                                                                          Margin="-12 0">
+                                                   Header="时间偏移"
+                                                   Foreground="{DynamicResource MaterialDesignBody}"
+                                                   Description="设定课程时间与实际时间的偏移值。增大偏移以抵消铃声提前，减小偏移以抵消铃声滞后。"
+                                                   IsOn="{Binding SettingsService.Settings.IsExactTimeEnabled, Mode=TwoWay}"
+                                                   Margin="-12 0">
                             <controls1:SettingsControl.Switcher>
                                 <TextBox Grid.Column="1" Grid.Row="1"
-                                                                 VerticalAlignment="Center"
-                                                                 MinWidth="150"
-                                                                 Foreground="{DynamicResource MaterialDesignBody}"
-                                                                 materialDesign:TextFieldAssist.SuffixText="秒"
-                                                                 Text="{Binding SettingsService.Settings.TimeOffsetSeconds, Converter={StaticResource IntToStringConverter}}"/>
+                                         VerticalAlignment="Center"
+                                         MinWidth="147"
+                                         Foreground="{DynamicResource MaterialDesignBody}"
+                                         materialDesign:TextFieldAssist.SuffixText="秒"
+                                         Text="{Binding SettingsService.Settings.TimeOffsetSeconds, Converter={StaticResource IntToStringConverter}}"/>
                             </controls1:SettingsControl.Switcher>
                         </controls1:SettingsControl>
                     </Expander.Header>
@@ -361,7 +361,7 @@
             <!-- 教学安全模式 -->
             <controls1:SettingsCard IconGlyph="CarBrakeAlert"
                                     Header="教学安全模式"
-                                    Description="启用后，ClassIsland 会在崩溃时自动退出而不弹出崩溃窗口，以确保教学不受到影响。"
+                                    Description="启用后，如果 ClassIsland 发生意外崩溃，将自动退出而不弹出崩溃窗口，以确保教学不受到影响。您可以在日志目录查看崩溃详情。"
                                     IsOn="{Binding SettingsService.Settings.IsCriticalSafeMode, Mode=TwoWay}"
                                     Margin="0 0 0 6" />
         </StackPanel>

--- a/ClassIsland/Views/SettingPages/StorageSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/StorageSettingsPage.xaml
@@ -31,7 +31,7 @@
             <!-- 启用自动备份 -->
             <materialDesign:Card Margin="0 0 0 6">
                 <Expander Background="Transparent"
-                          IsExpanded="{Binding SettingsService.Settings.IsAutoBackupEnabled, Mode=TwoWay}"
+                          IsExpanded="{Binding SettingsService.Settings.IsAutoBackupEnabled, Mode=OneWay}"
                           TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
                     <Expander.Header>
                         <ci:SettingsControl IconGlyph="AutoMode"

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
@@ -238,6 +238,14 @@
                                 </ci:SettingsControl.Switcher>
                             </ci:SettingsControl>
 
+                            <!-- 反转指针移入淡化 -->
+                            <ci:SettingsControl IconGlyph="MouseMoveUp"
+                                                Foreground="{DynamicResource MaterialDesignBody}"
+                                                Header="反转指针移入淡化"
+                                                Description="启用后，将默认淡化主界面，使主界面仅在鼠标移入时显示。此开关不影响隐藏主界面。"
+                                                IsOn="{Binding SettingsService.Settings.IsMouseInFadingReversed, Mode=TwoWay}"
+                                                Margin="0 6 0 0" />
+
                         </StackPanel>
                     </StackPanel>
                 </Expander>


### PR DESCRIPTION
> [fix: 忽略 IPC 广播信息可能出现 NullReferenceException 的问题](https://github.com/ClassIsland/ClassIsland/commit/86bb029a3058aee8ed06f24ff847935b1528ee2f)

没弄清为什么这里会出现 NullRef，所以只是套了个 catch，经测试问题不再复现。可能需要更好的修复方法。

> [fix: 修复特性调试窗口打开时报错的问题（未测试](https://github.com/ClassIsland/ClassIsland/commit/e88a075982e747affb5d26199c9b49d79c0f7bf4)

我移除了理论上会造成错误的代码，因为那块代码好像没有实际作用。
没有经过实际测试，因为我始终无法复现…

> [fix: 尝试缓解托盘菜单弹出偏移的问题](https://github.com/ClassIsland/ClassIsland/commit/34052fc539e97b791d70f56770bb9ec14a3ab910)

我感觉是 staysopen 出现的问题，所以重新加回了它。
之所以在上一次删除了它，是因为原先并没有这一条。

> [fix: 修复 时间点附加信息-持续时间 可能出现小数的问题](https://github.com/ClassIsland/ClassIsland/commit/1893dbb3a32e2fd4f03b4dbbd221a3755b3c8ee3)

这里我没有进行更多修改，只是做了错误修复。

> [fix: 修复天气颜色不能正常更新的问题](https://github.com/ClassIsland/ClassIsland/commit/e08e4de12a1bfb39de1089af000589af0cd16d5d)

这里应该是 WeatherColor 没有在天气变化后重置所导致问题。

> [fix: 修复时间线视图-拖动时间点会自动拉动非相邻时间块的问题](https://github.com/ClassIsland/ClassIsland/commit/f93bf7dcdc2e911a8caaebba2b332bd3ad766cb2)

这里的逻辑写的比较烧脑，以后需要解耦重构。

> [fix: 应用启动时，重新进行规则判断](https://github.com/ClassIsland/ClassIsland/commit/dff0be2e99f0b96b43e160c459895eca5d6e5125)

我在使用自动化时发现了这个问题，不知道是不是普遍问题，所以干脆全部重新判断了。

> [feat: 微调自动化、调试时间、时间偏移、课程表文本间距等设置页面](https://github.com/ClassIsland/ClassIsland/commit/59c7b2b9234b54cec1968347e0827188dbd2e47c)

我在这里进行了 #465 的修改，改为
「设定课程时间与实际时间的偏移值。增大偏移以抵消铃声提前，减小偏移以抵消铃声滞后。」
![image](https://github.com/user-attachments/assets/250af8ff-47da-4f9e-86a8-ef8f8624f6ed)
相较于建议的「设定课程时间与实际时间的偏移值，正值为提前，负值为推迟。」，
我不确定哪个更合适，可能需要进行商榷。