### PR TITLE
修改 ProcessLessons()

### DIFF
--- a/ClassIsland.Core/Abstractions/Services/ILessonsService.cs
+++ b/ClassIsland.Core/Abstractions/Services/ILessonsService.cs
@@ -40,11 +40,6 @@ public interface ILessonsService : INotifyPropertyChanged, INotifyPropertyChangi
 
     #region LessonsProperties
 
-    ///// <summary>
-    ///// 下一个时间点。
-    ///// </summary>
-    //TimeLayoutItem NextTimeLayoutItem { get; set; }
-
     internal TimeState CurrentOverlayStatus { get; set; }
 
     #endregion

--- a/ClassIsland.Core/Controls/LessonsControls/LessonControlExpanded.xaml.cs
+++ b/ClassIsland.Core/Controls/LessonsControls/LessonControlExpanded.xaml.cs
@@ -168,11 +168,11 @@ public partial class LessonControlExpanded : LessonControlBase, INotifyPropertyC
 
         if (SettingsSource != null)
         {
-            MasterTabIndex = LeftSeconds < SettingsSource.CountdownSeconds &&
+            MasterTabIndex = LeftSeconds <= SettingsSource.CountdownSeconds &&
                              SettingsSource.IsCountdownEnabled &&
                              IsLiveUpdatingEnabled ? 1 : 0;
             ExtraInfo4ShowSeconds = SettingsSource.ExtraInfoType == 4 &&
-                                    LeftSeconds < SettingsSource.ExtraInfo4ShowSecondsSeconds;
+                                    LeftSeconds <= SettingsSource.ExtraInfo4ShowSecondsSeconds;
         }
 
     }

--- a/ClassIsland.Shared.IPC/Abstractions/Services/IPublicLessonsService.cs
+++ b/ClassIsland.Shared.IPC/Abstractions/Services/IPublicLessonsService.cs
@@ -12,52 +12,60 @@ namespace ClassIsland.Shared.IPC.Abstractions.Services;
 public interface IPublicLessonsService
 {
     /// <summary>
-    /// 主计时器是否正在工作
+    /// 主计时器是否正在工作。
     /// </summary>
     bool IsTimerRunning { get; }
 
     /// <summary>
-    /// 当前加载的课表。如果当前没有课表，则为null。
+    /// 当前加载的课表。如果当前没有课表，则为 null。
     /// </summary>
     ClassPlan? CurrentClassPlan { get; set; }
 
     /// <summary>
-    /// 当前所处时间点<see cref="TimeLayoutItem"/>的索引。
+    /// 当前所处时间点<see cref="TimeLayoutItem"/>的索引。如无，则为 -1。
     /// </summary>
-    int? CurrentSelectedIndex { get; set; }
+    int CurrentSelectedIndex { get; set; }
 
     /// <summary>
-    /// 下一节课（下一个上课类型的时间点<see cref="TimeLayoutItem"/>）的科目。
+    /// 当前或下一节课（下一个上课类型的时间点<see cref="TimeLayoutItem"/>）的科目。如无，则为 <see cref="Subject.Empty"/>。
     /// </summary>
     Subject NextClassSubject { get; set; }
 
     /// <summary>
-    /// 下一个课间休息类型的时间点。
+    /// 当前或下一个课间休息类型的时间点。如无，则为 <see cref="TimeLayoutItem.Empty"/>。
     /// </summary>
     TimeLayoutItem NextBreakingTimeLayoutItem { get; set; }
 
     /// <summary>
-    /// 下一个上课类型的时间点。
+    /// 当前或下一个上课类型的时间点。如无，则为 <see cref="TimeLayoutItem.Empty"/>。
     /// </summary>
     TimeLayoutItem NextClassTimeLayoutItem { get; set; }
 
     /// <summary>
-    /// 距离上课剩余时间。
+    /// 距上课剩余时间。如果当前正在上课，或没有下一节课程，则为 <see cref="TimeSpan.Zero"/>。
     /// </summary>
     TimeSpan OnClassLeftTime { get; set; }
 
     /// <summary>
-    /// 当前时间点状态
+    /// 距下课剩余时间。如果当前不在上课，则为 <see cref="TimeSpan.Zero"/>。
+    /// </summary>
+    TimeSpan OnBreakingTimeLeftTime { get; set; }
+
+    /// <summary>
+    /// 当前时间点状态。
     /// </summary>
     TimeState CurrentState { get; set; }
 
     /// <summary>
-    /// 当前所处的时间点。
+    /// 当前所处的时间点。如果当前没有时间点，则为 <see cref="TimeLayoutItem.Empty"/>。
     /// </summary>
     TimeLayoutItem CurrentTimeLayoutItem { get; set; }
 
     /// <summary>
-    /// 当前所处时间点<see cref="TimeLayoutItem"/>的科目。如果没有加载课表，则为null。
+    /// 当前所处时间点<see cref="TimeLayoutItem"/>的科目。<br/><br/>
+    /// 如果当前是课间休息，则其中 <see cref="Subject.Name"/>(科目名) 为课间名称。<br/>
+    /// 如果当前课程未定义，则为 <see cref="Subject.Empty"/>。<br/>
+    /// 如果当前没有时间点，或没有加载课表，则为 null。<br/>
     /// </summary>
     Subject? CurrentSubject { get; set; }
 
@@ -77,23 +85,15 @@ public interface IPublicLessonsService
     bool IsLessonConfirmed { get; set; }
 
     /// <summary>
-    /// 距下课剩余时间
-    /// </summary>
-    TimeSpan OnBreakingTimeLeftTime { get; set; }
-
-    /// <summary>
     /// 本周多周轮换周数。
     /// </summary>
-    /// <remarks>
-    /// 第 2 位 - 双周轮换<br/>
-    /// 第 3 位 - 三周轮换<br/>
-    /// ……<br/>
+    /// <value>
+    /// 第 x 位数字是 y（MultiWeekRotation[x]=y）— 本周是 x 周轮换中的第 y 周。<br/>
     /// <br/>
-    /// 1 - 本周单周<br/>
-    /// 2 - 本周是双周<br/>
-    /// 3 - 本周是 3/x 周<br/>
-    /// ……<br/>
-    /// </remarks>
+    /// 例：<br/>
+    /// 第 2 位数字是 1（MultiWeekRotation[2]=1）— 本周是 2 周轮换中的第 1 周。<br/>
+    /// 第 4 位数字是 3（MultiWeekRotation[4]=3）— 本周是 4 周轮换中的第 3 周。<br/>
+    /// </value>
     ObservableCollection<int> MultiWeekRotation { get; set; }
 
     /// <summary>

--- a/ClassIsland.Shared/Enums/TimeState.cs
+++ b/ClassIsland.Shared/Enums/TimeState.cs
@@ -20,5 +20,9 @@ public enum TimeState
     /// <summary>
     /// 课间休息
     /// </summary>
-    Breaking
+    Breaking,
+    /// <summary>
+    /// 放学
+    /// </summary>
+    AfterSchool,
 }

--- a/ClassIsland.Shared/Enums/TimeState.cs
+++ b/ClassIsland.Shared/Enums/TimeState.cs
@@ -14,7 +14,7 @@ public enum TimeState
     /// </summary>
     OnClass,
     /// <summary>
-    /// 准备上课
+    /// 准备上课（预留）
     /// </summary>
     PrepareOnClass,
     /// <summary>

--- a/ClassIsland.Shared/Models/Profile/Subject.cs
+++ b/ClassIsland.Shared/Models/Profile/Subject.cs
@@ -23,7 +23,7 @@ public class Subject : AttachableSettingsObject
             if (value == _name) return;
             _name = value;
             if (string.IsNullOrEmpty(Initial) && !string.IsNullOrWhiteSpace(Name))
-                Initial = Name.Substring(0, 1);
+                Initial = Name.First().ToString();
             OnPropertyChanged();
         }
     }

--- a/ClassIsland.Shared/Models/Profile/TimeLayoutItem.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayoutItem.cs
@@ -57,6 +57,16 @@ public class TimeLayoutItem : AttachableSettingsObject, IComparable
         }
     }
 
+
+    /// <summary>
+    /// 代表一个空时间点。
+    /// </summary>
+    public static readonly TimeLayoutItem Empty = new()
+    {
+        StartSecond = DateTime.MinValue,
+        EndSecond = DateTime.MinValue,
+    };
+
     [JsonIgnore]
     public TimeSpan Last => EndSecond.TimeOfDay - StartSecond.TimeOfDay;
 
@@ -114,10 +124,10 @@ public class TimeLayoutItem : AttachableSettingsObject, IComparable
     /// 课间名称。
     /// </summary>
     [JsonIgnore]
-    public string BreakNameText => string.IsNullOrEmpty(_breakName) ? "课间休息" : _breakName;
+    public string BreakNameText => string.IsNullOrEmpty(BreakName) ? "课间休息" : BreakName;
 
     /// <summary>
-    /// 自定义课间名称。
+    /// 自定义课间名称。应使用<see cref="BreakNameText"/>获取实际课间名称。
     /// </summary>
     public string BreakName
     {

--- a/ClassIsland.Shared/Models/Profile/TimeRule.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeRule.cs
@@ -36,7 +36,7 @@ public class TimeRule : ObservableRecipient
     /// 0 - 不轮换<br/>
     /// 1 - 第一周<br/>
     /// 2 - 第二周<br/>
-    /// n - 第n周
+    /// y - 第 y 周
     /// </value>
     public int WeekCountDiv
     {

--- a/ClassIsland/Controls/Components/ScheduleComponent.xaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.xaml
@@ -22,7 +22,8 @@
             VerticalAlignment="Center"
             Mode="PrimaryMid"
             Padding="8 2"
-            CornerRadius="16">
+            CornerRadius="16"
+            x:Name="Tomorrow">
             <materialDesign:ColorZone.Style>
                 <Style TargetType="materialDesign:ColorZone">
                     <Style.Triggers>
@@ -98,6 +99,7 @@
                                 <Condition Binding="{Binding Settings.TomorrowScheduleShowMode}" Value="1"/>
                                 <Condition Binding="{Binding Settings.ShowPlaceholderOnEmptyClassPlan}" Value="True"/>
                                 <Condition Binding="{Binding LessonsService.CurrentClassPlan}" Value="{x:Null}"/>
+                                <Condition Binding="{Binding Visibility, ElementName=Tomorrow}" Value="Collapsed"/>
                             </MultiDataTrigger.Conditions>
                             <Setter Property="Visibility" Value="Visible"/>
                         </MultiDataTrigger>

--- a/ClassIsland/Controls/RuleSettingsControls/TimeStateRuleSettingsControl.xaml
+++ b/ClassIsland/Controls/RuleSettingsControls/TimeStateRuleSettingsControl.xaml
@@ -28,6 +28,9 @@
             <ComboBoxItem>
                 课间休息
             </ComboBoxItem>
+            <ComboBoxItem>
+                放学后
+            </ComboBoxItem>
         </ComboBox>
     </Grid>
 </ci:RuleSettingsControlBase>

--- a/ClassIsland/Services/LessonsService.cs
+++ b/ClassIsland/Services/LessonsService.cs
@@ -286,7 +286,8 @@ public class LessonsService : ObservableRecipient, ILessonsService
             return false;
         }
 
-        return CurrentState == s.State;
+        return CurrentState == s.State ||
+               CurrentState == TimeState.AfterSchool && s.State == TimeState.None;
     }
 
     private void MainTimerOnTick(object? sender, EventArgs e)

--- a/ClassIsland/Services/NotificationProviders/AfterSchoolNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/AfterSchoolNotificationProvider.cs
@@ -58,19 +58,18 @@ public class AfterSchoolNotificationProvider : INotificationProvider, IHostedSer
         NotificationHostService.RegisterNotificationProvider(this);
         Settings =
             NotificationHostService.GetNotificationProviderSettings<AfterSchoolNotificationProviderSettings>(ProviderGuid);
-        LessonsService.CurrentTimeStateChanged += NotificationHostServiceOnCurrentStateChanged;
+        LessonsService.OnAfterSchool += OnAfterSchool;
         SettingsElement = new AfterSchoolNotificationProviderSettingsControl(Settings);
     }
 
-    private void NotificationHostServiceOnCurrentStateChanged(object? sender, EventArgs e)
+    private void OnAfterSchool(object? sender, EventArgs e)
     {
         var settings = (IAfterSchoolNotificationProviderSettingsBase?)GetAttachedSettings() ?? Settings;
-        if (!settings.IsEnabled || LessonsService.CurrentState != TimeState.None || !LessonsService.IsClassPlanLoaded ||
-            ExactTimeService.GetCurrentLocalDateTime().TimeOfDay - LessonsService.CurrentClassPlan?.TimeLayout.Layouts.LastOrDefault()?.EndSecond.TimeOfDay > TimeSpan.FromSeconds(5)||
-            ExactTimeService.GetCurrentLocalDateTime().TimeOfDay < LessonsService.CurrentClassPlan?.TimeLayout.Layouts.LastOrDefault()?.EndSecond.TimeOfDay)
-        {
+        var now = ExactTimeService.GetCurrentLocalDateTime().TimeOfDay;
+        var afterSchoolTime = LessonsService.CurrentClassPlan?.TimeLayout.Layouts.LastOrDefault(i => i.TimeType is 0 or 1)?.EndSecond.TimeOfDay;
+        if (!settings.IsEnabled ||
+            (now - afterSchoolTime) > TimeSpan.FromSeconds(10))
             return;
-        }
 
         NotificationHostService.ShowNotification(new NotificationRequest()
         {

--- a/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
@@ -141,10 +141,10 @@ public class ClassNotificationProvider : INotificationProvider, IHostedService
             : Settings.IsClassOffNotificationEnabled;
 
 
-        if (!settingsIsClassOffNotificationEnabled || ExactTimeService.GetCurrentLocalDateTime().TimeOfDay - LessonsService.CurrentTimeLayoutItem.StartSecond.TimeOfDay > TimeSpan.FromSeconds(5))
-        {
+        if (!settingsIsClassOffNotificationEnabled ||
+            LessonsService.CurrentTimeLayoutItem == TimeLayoutItem.Empty ||
+            ExactTimeService.GetCurrentLocalDateTime().TimeOfDay - LessonsService.CurrentTimeLayoutItem.StartSecond.TimeOfDay > TimeSpan.FromSeconds(5))
             return;
-        }
 
         if (LessonsService.NextClassSubject != Subject.Empty)
         {
@@ -189,18 +189,11 @@ public class ClassNotificationProvider : INotificationProvider, IHostedService
             : Settings.IsClassOnNotificationEnabled;
         var settingsSource = (IClassNotificationSettings?)(settings?.IsAttachSettingsEnabled == true ? settings : Settings) ?? Settings;
 
-        if (!settingsIsClassOnNotificationEnabled)
-        {
+        if (!settingsIsClassOnNotificationEnabled ||
+            IsClassOnNotified ||
+            LessonsService.CurrentTimeLayoutItem == TimeLayoutItem.Empty ||
+            ExactTimeService.GetCurrentLocalDateTime().TimeOfDay - LessonsService.CurrentTimeLayoutItem.StartSecond.TimeOfDay > TimeSpan.FromSeconds(5))
             return;
-        }
-        if (IsClassOnNotified)
-        {
-            return;
-        }
-        if (ExactTimeService.GetCurrentLocalDateTime().TimeOfDay - LessonsService.CurrentTimeLayoutItem.StartSecond.TimeOfDay > TimeSpan.FromSeconds(5))
-        {
-            return;
-        }
 
         if (IsClassPreparingNotified)
         {


### PR DESCRIPTION
我调整了 LessonsService.ProcessLessons() 的架构设计，通过为每个 IPublicLessonsService 中的信息规定默认值，并要求每次 ProcessLessons 时全都更新，防止出现 ~少写一个 else 导致~ 信息未被更新的情况，可以保证每个信息都不会出错 (#322 #486)

添加了「放学后」这一时间状态，定义为「当日全部时间点结束，且当日有课程」。
因为感觉可以和时间状态「无」有所区分，省去各模块自行判断放学的代码。