### PR TITLE
ui & feat: 统一部分组件设置风格,并为天气组件添加Uri跳转 (master)

### DIFF
--- a/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
@@ -13,28 +13,48 @@
                          xmlns:models="clr-namespace:ClassIsland.Models"
                          xmlns:components="clr-namespace:ClassIsland.Controls.Components"
                          xmlns:componentSettings="clr-namespace:ClassIsland.Models.ComponentSettings"
-                         mc:Ignorable="d" 
-                         d:DesignHeight="450" d:DesignWidth="800">
+                         mc:Ignorable="d">
     <ScrollViewer>
         <Grid
             DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=components:CountDownComponentSettingsControl}}">
-            <StackPanel>
-                <TextBlock Text="倒计时名称" />
-                <TextBox Text="{Binding Settings.CountDownName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         Margin="10 8 0 0" MinWidth="180" HorizontalAlignment="Left" />
-                <TextBlock Text="结束日期" Margin="0 8 0 0" />
-                <DatePicker SelectedDate="{Binding Settings.OverTime, Mode=TwoWay}"
-                            Margin="10 8 0 0" HorizontalAlignment="Left"
-                            Width="120" />
-                <TextBlock Text="字体颜色" Margin="0 8 0 0" />
-                <controls1:ColorPicker Color="{Binding Settings.FontColor,Mode=TwoWay}"
-                                       Margin="10,8,0,0" HorizontalAlignment="Left" Width="auto" />
-                <TextBlock Text="字体大小" Margin="0 8 0 0" />
-                <Slider Width="180" Margin="10,8,0,0" HorizontalAlignment="Left"
-                        Maximum="30" Minimum="16" TickFrequency="1" TickPlacement="None" IsSnapToTickEnabled="True"
-                        AutoToolTipPlacement="BottomRight" AutoToolTipPrecision="2"
-                        Value="{Binding Settings.FontSize}" />
-                <CheckBox Content="紧凑模式" Margin="0 8 0 0" IsChecked="{Binding Settings.IsCompactModeEnabled}" />
+            <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
+                <controls1:SettingsCard IconGlyph="Tag" Header="倒计时名称"
+                    Description="会作为设定日期事件名称显示">
+                    <controls1:SettingsCard.Switcher>
+                        <TextBox Text="{Binding Settings.CountDownName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Margin="10 8 0 0" MinWidth="180"/>
+                    </controls1:SettingsCard.Switcher>
+                </controls1:SettingsCard>
+
+                <controls1:SettingsCard IconGlyph="Calendar" Header="结束日期"
+                                        Description="倒计时为0天时的日期~">
+                    <controls1:SettingsCard.Switcher>
+                        <DatePicker SelectedDate="{Binding Settings.OverTime, Mode=TwoWay}"
+                                    Margin="10 8 0 0" Width="120" />
+                    </controls1:SettingsCard.Switcher>
+                </controls1:SettingsCard>
+
+                <controls1:SettingsCard IconGlyph="Color" Header="字体颜色"
+                                        Description="事件名称和倒计时的字体颜色">
+                    <controls1:SettingsCard.Switcher>
+                        <controls1:ColorPicker Color="{Binding Settings.FontColor,Mode=TwoWay}"
+                                               Margin="10,8,0,0" Width="auto" />
+                    </controls1:SettingsCard.Switcher>
+                </controls1:SettingsCard>
+                
+                <controls1:SettingsCard IconGlyph="FontSize" Header="字体大小"
+                                        Description="事件名称和倒计时的字体大小">
+                    <controls1:SettingsCard.Switcher>
+                        <Slider Width="180" Margin="10,8,0,0"
+                                Maximum="30" Minimum="16" TickFrequency="1" TickPlacement="None" IsSnapToTickEnabled="True"
+                                AutoToolTipPlacement="BottomRight" AutoToolTipPrecision="2"
+                                Value="{Binding Settings.FontSize}" />
+                    </controls1:SettingsCard.Switcher>
+                </controls1:SettingsCard>
+                
+                <controls1:SettingsCard IconGlyph="Ruler" Header="紧凑模式"
+                                        Description="启用后,将隐藏“距离”和“还有”二词"
+                                        IsOn="{Binding Settings.IsCompactModeEnabled, Mode=TwoWay}"/>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/CountDownComponentSettingsControl.xaml
@@ -18,7 +18,7 @@
         <Grid
             DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=components:CountDownComponentSettingsControl}}">
             <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
-                <controls1:SettingsCard IconGlyph="Tag" Header="倒计时名称"
+                <controls1:SettingsCard IconGlyph="TagOutline" Header="倒计时名称"
                     Description="会作为设定日期事件名称显示">
                     <controls1:SettingsCard.Switcher>
                         <TextBox Text="{Binding Settings.CountDownName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -26,7 +26,7 @@
                     </controls1:SettingsCard.Switcher>
                 </controls1:SettingsCard>
 
-                <controls1:SettingsCard IconGlyph="Calendar" Header="结束日期"
+                <controls1:SettingsCard IconGlyph="CalendarOutline" Header="结束日期"
                                         Description="倒计时为0天时的日期~">
                     <controls1:SettingsCard.Switcher>
                         <DatePicker SelectedDate="{Binding Settings.OverTime, Mode=TwoWay}"
@@ -34,7 +34,7 @@
                     </controls1:SettingsCard.Switcher>
                 </controls1:SettingsCard>
 
-                <controls1:SettingsCard IconGlyph="Color" Header="字体颜色"
+                <controls1:SettingsCard IconGlyph="PaintBucket" Header="字体颜色"
                                         Description="事件名称和倒计时的字体颜色">
                     <controls1:SettingsCard.Switcher>
                         <controls1:ColorPicker Color="{Binding Settings.FontColor,Mode=TwoWay}"

--- a/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
@@ -22,7 +22,7 @@
                 </ci:SettingsCard.Switcher>
             </ci:SettingsCard>
 
-            <ci:SettingsCard IconGlyph="Color"
+            <ci:SettingsCard IconGlyph="PaintBucket"
                              Header="字体颜色"
                              Description="选择要显示文本的颜色">
                 <ci:SettingsCard.Switcher>

--- a/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/TextComponentSettingsControl.xaml
@@ -11,17 +11,35 @@
                         d:DesignHeight="450" d:DesignWidth="800">
     <ScrollViewer>
         <StackPanel
+            Style="{StaticResource SettingsPageStackPanelStyle}"
             DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:TextComponentSettingsControl}}">
-            <TextBlock Text="文本内容" />
-            <TextBox HorizontalAlignment="Left" MinWidth="200" Margin="10 4 0 0"
-                     Text="{Binding Settings.TextContent,UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="字体颜色" Margin="0 8 0 0" />
-            <ci:ColorPicker Width="auto" Margin="10 8 0 0" HorizontalAlignment="Left"
-                            Color="{Binding Settings.FontColor, Mode=TwoWay}" />
-            <TextBlock Text="字体大小" Margin="0 8 0 0" />
-            <Slider Width="200" Margin="10 8 0 0" HorizontalAlignment="Left"
-                    Maximum="30" Minimum="16" IsSnapToTickEnabled="True" AutoToolTipPlacement="BottomRight"
-                    Value="{Binding Settings.FontSize}" />
+            <ci:SettingsCard IconGlyph="Text"
+                    Header="文本内容"
+                    Description="要显示的文本...">
+                <ci:SettingsCard.Switcher>
+                    <TextBox MinWidth="200" Margin="10 4 0 0"
+                             Text="{Binding Settings.TextContent,UpdateSourceTrigger=PropertyChanged}" />
+                </ci:SettingsCard.Switcher>
+            </ci:SettingsCard>
+
+            <ci:SettingsCard IconGlyph="Color"
+                             Header="字体颜色"
+                             Description="选择要显示文本的颜色">
+                <ci:SettingsCard.Switcher>
+                    <ci:ColorPicker Width="auto" Margin="10 8 0 0"
+                                    Color="{Binding Settings.FontColor, Mode=TwoWay}" />
+                </ci:SettingsCard.Switcher>
+            </ci:SettingsCard>
+
+            <ci:SettingsCard IconGlyph="FontSize"
+                             Header="字体大小"
+                             Description="修改要显示的文本的大小">
+                <ci:SettingsCard.Switcher>
+                    <Slider Width="200" Margin="10 8 0 0"
+                            Maximum="30" Minimum="16" IsSnapToTickEnabled="True" AutoToolTipPlacement="BottomRight"
+                            Value="{Binding Settings.FontSize}" />
+                </ci:SettingsCard.Switcher>
+            </ci:SettingsCard>
         </StackPanel>
     </ScrollViewer>
 </controls:ComponentBase>

--- a/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
@@ -14,7 +14,9 @@
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:WeatherComponentSettingsControl}}">
         <ScrollViewer>
             <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
-                <materialDesign:ColorZone Background="RoyalBlue" Panel.ZIndex="1" Margin="0 0 0 5">
+                <materialDesign:ColorZone Background="#204169e1" 
+                                          Panel.ZIndex="1" 
+                                          Margin="0 0 0 5">
                     <Grid>
                         <DockPanel Margin="8 4">
                             <materialDesign:PackIcon Kind="Info"
@@ -32,7 +34,7 @@
                         </DockPanel>
                     </Grid>
                 </materialDesign:ColorZone>
-                <ci:SettingsCard IconGlyph="AlertCircleCheck" Header="显示预警信号"
+                <ci:SettingsCard IconGlyph="AlertCircleCheckOutline" Header="显示预警信号"
                                  Description="启用后,预警将以图标形式显示在天气组件上"
                                  IsOn="{Binding Settings.ShowAlerts, Mode=TwoWay}"/>
             </StackPanel>

--- a/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
@@ -7,14 +7,34 @@
                         xmlns:local="clr-namespace:ClassIsland.Controls.Components"
                         xmlns:controls="clr-namespace:ClassIsland.Core.Abstractions.Controls;assembly=ClassIsland.Core"
                         xmlns:componentSettings="clr-namespace:ClassIsland.Models.ComponentSettings"
+                        xmlns:ci="http://classisland.tech/schemas/xaml/core"
+                        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
                         mc:Ignorable="d" 
                         d:DesignHeight="450" d:DesignWidth="800">
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:WeatherComponentSettingsControl}}">
         <ScrollViewer>
-            <StackPanel>
-                <CheckBox IsChecked="{Binding Settings.ShowAlerts}" Content="显示预警信号。" />
-
-                <TextBlock Text="要调整显示天气的城市，请转到【天气】选项卡。" TextWrapping="Wrap" Margin="0 8 0 0" />
+            <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
+                <materialDesign:ColorZone Background="RoyalBlue" Panel.ZIndex="1" Margin="0 0 0 5">
+                    <Grid>
+                        <DockPanel Margin="8 4">
+                            <materialDesign:PackIcon Kind="Info"
+                                                     Height="20" Width="20"/>
+                            <TextBlock TextWrapping="Wrap"
+                                       VerticalAlignment="Center"
+                                       Margin="4 0 0 0" >
+                                <Run>本页面仅包含</Run><Bold>组件设置</Bold>
+                                <Run>要调整显示天气的城市，请转到</Run>
+                                <ci:NavHyperlink 
+                                    CommandParameter="classisland://app/settings/weather">
+                                    【天气】</ci:NavHyperlink>
+                                <Run>选项卡。</Run>
+                            </TextBlock>
+                        </DockPanel>
+                    </Grid>
+                </materialDesign:ColorZone>
+                <ci:SettingsCard IconGlyph="AlertCircleCheck" Header="显示预警信号"
+                                 Description="启用后,预警将以图标形式显示在天气组件上"
+                                 IsOn="{Binding Settings.ShowAlerts, Mode=TwoWay}"/>
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
*迁移更改至`master`分支,现重新申请拉取*

效果预览:
- 天气
![屏幕截图 2024-11-13 234826](https://github.com/user-attachments/assets/44bb0c00-1602-4087-9036-833ba4f53fa4)
- 文本
![屏幕截图 2024-11-13 234842](https://github.com/user-attachments/assets/e44345e0-c9b9-444f-b271-61265baa39b2)
- 倒计时日
![屏幕截图 2024-11-13 234855](https://github.com/user-attachments/assets/4b48df93-fcd9-4476-953f-a0cdd19cae31)
