### PR TITLE
Add GPT-SoVITS TTS Support

### DIFF
--- a/ClassIsland/App.xaml.cs
+++ b/ClassIsland/App.xaml.cs
@@ -361,6 +361,7 @@ public partial class App : AppBase, IAppHost
                         {
                             0 => new SystemSpeechService(),
                             1 => new EdgeTtsService(),
+                            2 => new GPTSoVITSService(),
                             _ => new SystemSpeechService()
                         };
                     }

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -216,6 +216,147 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private int _settingsPagesCachePolicy = 0;
     private string _notificationSpeechCustomSmgTokenSource = "";
 
+     #region GPTSoVITS
+
+    private string _gptSoVITSServerIP = "127.0.0.1";
+    private string _gptSoVITSPort = "8000";
+    private string _gptSoVITSVoiceName = "your_voice_name";
+    private string _gptSoVITSTextLang = "zh";
+    private string _gptSoVITSRefAudioPath = "archive_jingyuan_1.wav";
+    private string _gptSoVITSPromptLang = "zh";
+    private string _gptSoVITSPromptText = "我是「罗浮」云骑将军景元。不必拘谨，「将军」只是一时的身份，你称呼我景元便可";
+    private string _gptSoVITSTextSplitMethod = "cut5";
+    private int _gptSoVITSBatchSize = 1;
+
+    /// <summary>
+    /// GPTSoVITS 服务器的 IP 地址。
+    /// </summary>
+    public string GPTSoVITSServerIP
+    {
+        get => _gptSoVITSServerIP;
+        set
+        {
+            if (value == _gptSoVITSServerIP) return;
+            _gptSoVITSServerIP = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// GPTSoVITS 服务器的端口。
+    /// </summary>
+    public string GPTSoVITSPort
+    {
+        get => _gptSoVITSPort;
+        set
+        {
+            if (value == _gptSoVITSPort) return;
+            _gptSoVITSPort = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// GPTSoVITS 使用的语音名称。
+    /// </summary>
+    public string GPTSoVITSVoiceName
+    {
+        get => _gptSoVITSVoiceName;
+        set
+        {
+            if (value == _gptSoVITSVoiceName) return;
+            _gptSoVITSVoiceName = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 文本语言。
+    /// </summary>
+    public string GPTSoVITSTextLang
+    {
+        get => _gptSoVITSTextLang;
+        set
+        {
+            if (value == _gptSoVITSTextLang) return;
+            _gptSoVITSTextLang = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 参考音频的路径。
+    /// </summary>
+    public string GPTSoVITSRefAudioPath
+    {
+        get => _gptSoVITSRefAudioPath;
+        set
+        {
+            if (value == _gptSoVITSRefAudioPath) return;
+            _gptSoVITSRefAudioPath = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 提示语言。
+    /// </summary>
+    public string GPTSoVITSPromptLang
+    {
+        get => _gptSoVITSPromptLang;
+        set
+        {
+            if (value == _gptSoVITSPromptLang) return;
+            _gptSoVITSPromptLang = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 提示文本。
+    /// </summary>
+    public string GPTSoVITSPromptText
+    {
+        get => _gptSoVITSPromptText;
+        set
+        {
+            if (value == _gptSoVITSPromptText) return;
+            _gptSoVITSPromptText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 文本分割方法。
+    /// </summary>
+    public string GPTSoVITSTextSplitMethod
+    {
+        get => _gptSoVITSTextSplitMethod;
+        set
+        {
+            if (value == _gptSoVITSTextSplitMethod) return;
+            _gptSoVITSTextSplitMethod = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 批量大小。
+    /// </summary>
+    public int GPTSoVITSBatchSize
+    {
+        get => _gptSoVITSBatchSize;
+        set
+        {
+            if (value == _gptSoVITSBatchSize) return;
+            _gptSoVITSBatchSize = value;
+            OnPropertyChanged();
+        }
+    }
+
+    #endregion
+
+
     public void NotifyPropertyChanged(string propertyName)
     {
         OnPropertyChanged(propertyName);

--- a/ClassIsland/Services/SpeechService/GPTSovitsService.cs
+++ b/ClassIsland/Services/SpeechService/GPTSovitsService.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ClassIsland.Shared.Abstraction.Services;
+
+using Microsoft.Extensions.Logging;
+
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace ClassIsland.Services.SpeechService
+{
+    public class GPTSoVITSService : ISpeechService
+    {
+        public static readonly string GPTSoVITSCacheFolderPath = Path.Combine(App.AppCacheFolderPath, "GPTSoVITS");
+
+        private ILogger<GPTSoVITSService> Logger { get; } = App.GetService<ILogger<GPTSoVITSService>>();
+
+        private SettingsService SettingsService { get; } = App.GetService<SettingsService>();
+
+        private Queue<GPTSoVITSPlayInfo> PlayingQueue { get; } = new();
+
+        private bool IsPlaying { get; set; } = false;
+
+        private CancellationTokenSource? requestingCancellationTokenSource;
+
+        private IWavePlayer? CurrentWavePlayer { get; set; }
+
+        private readonly HttpClient httpClient;
+
+        public GPTSoVITSService()
+        {
+            Logger.LogInformation("初始化了 GPTSoVITS 服务。");
+            httpClient = new HttpClient();
+        }
+
+        private string GetCachePath(string text)
+        {
+            var data = Encoding.UTF8.GetBytes(text);
+            var md5 = MD5.HashData(data);
+            var md5String = md5.Aggregate("", (current, t) => current + t.ToString("x2"));
+            var path = Path.Combine(GPTSoVITSCacheFolderPath, SettingsService.Settings.GPTSoVITSVoiceName, $"{md5String}.wav");
+            var directory = Path.GetDirectoryName(path);
+            if (!Directory.Exists(directory) && directory != null)
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            return path;
+        }
+
+        public void EnqueueSpeechQueue(string text)
+        {
+            Logger.LogInformation("以 {VoiceName} 朗读文本：{Text}", SettingsService.Settings.GPTSoVITSVoiceName, text);
+            var previousCts = requestingCancellationTokenSource;
+            requestingCancellationTokenSource = new CancellationTokenSource();
+            if (previousCts is { IsCancellationRequested: false })
+            {
+                requestingCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(previousCts.Token, requestingCancellationTokenSource.Token);
+            }
+
+            var cache = GetCachePath(text);
+            Logger.LogDebug("语音缓存路径：{CachePath}", cache);
+
+            Task? task = null;
+            if (!File.Exists(cache))
+            {
+                task = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var response = await GenerateSpeechAsync(text, cache, requestingCancellationTokenSource.Token);
+                        if (!response)
+                        {
+                            Logger.LogError("生成语音失败，文本：{Text}", text);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex, "生成语音时发生异常。");
+                    }
+                }, requestingCancellationTokenSource.Token);
+            }
+
+            if (requestingCancellationTokenSource.IsCancellationRequested)
+                return;
+
+            PlayingQueue.Enqueue(new GPTSoVITSPlayInfo(cache, new CancellationTokenSource(), task));
+            _ = ProcessPlayerList();
+        }
+
+        public void ClearSpeechQueue()
+        {
+            requestingCancellationTokenSource?.Cancel();
+            CurrentWavePlayer?.Stop();
+            CurrentWavePlayer?.Dispose();
+            CurrentWavePlayer = null;
+            while (PlayingQueue.Count > 0)
+            {
+                var playInfo = PlayingQueue.Dequeue();
+                playInfo.CancellationTokenSource.Cancel();
+            }
+            // IsPlaying = false;
+        }
+
+        private async Task<bool> GenerateSpeechAsync(string text, string filePath, CancellationToken cancellationToken)
+        {
+            var settings = SettingsService.Settings;
+            var serverIP = settings.GPTSoVITSServerIP;
+            var port = settings.GPTSoVITSPort;
+
+            var queryParams = new Dictionary<string, string>
+            {
+                { "text", text },
+                { "text_lang", settings.GPTSoVITSTextLang },
+                { "ref_audio_path", settings.GPTSoVITSRefAudioPath },
+                { "prompt_lang", settings.GPTSoVITSPromptLang },
+                { "prompt_text", settings.GPTSoVITSPromptText },
+                { "text_split_method", settings.GPTSoVITSTextSplitMethod },
+                { "batch_size", settings.GPTSoVITSBatchSize.ToString() },
+                { "media_type", "wav" },
+                { "streaming_mode", "true" }
+            };
+
+            var queryString = string.Join("&", queryParams.Select(kvp => $"{kvp.Key}={Uri.EscapeDataString(kvp.Value)}"));
+            var requestUri = $"http://{serverIP}:{port}/tts?{queryString}";
+
+            try
+            {
+                Logger.LogDebug("发送 TTS 请求到：{RequestUri}", requestUri);
+                using var response = await httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                    await response.Content.CopyToAsync(fs, cancellationToken);
+                    Logger.LogDebug("语音生成并保存到：{FilePath}", filePath);
+                    return true;
+                }
+                else
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    Logger.LogError("TTS 请求失败，状态码：{StatusCode}, 内容：{ErrorContent}", response.StatusCode, errorContent);
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "发送 TTS 请求时发生异常。");
+                return false;
+            }
+        }
+
+        private async Task ProcessPlayerList()
+        {
+            if (IsPlaying)
+                return;
+            IsPlaying = true;
+            while (PlayingQueue.Count > 0)
+            {
+                var playInfo = PlayingQueue.Dequeue();
+                if (playInfo.CancellationTokenSource.IsCancellationRequested)
+                    continue;
+                if (playInfo.DownloadTask != null)
+                {
+                    Logger.LogDebug("等待语音生成完成...");
+                    await playInfo.DownloadTask;
+                    Logger.LogDebug("语音生成完成。");
+                }
+
+                if (!File.Exists(playInfo.FilePath))
+                {
+                    Logger.LogError("语音文件不存在：{FilePath}", playInfo.FilePath);
+                    continue;
+                }
+
+                CurrentWavePlayer?.Dispose();
+                var player = CurrentWavePlayer = new DirectSoundOut();
+                try
+                {
+                    await using var audio = new AudioFileReader(playInfo.FilePath);
+                    var volume = new VolumeSampleProvider(audio)
+                    {
+                        Volume = (float)SettingsService.Settings.SpeechVolume
+                    };
+                    player.Init(volume);
+                    Logger.LogDebug("开始播放 {FilePath}", playInfo.FilePath);
+                    player.Play();
+                    playInfo.IsPlayingCompleted = false;
+
+                    var playbackTcs = new TaskCompletionSource<bool>();
+                    void PlaybackStoppedHandler(object? sender, StoppedEventArgs args)
+                    {
+                        playInfo.IsPlayingCompleted = true;
+                        playbackTcs.SetResult(true);
+                    }
+
+                    player.PlaybackStopped += PlaybackStoppedHandler;
+
+                    await playbackTcs.Task;
+
+                    player.PlaybackStopped -= PlaybackStoppedHandler;
+                    Logger.LogDebug("结束播放 {FilePath}", playInfo.FilePath);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "无法播放语音。");
+                }
+            }
+
+            CurrentWavePlayer?.Dispose();
+            CurrentWavePlayer = null;
+            IsPlaying = false;
+        }
+    }
+
+    // 辅助类来存储播放信息
+    public class GPTSoVITSPlayInfo
+    {
+        public string FilePath { get; }
+        public CancellationTokenSource CancellationTokenSource { get; }
+        public Task? DownloadTask { get; }
+        public bool IsPlayingCompleted { get; set; }
+
+        public GPTSoVITSPlayInfo(string filePath, CancellationTokenSource cts, Task? downloadTask)
+        {
+            FilePath = filePath;
+            CancellationTokenSource = cts;
+            DownloadTask = downloadTask;
+            IsPlayingCompleted = false;
+        }
+    }
+}

--- a/ClassIsland/Services/SpeechService/GPTSovitsService.cs
+++ b/ClassIsland/Services/SpeechService/GPTSovitsService.cs
@@ -126,7 +126,7 @@ namespace ClassIsland.Services.SpeechService
                 { "text_split_method", settings.GPTSoVITSTextSplitMethod },
                 { "batch_size", settings.GPTSoVITSBatchSize.ToString() },
                 { "media_type", "wav" },
-                { "streaming_mode", "true" }
+                { "streaming_mode", "false" }
             };
 
             var queryString = string.Join("&", queryParams.Select(kvp => $"{kvp.Key}={Uri.EscapeDataString(kvp.Value)}"));

--- a/ClassIsland/ViewModels/SettingsPages/NotificationSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/NotificationSettingsViewModel.cs
@@ -35,5 +35,160 @@ public class NotificationSettingsViewModel : ObservableRecipient
     public List<eVoice> EdgeVoices { get; } =
         EdgeTts.GetVoice().FindAll(i => i.Locale.Contains("zh-CN"));
 
-    public string TestSpeechText { get; set; } = "风带来了故事的种子，时间使之发芽。";
+    // 现有的测试语音文本属性
+    private string _testSpeechText = "风带来了故事的种子，时间使之发芽。";
+    public string TestSpeechText
+    {
+        get => _testSpeechText;
+        set
+        {
+            if (_testSpeechText != value)
+            {
+                _testSpeechText = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    // GPTSoVITS 测试朗读文本
+    private string _testSpeechTextGPTSoVITS = "风带来了故事的种子，时间使之发芽。";
+    public string TestSpeechTextGPTSoVITS
+    {
+        get => _testSpeechTextGPTSoVITS;
+        set
+        {
+            if (_testSpeechTextGPTSoVITS != value)
+            {
+                _testSpeechTextGPTSoVITS = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    // GPTSoVITS 相关设置属性
+    private string? _gptSoVITSServerIP;
+    public string? GPTSoVITSServerIP
+    {
+        get => _gptSoVITSServerIP;
+        set
+        {
+            if (_gptSoVITSServerIP != value)
+            {
+                _gptSoVITSServerIP = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSPort;
+    public string? GPTSoVITSPort
+    {
+        get => _gptSoVITSPort;
+        set
+        {
+            if (_gptSoVITSPort != value)
+            {
+                _gptSoVITSPort = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSVoiceName;
+    public string? GPTSoVITSVoiceName
+    {
+        get => _gptSoVITSVoiceName;
+        set
+        {
+            if (_gptSoVITSVoiceName != value)
+            {
+                _gptSoVITSVoiceName = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSTextLang;
+    public string? GPTSoVITSTextLang
+    {
+        get => _gptSoVITSTextLang;
+        set
+        {
+            if (_gptSoVITSTextLang != value)
+            {
+                _gptSoVITSTextLang = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSRefAudioPath;
+    public string? GPTSoVITSRefAudioPath
+    {
+        get => _gptSoVITSRefAudioPath;
+        set
+        {
+            if (_gptSoVITSRefAudioPath != value)
+            {
+                _gptSoVITSRefAudioPath = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSPromptLang;
+    public string? GPTSoVITSPromptLang
+    {
+        get => _gptSoVITSPromptLang;
+        set
+        {
+            if (_gptSoVITSPromptLang != value)
+            {
+                _gptSoVITSPromptLang = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSPromptText;
+    public string? GPTSoVITSPromptText
+    {
+        get => _gptSoVITSPromptText;
+        set
+        {
+            if (_gptSoVITSPromptText != value)
+            {
+                _gptSoVITSPromptText = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _gptSoVITSTextSplitMethod;
+    public string? GPTSoVITSTextSplitMethod
+    {
+        get => _gptSoVITSTextSplitMethod;
+        set
+        {
+            if (_gptSoVITSTextSplitMethod != value)
+            {
+                _gptSoVITSTextSplitMethod = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private int _gptSoVITSBatchSize;
+    public int GPTSoVITSBatchSize
+    {
+        get => _gptSoVITSBatchSize;
+        set
+        {
+            if (_gptSoVITSBatchSize != value)
+            {
+                _gptSoVITSBatchSize = value;
+                OnPropertyChanged();
+            }
+        }
+    }
 }

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -29,16 +29,19 @@
         <CollectionViewSource Source="{Binding SettingsService.Settings.NotificationProvidersPriority}"
                               x:Key="CollectionViewSourceNotificationProviders"
                               Filter="CollectionViewSourceNotificationProviders_OnFilter"/>
+        <!-- 定义 BooleanToVisibilityConverter，如果尚未定义 -->
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </controls:SettingsPageBase.Resources>
+
     <controls1:ListDetailView Margin="12"
                               ShowTitleWhenNotCompressed="True"
                               IsEnabled="{Binding ManagementService.Policy.DisableSettingsEditing, Converter={StaticResource InvertBooleanConverter}}"
                               IsPanelOpened="{Binding ViewModel.IsNotificationSettingsPanelOpened, Mode=TwoWay}">
+
         <controls1:ListDetailView.TitleElement>
             <Grid>
-                <Grid
-                    DataContext="{Binding ViewModel.NotificationSettingsSelectedProvider, Converter={StaticResource GuidToNotificationProviderConverter}, Mode=OneWay}"
-                    d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}">
+                <Grid DataContext="{Binding ViewModel.NotificationSettingsSelectedProvider, Converter={StaticResource GuidToNotificationProviderConverter}, Mode=OneWay}"
+                      d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}">
                     <TextBlock Text="{Binding Name}"
                                Style="{StaticResource MaterialDesignHeadline5TextBlock}"
                                TextTrimming="CharacterEllipsis"
@@ -46,6 +49,7 @@
                 </Grid>
             </Grid>
         </controls1:ListDetailView.TitleElement>
+
         <controls1:ListDetailView.LeftContent>
             <!-- 提醒提供方 -->
             <Grid Margin="0 0 4 0">
@@ -53,26 +57,28 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
+
                 <!-- 提醒开关 -->
                 <controls2:SettingsCard Grid.Row="0" IconGlyph="BellNotificationOutline"
                                         Margin="0 0 0 6"
                                         Header="启用提醒"
                                         IsOn="{Binding SettingsService.Settings.IsNotificationEnabled, Mode=TwoWay}"
-                                        Description="启用提醒后，将会对重要事件发出醒目提醒。拖动提醒提供方以调整对应类型提醒的优先级。" />
+                                        Description="启用提醒后，将会在对重要事件发出醒目提醒。拖动提醒提供方以调整对应类型提醒的优先级。" />
+
                 <!-- 提醒提供方列表 -->
                 <TabControl Grid.Row="1">
                     <TabItem Header="提醒提供方">
-                        <ListBox
-                            ItemsSource="{Binding Source={StaticResource CollectionViewSourceNotificationProviders}}"
-                            SelectionMode="Single"
-                            dd:DragDrop.IsDragSource="True"
-                            dd:DragDrop.IsDropTarget="True"
-                            SelectionChanged="Selector_OnSelected"
-                            HorizontalContentAlignment="Stretch"
-                            dd:DragDrop.DropTargetAdornerBrush="{DynamicResource PrimaryHueMidBrush}"
-                            SelectedItem="{Binding ViewModel.NotificationSettingsSelectedProvider, Mode=TwoWay}"
-                            ItemContainerStyle="{StaticResource MaterialDesignListBoxItem}"
-                            Style="{StaticResource MaterialDesignNavigationPrimaryListBox}">
+                        <ListBox ItemsSource="{Binding Source={StaticResource CollectionViewSourceNotificationProviders}}"
+                                 SelectionMode="Single"
+                                 dd:DragDrop.IsDragSource="True"
+                                 dd:DragDrop.IsDropTarget="True"
+                                 SelectionChanged="Selector_OnSelected"
+                                 HorizontalContentAlignment="Stretch"
+                                 dd:DragDrop.DropTargetAdornerBrush="{DynamicResource PrimaryHueMidBrush}"
+                                 SelectedItem="{Binding ViewModel.NotificationSettingsSelectedProvider, Mode=TwoWay}"
+                                 ItemContainerStyle="{StaticResource MaterialDesignListBoxItem}"
+                                 Style="{StaticResource MaterialDesignNavigationPrimaryListBox}">
+
                             <dd:DragDrop.EffectMoveAdornerTemplate>
                                 <DataTemplate>
                                     <materialDesign:ColorZone Mode="PrimaryMid" Height="24"
@@ -85,12 +91,12 @@
                                     </materialDesign:ColorZone>
                                 </DataTemplate>
                             </dd:DragDrop.EffectMoveAdornerTemplate>
+
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <Grid
-                                        DataContext="{Binding Converter={StaticResource GuidToNotificationProviderConverter}}"
-                                        d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}"
-                                        Background="Transparent">
+                                    <Grid DataContext="{Binding Converter={StaticResource GuidToNotificationProviderConverter}}"
+                                          d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}"
+                                          Background="Transparent">
                                         <Grid.RowDefinitions>
                                             <RowDefinition />
                                             <RowDefinition />
@@ -107,11 +113,13 @@
                                                           VerticalAlignment="Center"
                                                           ClipToBounds="True" Margin="6"
                                                           Content="{Binding ProviderInstance.IconElement}" />
+                                        
                                         <!-- 标题 -->
                                         <TextBlock Grid.Column="1" Grid.Row="0"
                                                    TextWrapping="Wrap"
                                                    Text="{Binding Name}"
                                                    FontSize="16" FontWeight="Bold" />
+                                        
                                         <!-- 描述 -->
                                         <TextBlock Grid.Column="1" Grid.Row="1"
                                                    TextWrapping="Wrap"
@@ -121,11 +129,12 @@
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
-
                     </TabItem>
+
                     <TabItem Header="高级设置">
                         <ScrollViewer Background="{DynamicResource MaterialDesignPaper}">
                             <StackPanel Margin="0 0 0 8">
+                                
                                 <!-- 启用提醒语音 -->
                                 <materialDesign:Card>
                                     <Expander Background="Transparent"
@@ -155,36 +164,41 @@
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
                                             </Grid.RowDefinitions>
+
+                                            <!-- 默认启用 -->
                                             <CheckBox Content="默认启用" IsChecked="{Binding SettingsService.Settings.IsSpeechEnabled}"
                                                       Margin="0 0 0 6" />
 
+                                            <!-- 语音引擎 -->
                                             <TextBlock Grid.Row="1" Grid.Column="0" Text="语音引擎"
                                                        VerticalAlignment="Center" />
                                             <StackPanel Grid.Row="1" Grid.Column="1"
                                                         Orientation="Horizontal"
                                                         HorizontalAlignment="Right"
                                                         VerticalAlignment="Center">
-                                                <ListBox
-                                                    Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                                                    SelectedIndex="{Binding SettingsService.Settings.SpeechSource}">
+                                                <ListBox Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
+                                                         SelectedIndex="{Binding SettingsService.Settings.SpeechSource}"
+                                                         Width="200">
                                                     <ListBoxItem Content="系统TTS"
                                                                  IsEnabled="{Binding SettingsService.Settings.IsSystemSpeechSystemExist}" />
                                                     <ListBoxItem Content="Edge TTS"
                                                                  IsEnabled="{Binding SettingsService.Settings.IsNetworkConnect, Mode=TwoWay}" />
+                                                    <ListBoxItem Content="GPTSoVITS" />
                                                 </ListBox>
                                             </StackPanel>
 
+                                            <!-- Edge TTS 相关设置，仅在选择 Edge TTS 时显示 -->
                                             <StackPanel Grid.Row="2" Grid.Column="0"
                                                         Grid.ColumnSpan="2" Margin="0 6 0 6">
                                                 <StackPanel.Style>
                                                     <Style TargetType="StackPanel">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
                                                         <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding SettingsService.Settings.SpeechSource}"
-                                                                         Value="1">
+                                                            <!-- 假设 Edge TTS 在 ListBox 中的索引为 1 -->
+                                                            <DataTrigger Binding="{Binding SettingsService.Settings.SpeechSource}" Value="1">
                                                                 <Setter Property="Visibility" Value="Visible" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
-                                                        <Setter Property="Visibility" Value="Collapsed" />
                                                     </Style>
                                                 </StackPanel.Style>
                                                 <TextBlock TextWrapping="Wrap" Text="注意：EdgeTTS需要联网工作，并且可能存在一定延迟。" />
@@ -192,7 +206,8 @@
                                                           materialDesign:HintAssist.Hint="EdgeTTS说话人"
                                                           SelectedValuePath="ShortName"
                                                           SelectedValue="{Binding SettingsService.Settings.EdgeTtsVoiceName}"
-                                                          ItemsSource="{Binding ViewModel.EdgeVoices}">
+                                                          ItemsSource="{Binding ViewModel.EdgeVoices}"
+                                                          Width="200">
                                                     <ComboBox.ItemTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding FriendlyName}" />
@@ -201,6 +216,112 @@
                                                 </ComboBox>
                                             </StackPanel>
 
+                                            <!-- GPTSoVITS 相关设置，仅在选择 GPTSoVITS 时显示 -->
+                                            <StackPanel Grid.Row="3" Grid.Column="0"
+                                                        Grid.ColumnSpan="2" Margin="0 6 0 6">
+                                                <StackPanel.Style>
+                                                    <Style TargetType="StackPanel">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <!-- 假设 GPTSoVITS 在 ListBox 中的索引为 2 -->
+                                                            <DataTrigger Binding="{Binding SettingsService.Settings.SpeechSource}" Value="2">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+                                                
+                                                <!-- GPTSoVITS 设置 -->
+                                                <TextBlock Text="GPTSoVITS 设置" FontWeight="Bold" FontSize="16" Margin="0 0 0 4"/>
+
+                                                <!-- 服务器 IP -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="服务器 IP：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSServerIP, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 服务器端口 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="服务器端口：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 语音名称 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="语音名称：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSVoiceName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 文本语言 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="文本语言：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSTextLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 参考音频路径 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="参考音频路径：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSRefAudioPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+                                                    
+                                                <!-- 提示语言 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="提示语言：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 提示文本 -->
+                                                <StackPanel Orientation="Vertical" Margin="0 2">
+                                                    <TextBlock Text="提示文本：" Width="150" VerticalAlignment="Top" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+                                                </StackPanel>
+
+                                                <!-- 文本分割方法 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="文本分割方法：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSTextSplitMethod, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 批量大小 -->
+                                                <StackPanel Orientation="Horizontal" Margin="0 2">
+                                                    <TextBlock Text="批量大小：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSBatchSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="200" />
+                                                </StackPanel>
+
+                                                <!-- 测试朗读文本 -->
+                                                <StackPanel Orientation="Vertical" Margin="0 2">
+                                                    <TextBlock Text="测试朗读文本：" Width="150" VerticalAlignment="Top" />
+                                                    <TextBox Text="{Binding ViewModel.TestSpeechTextGPTSoVITS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+                                                </StackPanel>
+
+                                                <!-- 测试语音和打开设置按钮 -->
+                                                <WrapPanel Margin="0 6 0 0">
+                                                    <Button Click="ButtonTestSpeechingGPTSoVITS_OnClick"
+                                                            HorizontalAlignment="Left"
+                                                            Style="{StaticResource MaterialDesignFlatButton}">
+                                                        <controls2:IconText Kind="Play"
+                                                                            Text="测试语音" />
+                                                    </Button>
+                                                    <Button Click="ButtonOpenSpeechSettingsGPTSoVITS_OnClick"
+                                                            HorizontalAlignment="Left"
+                                                            Style="{StaticResource MaterialDesignFlatButton}">
+                                                        <controls2:IconText Kind="ExternalLink"
+                                                                            Text="GPTSoVITS设置" />
+                                                    </Button>
+                                                </WrapPanel>
+                                            </StackPanel>
+
+                                            <!-- 语音音量 -->
                                             <TextBlock Grid.Row="3" Grid.Column="0" Text="语音音量"
                                                        VerticalAlignment="Center"
                                                        Margin="0 6 0 0" />
@@ -217,13 +338,14 @@
                                                         Width="150" />
                                             </StackPanel>
 
+                                            <!-- 测试朗读文本和测试语音功能 -->
                                             <TextBox Grid.Row="4" Grid.Column="0"
                                                      Grid.ColumnSpan="2"
                                                      Margin="0 6 0 0"
                                                      Style="{StaticResource MaterialDesignFloatingHintTextBox}"
                                                      materialDesign:HintAssist.Hint="测试朗读文本"
                                                      Text="{Binding ViewModel.TestSpeechText}" />
-
+                                            
                                             <WrapPanel Grid.Row="5" Grid.Column="0"
                                                        Grid.ColumnSpan="2"
                                                        Margin="0 6 0 0">
@@ -243,10 +365,10 @@
                                         </Grid>
                                     </Expander>
                                 </materialDesign:Card>
+
                                 <!-- 启用提醒强调特效 -->
                                 <materialDesign:Card Margin="0 6 0 0">
                                     <Expander Background="Transparent"
-                                              IsEnabled="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Converter={StaticResource InvertBooleanConverter}}"
                                               IsExpanded="{Binding SettingsService.Settings.AllowNotificationEffect, Mode=OneWay}"
                                               TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
                                         <Expander.Header>
@@ -263,11 +385,11 @@
                                             <CheckBox Content="默认启用"
                                                       IsChecked="{Binding SettingsService.Settings.IsNotificationEffectEnabled}"
                                                       Margin="0 0 0 6" />
+                                            
                                             <!-- 提醒特效渲染精度 -->
-                                            <controls2:SettingsControl
-                                                IconGlyph="LayersOutline" Header="提醒特效渲染精度"
-                                                Foreground="{DynamicResource MaterialDesignBody}"
-                                                Description="提醒特效渲染时的精度，使用较低的精度性能可以获得较好的性能。">
+                                            <controls2:SettingsControl IconGlyph="LayersOutline" Header="提醒特效渲染精度"
+                                                                       Foreground="{DynamicResource MaterialDesignBody}"
+                                                                       Description="提醒特效渲染时的精度，使用较低的精度性能可以获得较好的性能。">
                                                 <controls2:SettingsControl.Switcher>
                                                     <Slider Minimum="0.1" Maximum="1.5"
                                                             TickFrequency="0.05"
@@ -281,6 +403,7 @@
                                         </StackPanel>
                                     </Expander>
                                 </materialDesign:Card>
+
                                 <!-- 启用提醒音效 -->
                                 <materialDesign:Card Margin="0 6 0 0">
                                     <Expander Background="Transparent"
@@ -295,7 +418,7 @@
                                                                        Margin="-12 0" />
                                         </Expander.Header>
                                         <Grid Margin="36 0 48 12"
-                                                    IsEnabled="{Binding SettingsService.Settings.AllowNotificationSound}">
+                                              IsEnabled="{Binding SettingsService.Settings.AllowNotificationSound}">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition />
                                                 <ColumnDefinition Width="Auto" />
@@ -305,11 +428,13 @@
                                                 <RowDefinition Height="Auto" />
                                                 <RowDefinition Height="Auto" />
                                             </Grid.RowDefinitions>
+
                                             <!-- 默认启用 -->
                                             <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" 
                                                       Content="默认启用"
                                                       IsChecked="{Binding SettingsService.Settings.IsNotificationSoundEnabled}"
                                                       Margin="0 0 0 6" />
+
                                             <!-- 音效音量 -->
                                             <TextBlock Grid.Row="1" Grid.Column="0"
                                                        Text="音效音量"
@@ -324,6 +449,7 @@
                                                     AutoToolTipPrecision="2"
                                                     IsSnapToTickEnabled="True" 
                                                     />
+
                                             <!-- 自定义音效 -->
                                             <controls2:SettingsControl Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" 
                                                                        IconGlyph="FileMusicOutline" Header="自定义音效"
@@ -333,7 +459,8 @@
                                                     <StackPanel Orientation="Horizontal"
                                                                 HorizontalAlignment="Right"
                                                                 VerticalAlignment="Center">
-                                                        <TextBox MinWidth="150" MaxWidth="150"
+                                                        <TextBox MinWidth="150"
+                                                                 MaxWidth="150"
                                                                  materialDesign:HintAssist.Hint="（默认音效）"
                                                                  Text="{Binding SettingsService.Settings.NotificationSoundPath}"
                                                                  VerticalAlignment="Center"
@@ -348,6 +475,7 @@
                                         </Grid>
                                     </Expander>
                                 </materialDesign:Card>
+
                                 <!-- 置顶提醒 -->
                                 <materialDesign:Card Margin="0 6 0 0">
                                     <Expander Background="Transparent"
@@ -374,10 +502,9 @@
                         </ScrollViewer>
                     </TabItem>
                 </TabControl>
-
-                <!--<TextBlock Grid.Row="1" Text="{Binding ViewModel.NotificationSettingsSelectedProvider}"></TextBlock>-->
             </Grid>
         </controls1:ListDetailView.LeftContent>
+
         <controls1:ListDetailView.RightContent>
             <!-- 提醒详细信息 -->
             <Grid>
@@ -385,17 +512,15 @@
                     <Grid.Style>
                         <Style TargetType="Grid">
                             <Style.Triggers>
-                                <DataTrigger
-                                    Binding="{Binding ViewModel.NotificationSettingsSelectedProvider, Mode=TwoWay}"
-                                    Value="{x:Null}">
+                                <DataTrigger Binding="{Binding ViewModel.NotificationSettingsSelectedProvider, Mode=TwoWay}"
+                                             Value="{x:Null}">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Grid.Style>
-                    <Grid
-                        DataContext="{Binding ViewModel.NotificationSettingsSelectedProvider, Converter={StaticResource GuidToNotificationProviderConverter}, Mode=OneWay}"
-                        d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}">
+                    <Grid DataContext="{Binding ViewModel.NotificationSettingsSelectedProvider, Converter={StaticResource GuidToNotificationProviderConverter}, Mode=OneWay}"
+                          d:DataContext="{d:DesignInstance notification:NotificationProviderRegisterInfo}">
                         <ContentPresenter ClipToBounds="True"
                                           Margin="0 48 0 0"
                                           Content="{Binding ProviderInstance.SettingsElement}" />
@@ -417,9 +542,8 @@
                                        Margin="0 8 0 0" />
                         </StackPanel>
 
-                        <Expander
-                            VerticalAlignment="Top"
-                            Background="{DynamicResource MaterialDesignPaper}">
+                        <Expander VerticalAlignment="Top"
+                                  Background="{DynamicResource MaterialDesignPaper}">
                             <Expander.Header>
                                 <StackPanel Orientation="Horizontal">
                                     <ToggleButton Margin="0 0 4 0"
@@ -432,12 +556,14 @@
                                             IsEnabled="{Binding ProviderSettings.IsSettingsEnabled}">
                                     <TextBlock Text="此处的设置将覆盖全局设置和提醒请求中要求的设置。" Margin="2 4"
                                                Visibility="{Binding ProviderSettings.IsSettingsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    
                                     <!-- 启用提醒语音 -->
                                     <controls2:SettingsCard IconGlyph="TextToSpeech"
                                                             Foreground="{DynamicResource MaterialDesignBody}"
                                                             Header="启用提醒语音"
                                                             Description="在发出提醒时用语音播报提醒内容。"
                                                             IsOn="{Binding ProviderSettings.IsSpeechEnabled, Mode=TwoWay}" />
+                                    
                                     <!-- 启用提醒强调特效 -->
                                     <controls2:SettingsCard IconGlyph="LayersOutline"
                                                             Margin="0 6 0 0"
@@ -446,6 +572,7 @@
                                                             IsEnabled="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Converter={StaticResource InvertBooleanConverter}, RelativeSource={RelativeSource FindAncestor, AncestorType=local:NotificationSettingsPage}}"
                                                             Description="启用后，发出提醒时会播放全屏强调特效。"
                                                             IsOn="{Binding ProviderSettings.IsNotificationEffectEnabled, Mode=TwoWay}" />
+                                    
                                     <!-- 启用提醒音效 -->
                                     <materialDesign:Card Margin="0 6 0 0">
                                         <Expander Background="Transparent"
@@ -462,7 +589,7 @@
                                             <StackPanel Margin="36 0 48 12"
                                                         IsEnabled="{Binding ProviderSettings.IsNotificationSoundEnabled}">
                                                 <!-- 自定义音效 -->
-                                                <controls2:SettingsControl
+                                                <ccontrols2:SettingsControl
                                                     IconGlyph="FileMusicOutline" Header="自定义音效"
                                                     Foreground="{DynamicResource MaterialDesignBody}"
                                                     Description="设置自定义音效，留空以禁用。如果音效长于提醒显示时间，多出来的部分会被截断。">

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -269,7 +269,7 @@
                                                              Margin="0 4" Width="200" />
                                                 </StackPanel>
                                                     
-                                                <!-- 提示语言 -->
+                                                <!-- 参考音频语言 -->
                                                 <StackPanel Orientation="Horizontal" Margin="0 2">
                                                     <TextBlock Text="参考音频语言：" Width="150" VerticalAlignment="Center" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
@@ -290,7 +290,7 @@
                                                              Margin="0 4" Width="200" />
                                                 </StackPanel>
 
-                                                <!-- 批量大小 -->
+                                                <!-- 并发数 -->
                                                 <StackPanel Orientation="Horizontal" Margin="0 2">
                                                     <TextBlock Text="并发数：" Width="150" VerticalAlignment="Center" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSBatchSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
@@ -316,13 +316,13 @@
                                                         AutoToolTipPrecision="2"
                                                         Width="150" />
                                             </StackPanel>
-
+                                            
                                             <!-- 测试朗读文本和测试语音功能 -->
                                             <TextBox Grid.Row="4" Grid.Column="0"
                                                      Grid.ColumnSpan="2"
                                                      Margin="0 6 0 0"
                                                      Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                                                     materialDesign:HintAssist.Hint="测试朗读文本"
+                                                     materialDesign:HintAssist.Hint="朗读测试文本"
                                                      Text="{Binding ViewModel.TestSpeechText}" />
                                             
                                             <WrapPanel Grid.Row="5" Grid.Column="0"

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -589,7 +589,7 @@
                                             <StackPanel Margin="36 0 48 12"
                                                         IsEnabled="{Binding ProviderSettings.IsNotificationSoundEnabled}">
                                                 <!-- 自定义音效 -->
-                                                <ccontrols2:SettingsControl
+                                                <controls2:SettingsControl
                                                     IconGlyph="FileMusicOutline" Header="自定义音效"
                                                     Foreground="{DynamicResource MaterialDesignBody}"
                                                     Description="设置自定义音效，留空以禁用。如果音效长于提醒显示时间，多出来的部分会被截断。">

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -278,9 +278,9 @@
 
                                                 <!-- 提示文本 -->
                                                 <StackPanel Orientation="Vertical" Margin="0 2">
-                                                    <TextBlock Text="参考音频文本：" Width="150" VerticalAlignment="Top" />
+                                                    <TextBlock Text="参考音频文本：" Width="150" VerticalAlignment="Stretch" HorizontalAlignment="Left" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Stretch" />
                                                 </StackPanel>
 
                                                 <!-- 文本分割方法 -->
@@ -303,11 +303,11 @@
                                             <!-- 语音音量 -->
                                             <TextBlock Grid.Row="3" Grid.Column="0" Text="语音音量"
                                                        VerticalAlignment="Center"
-                                                       Margin="0 6 0 0" />
+                                                       Margin="0 6 0 6" />
                                             <StackPanel Grid.Row="3" Grid.Column="1"
                                                         Orientation="Horizontal"
                                                         HorizontalAlignment="Right"
-                                                        Margin="0 6 0 0"
+                                                        Margin="0 6 0 6"
                                                         VerticalAlignment="Center">
                                                 <Slider Minimum="0" Maximum="1"
                                                         Value="{Binding SettingsService.Settings.SpeechVolume}"

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -183,7 +183,7 @@
                                                                  IsEnabled="{Binding SettingsService.Settings.IsSystemSpeechSystemExist}" />
                                                     <ListBoxItem Content="Edge TTS"
                                                                  IsEnabled="{Binding SettingsService.Settings.IsNetworkConnect, Mode=TwoWay}" />
-                                                    <ListBoxItem Content="GPTSoVITS" />
+                                                    <ListBoxItem Content="GPT-SoVITS" />
                                                 </ListBox>
                                             </StackPanel>
 
@@ -232,7 +232,7 @@
                                                 </StackPanel.Style>
                                                 
                                                 <!-- GPTSoVITS 设置 -->
-                                                <TextBlock Text="GPTSoVITS 设置" FontWeight="Bold" FontSize="16" Margin="0 0 0 4"/>
+                                                <TextBlock Text="GPT-SoVITS 设置" FontWeight="Bold" FontSize="16" Margin="0 0 0 4"/>
 
                                                 <!-- 服务器 IP -->
                                                 <StackPanel Orientation="Horizontal" Margin="0 2">
@@ -271,14 +271,14 @@
                                                     
                                                 <!-- 提示语言 -->
                                                 <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="提示语言：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBlock Text="参考音频语言：" Width="150" VerticalAlignment="Center" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                                              Margin="0 4" Width="200" />
                                                 </StackPanel>
 
                                                 <!-- 提示文本 -->
                                                 <StackPanel Orientation="Vertical" Margin="0 2">
-                                                    <TextBlock Text="提示文本：" Width="150" VerticalAlignment="Top" />
+                                                    <TextBlock Text="参考音频文本：" Width="150" VerticalAlignment="Top" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                                              Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
                                                 </StackPanel>
@@ -292,33 +292,12 @@
 
                                                 <!-- 批量大小 -->
                                                 <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="批量大小：" Width="150" VerticalAlignment="Center" />
+                                                    <TextBlock Text="并发数：" Width="150" VerticalAlignment="Center" />
                                                     <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSBatchSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                                              Margin="0 4" Width="200" />
                                                 </StackPanel>
 
-                                                <!-- 测试朗读文本 -->
-                                                <StackPanel Orientation="Vertical" Margin="0 2">
-                                                    <TextBlock Text="测试朗读文本：" Width="150" VerticalAlignment="Top" />
-                                                    <TextBox Text="{Binding ViewModel.TestSpeechTextGPTSoVITS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
-                                                </StackPanel>
 
-                                                <!-- 测试语音和打开设置按钮 -->
-                                                <WrapPanel Margin="0 6 0 0">
-                                                    <Button Click="ButtonTestSpeechingGPTSoVITS_OnClick"
-                                                            HorizontalAlignment="Left"
-                                                            Style="{StaticResource MaterialDesignFlatButton}">
-                                                        <controls2:IconText Kind="Play"
-                                                                            Text="测试语音" />
-                                                    </Button>
-                                                    <Button Click="ButtonOpenSpeechSettingsGPTSoVITS_OnClick"
-                                                            HorizontalAlignment="Left"
-                                                            Style="{StaticResource MaterialDesignFlatButton}">
-                                                        <controls2:IconText Kind="ExternalLink"
-                                                                            Text="GPTSoVITS设置" />
-                                                    </Button>
-                                                </WrapPanel>
                                             </StackPanel>
 
                                             <!-- 语音音量 -->
@@ -354,12 +333,6 @@
                                                         Style="{StaticResource MaterialDesignFlatButton}">
                                                     <controls2:IconText Kind="Play"
                                                                         Text="测试语音" />
-                                                </Button>
-                                                <Button Click="ButtonOpenSpeechSettings_OnClick"
-                                                        HorizontalAlignment="Left"
-                                                        Style="{StaticResource MaterialDesignFlatButton}">
-                                                    <controls2:IconText Kind="ExternalLink"
-                                                                        Text="系统文本转语音设置" />
                                                 </Button>
                                             </WrapPanel>
                                         </Grid>

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml
@@ -176,15 +176,14 @@
                                                         Orientation="Horizontal"
                                                         HorizontalAlignment="Right"
                                                         VerticalAlignment="Center">
-                                                <ListBox Style="{StaticResource MaterialDesignChoiceChipPrimaryOutlineListBox}"
-                                                         SelectedIndex="{Binding SettingsService.Settings.SpeechSource}"
-                                                         Width="200">
-                                                    <ListBoxItem Content="系统TTS"
-                                                                 IsEnabled="{Binding SettingsService.Settings.IsSystemSpeechSystemExist}" />
-                                                    <ListBoxItem Content="Edge TTS"
-                                                                 IsEnabled="{Binding SettingsService.Settings.IsNetworkConnect, Mode=TwoWay}" />
-                                                    <ListBoxItem Content="GPT-SoVITS" />
-                                                </ListBox>
+                                                <ComboBox SelectedIndex="{Binding SettingsService.Settings.SpeechSource}"
+                                                         >
+                                                    <ComboBoxItem Content="系统TTS"
+                                                                  IsEnabled="{Binding SettingsService.Settings.IsSystemSpeechSystemExist}" />
+                                                    <ComboBoxItem Content="Edge TTS"
+                                                                  IsEnabled="{Binding SettingsService.Settings.IsNetworkConnect, Mode=TwoWay}" />
+                                                    <ComboBoxItem Content="GPT-SoVITS" />
+                                                </ComboBox>
                                             </StackPanel>
 
                                             <!-- Edge TTS 相关设置，仅在选择 Edge TTS 时显示 -->
@@ -206,8 +205,7 @@
                                                           materialDesign:HintAssist.Hint="EdgeTTS说话人"
                                                           SelectedValuePath="ShortName"
                                                           SelectedValue="{Binding SettingsService.Settings.EdgeTtsVoiceName}"
-                                                          ItemsSource="{Binding ViewModel.EdgeVoices}"
-                                                          Width="200">
+                                                          ItemsSource="{Binding ViewModel.EdgeVoices}">
                                                     <ComboBox.ItemTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding FriendlyName}" />
@@ -217,7 +215,7 @@
                                             </StackPanel>
 
                                             <!-- GPTSoVITS 相关设置，仅在选择 GPTSoVITS 时显示 -->
-                                            <StackPanel Grid.Row="3" Grid.Column="0"
+                                            <StackPanel Grid.Row="2" Grid.Column="0"
                                                         Grid.ColumnSpan="2" Margin="0 6 0 6">
                                                 <StackPanel.Style>
                                                     <Style TargetType="StackPanel">
@@ -230,76 +228,71 @@
                                                         </Style.Triggers>
                                                     </Style>
                                                 </StackPanel.Style>
-                                                
-                                                <!-- GPTSoVITS 设置 -->
-                                                <TextBlock Text="GPT-SoVITS 设置" FontWeight="Bold" FontSize="16" Margin="0 0 0 4"/>
 
                                                 <!-- 服务器 IP -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="服务器 IP：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSServerIP, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSServerIP, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="服务器 IP"/>
 
                                                 <!-- 服务器端口 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="服务器端口：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="服务器端口"/>
 
                                                 <!-- 语音名称 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="语音名称：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSVoiceName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSVoiceName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="语音名称"/>
 
                                                 <!-- 文本语言 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="文本语言：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSTextLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSTextLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="文本语言"/>
 
                                                 <!-- 参考音频路径 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="参考音频路径：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSRefAudioPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSRefAudioPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="参考音频路径"/>
                                                     
                                                 <!-- 参考音频语言 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="参考音频语言：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptLang, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="参考音频语言"/>
 
-                                                <!-- 提示文本 -->
-                                                <StackPanel Orientation="Vertical" Margin="0 2">
-                                                    <TextBlock Text="参考音频文本：" Width="150" VerticalAlignment="Stretch" HorizontalAlignment="Left" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="350" Height="60" TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Stretch" />
-                                                </StackPanel>
+                                                <!-- 参考音频文本 -->
+                                                <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSPromptText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                                         Margin="0 4 0 0" 
+                                                         TextWrapping="Wrap"
+                                                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                         materialDesign:HintAssist.Hint="参考音频文本"/>
 
-                                                <!-- 文本分割方法 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="文本分割方法：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSTextSplitMethod, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
+                                                <Expander Background="{x:Null}"
+                                                          Margin="0 6 0 0"
+                                                          materialDesign:ExpanderAssist.VerticalHeaderPadding="2"
+                                                          materialDesign:ExpanderAssist.HorizontalHeaderPadding="0"
+                                                          Header="高级选项">
+                                                    <StackPanel>
+                                                        <!-- 文本分割方法 -->
+                                                        <TextBox
+                                                            Text="{Binding SettingsService.Settings.GPTSoVITSTextSplitMethod, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                            Margin="0 4 0 0"
+                                                            Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                            materialDesign:HintAssist.Hint="文本分割方法" />
 
-                                                <!-- 并发数 -->
-                                                <StackPanel Orientation="Horizontal" Margin="0 2">
-                                                    <TextBlock Text="并发数：" Width="150" VerticalAlignment="Center" />
-                                                    <TextBox Text="{Binding SettingsService.Settings.GPTSoVITSBatchSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                                                             Margin="0 4" Width="200" />
-                                                </StackPanel>
-
-
+                                                        <!-- 并发数 -->
+                                                        <TextBox
+                                                            Text="{Binding SettingsService.Settings.GPTSoVITSBatchSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                            Margin="0 4 0 0"
+                                                            Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                                                            materialDesign:HintAssist.Hint="并发数" />
+                                                    </StackPanel></Expander>
                                             </StackPanel>
-
                                             <!-- 语音音量 -->
                                             <TextBlock Grid.Row="3" Grid.Column="0" Text="语音音量"
                                                        VerticalAlignment="Center"
@@ -322,9 +315,9 @@
                                                      Grid.ColumnSpan="2"
                                                      Margin="0 6 0 0"
                                                      Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                                                     materialDesign:HintAssist.Hint="朗读测试文本"
+                                                     materialDesign:HintAssist.Hint="测试朗读文本"
                                                      Text="{Binding ViewModel.TestSpeechText}" />
-                                            
+
                                             <WrapPanel Grid.Row="5" Grid.Column="0"
                                                        Grid.ColumnSpan="2"
                                                        Margin="0 6 0 0">
@@ -333,6 +326,12 @@
                                                         Style="{StaticResource MaterialDesignFlatButton}">
                                                     <controls2:IconText Kind="Play"
                                                                         Text="测试语音" />
+                                                </Button>
+                                                <Button Click="ButtonOpenSpeechSettings_OnClick"
+                                                        HorizontalAlignment="Left"
+                                                        Style="{StaticResource MaterialDesignFlatButton}">
+                                                    <controls2:IconText Kind="ExternalLink"
+                                                                        Text="系统文本转语音设置" />
                                                 </Button>
                                             </WrapPanel>
                                         </Grid>

--- a/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml.cs
+++ b/ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml.cs
@@ -92,4 +92,25 @@ public partial class NotificationSettingsPage : SettingsPageBase
     {
         Process.Start(@"C:\WINDOWS\system32\rundll32.exe", @"shell32.dll,Control_RunDLL C:\WINDOWS\system32\Speech\SpeechUX\sapi.cpl");
     }
+
+     // 新增的 GPTSoVITS 测试语音按钮事件处理
+    private void ButtonTestSpeechingGPTSoVITS_OnClick(object sender, RoutedEventArgs e)
+    {
+        // 调用 GPTSoVITS 服务进行测试语音
+        // 确保 ViewModel 和 SpeechService 已正确配置
+        SpeechService.ClearSpeechQueue();
+        SpeechService.EnqueueSpeechQueue(ViewModel.TestSpeechTextGPTSoVITS);
+    }
+
+    // 新增的 GPTSoVITS 打开设置按钮事件处理
+    private void ButtonOpenSpeechSettingsGPTSoVITS_OnClick(object sender, RoutedEventArgs e)
+    {
+        // 打开 GPTSoVITS 的相关设置页面
+        // 请将 URL 替换为实际的 GPTSoVITS 设置页面地址
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "https://gptsovits.example.com/settings", // 替换为实际 URL
+            UseShellExecute = true
+        });
+    }
 }


### PR DESCRIPTION
Add GPT-SoVITS as backend of TTS Service
This pull request introduces a new speech service, GPTSoVITS, to the `ClassIsland` application. The changes include adding the new service, updating settings to accommodate the new service, and modifying the user interface to support the new settings.

### Addition of GPTSoVITS service:

* [`ClassIsland/App.xaml.cs`](diffhunk://#diff-04bee75167d5b1b384bdd1cf0d6c248f339b0f03b3e7746b57999b75f04224f6R364): Added `GPTSoVITSService` to the list of speech services.
* [`ClassIsland/Services/SpeechService/GPTSovitsService.cs`](diffhunk://#diff-f9f0a33562ff812081199e0e7efdcc7a2c6c3d019c1018fdf600299f17584386R1-R239): Implemented the `GPTSoVITSService` class, which includes methods for generating and playing speech using the GPTSoVITS service.

### Update to settings:

* [`ClassIsland/Models/Settings.cs`](diffhunk://#diff-d69b7bc39d7c8f14a68e012242879aef7ec31707d73dc11a7ef32280dfb0dcecR219-R359): Added new settings properties for configuring the GPTSoVITS service, such as server IP, port, voice name, and other related settings.

### User interface modifications:

* [`ClassIsland/ViewModels/SettingsPages/NotificationSettingsViewModel.cs`](diffhunk://#diff-f13b625b3ce53b08cfed12e61dfb0519f26486c833f33a941ae56b4a745c03bfL38-R193): Added properties for binding GPTSoVITS settings and test speech text in the view model.
* [`ClassIsland/Views/SettingPages/NotificationSettingsPage.xaml`](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R32-R43): Updated the UI to include new settings fields and controls for GPTSoVITS. [[1]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R32-R43) [[2]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R52-R71) [[3]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R81) [[4]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R94-R97) [[5]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713R116-R122) [[6]](diffhunk://#diff-58f3846619c2fa5dec1b257c8ecd3a8a4938929c611e89a6b243057b15be6713L124-R137)