### PR TITLE
修复应用设置导航栏排序、托盘菜单偏移

### DIFF
--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -650,6 +650,19 @@ public partial class MainWindow : Window
     {
         switch (ViewModel.Settings.TaskBarIconClickBehavior)
         {
+            case 0:
+                if (TaskBarIconService.MainTaskBarIcon.ContextMenu != null)
+                {
+                    GetCursorPos(out var ptr);
+                    if (PresentationSource.FromVisual(this) == null)
+                    {
+                        break;
+                    }
+                    GetCurrentDpi(out var dpiX, out var dpiY, TaskBarIconService.MainTaskBarIcon.ContextMenu);
+                    TaskBarIconService.MainTaskBarIcon.ShowContextMenu(new System.Drawing.Point((int)(ptr.X / dpiX), (int)
+                        (ptr.Y / dpiY)));
+                }
+                break;
             case 1:
                 OpenProfileSettingsWindow();
                 break;

--- a/ClassIsland/Services/TaskBarIconService.cs
+++ b/ClassIsland/Services/TaskBarIconService.cs
@@ -13,28 +13,6 @@ namespace ClassIsland.Services;
 
 public class TaskBarIconService : IHostedService, ITaskBarIconService
 {
-    private SettingsService SettingsService { get; }
-
-    public TaskBarIconService(SettingsService settingsService)
-    {
-        SettingsService = settingsService;
-        SettingsService.Settings.PropertyChanged += SettingsOnPropertyChanged;
-        UpdateMenuAction();
-    }
-
-    private void UpdateMenuAction()
-    {
-        MainTaskBarIcon.MenuActivation =
-            SettingsService.Settings.TaskBarIconClickBehavior == 0 ?
-            PopupActivationMode.LeftOrRightClick :
-            PopupActivationMode.RightClick;
-    }
-
-    private void SettingsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        UpdateMenuAction();
-    }
-
     public TaskbarIcon MainTaskBarIcon
     {
         get;
@@ -44,8 +22,8 @@ public class TaskBarIconService : IHostedService, ITaskBarIconService
         {
             BackgroundSource = new BitmapImage(new Uri("pack://application:,,,/ClassIsland;component/Assets/AppLogo.png", UriKind.Absolute)),
         },
-        ToolTipText = "ClassIsland",
-        NoLeftClickDelay = true,
+        MenuActivation = PopupActivationMode.RightClick,
+        ToolTipText = "ClassIsland"
     };
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/ClassIsland/Views/SettingsWindowNew.xaml
+++ b/ClassIsland/Views/SettingsWindowNew.xaml
@@ -130,7 +130,8 @@
 
         <CollectionViewSource x:Key="NavigationCollectionViewSource"
                               Source="{x:Static services:SettingsWindowRegistryService.Registered}"
-                              Filter="NavigationCollectionViewSource_OnFilter">
+                              Filter="NavigationCollectionViewSource_OnFilter"
+                              IsLiveFilteringRequested="True">
             <CollectionViewSource.GroupDescriptions>
                 <PropertyGroupDescription PropertyName="Category"/>
             </CollectionViewSource.GroupDescriptions>


### PR DESCRIPTION
<img src="https://i0.hdslb.com/bfs/new_dyn/a432a6210cf563930ae8060e35528644474730260.png" align="right" width=300/>

@wjj-8283 @LiPolymer 

#### 请求系统语言设置为英文，或安装了最新版 ExtraIsland 插件的同学协助测试：

应用设置的导航栏项目顺序不正常的问题是否修复。

需要留意「关于 ClassIsland」的位置是否处在「拓展设置页面」和「调试页面」之间。（如图）

---

#### 请求触屏使用者协助测试：

重启 ClassIsland 后，分别通过触摸轻点和长按方式首次打开托盘菜单，弹出位置是否会出现偏移现象。