### PR TITLE
feat: 添加 ⌈使用原始屏幕尺寸⌋ 选项；为主窗口增加一组变换，以便从插件使用；为天气组件界面提示增加圆角

### DIFF
--- a/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
+++ b/ClassIsland/Controls/Components/WeatherComponentSettingsControl.xaml
@@ -16,6 +16,7 @@
             <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
                 <materialDesign:ColorZone Background="#204169e1" 
                                           Panel.ZIndex="1" 
+                                          CornerRadius="4"
                                           Margin="0 0 0 5">
                     <Grid>
                         <DockPanel Margin="8 4">

--- a/ClassIsland/MainWindow.xaml
+++ b/ClassIsland/MainWindow.xaml
@@ -581,5 +581,9 @@
             <Run Text="{x:Static local:App.AppVersionLong}"/>
         </TextBlock>
 
+        <!-- Reserved transforms -->
+        <Grid.RenderTransform>
+            <TranslateTransform/>
+        </Grid.RenderTransform>
     </Grid>
 </Window>

--- a/ClassIsland/MainWindow.xaml
+++ b/ClassIsland/MainWindow.xaml
@@ -583,7 +583,12 @@
 
         <!-- Reserved transforms -->
         <Grid.RenderTransform>
-            <TranslateTransform/>
+            <TransformGroup>
+                <TranslateTransform/>
+                <ScaleTransform/>
+                <RotateTransform/>
+                <MatrixTransform/>
+            </TransformGroup>
         </Grid.RenderTransform>
     </Grid>
 </Window>

--- a/ClassIsland/MainWindow.xaml.cs
+++ b/ClassIsland/MainWindow.xaml.cs
@@ -49,7 +49,7 @@ using Linearstar.Windows.RawInput;
 using ProgressBar = System.Windows.Controls.ProgressBar;
 using WindowChrome = System.Windows.Shell.WindowChrome;
 using ClassIsland.Services.Management;
-
+using Point = System.Windows.Point;
 
 
 #if DEBUG
@@ -937,6 +937,8 @@ public partial class MainWindow : Window
             : Screen.PrimaryScreen;
         if (screen == null)
             return;
+        double offsetAreaTop = ViewModel.Settings.IsIgnoreWorkAreaEnabled ? screen.Bounds.Top : screen.WorkingArea.Top;
+        double offsetAreaBottom = ViewModel.Settings.IsIgnoreWorkAreaEnabled ? screen.Bounds.Bottom : screen.WorkingArea.Bottom;
         var aw = RenderSize.Width * dpiX;
         var ah = RenderSize.Height * dpiY;
         var c = (double)(screen.WorkingArea.Left + screen.WorkingArea.Right) / 2;
@@ -950,27 +952,27 @@ public partial class MainWindow : Window
         {
             case 0: //左上
                 //Left = (screen.WorkingArea.Left + ox) / dpiX;
-                Top = (screen.WorkingArea.Top + oy) / dpiY;
+                Top = (offsetAreaTop + oy) / dpiY;
                 break;
             case 1: // 中上
                 //Left = (c - aw / 2 + ox) / dpiX;
-                Top = (screen.WorkingArea.Top + oy) / dpiY;
+                Top = (offsetAreaTop + oy) / dpiY;
                 break;
             case 2: // 右上
                 //Left = (screen.WorkingArea.Right - aw + ox) / dpiX;
-                Top = (screen.WorkingArea.Top + oy) / dpiY;
+                Top = (offsetAreaTop + oy) / dpiY;
                 break;
             case 3: // 左下
                 //Left = (screen.WorkingArea.Left + ox) / dpiX;
-                Top = (screen.WorkingArea.Bottom - ah + oy) / dpiY;
+                Top = (offsetAreaBottom - ah + oy) / dpiY;
                 break;
             case 4: // 中下
                 //Left = (c - aw / 2 + ox) / dpiX;
-                Top = (screen.WorkingArea.Bottom - ah + oy) / dpiY;
+                Top = (offsetAreaBottom - ah + oy) / dpiY;
                 break;
             case 5: // 右下
                 //Left = (screen.WorkingArea.Right - aw + ox) / dpiX;
-                Top = (screen.WorkingArea.Bottom - ah + oy) / dpiY;
+                Top = (offsetAreaBottom - ah + oy) / dpiY;
                 break;
         }
 

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -1650,6 +1650,18 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         }
     }
 
+    bool _isIgnoreWorkAreaEnabled;
+    public bool IsIgnoreWorkAreaEnabled
+    {
+        get => _isIgnoreWorkAreaEnabled;
+        set
+        {
+            if (value == _isIgnoreWorkAreaEnabled) return;
+            _isIgnoreWorkAreaEnabled = value;
+            OnPropertyChanged();
+        }
+    }
+    
     public int WindowDockingOffsetX
     {
         get => _windowDockingOffsetX;

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.xaml
@@ -253,9 +253,16 @@
 
             <!-- 兼容透明模式 -->
             <ci:SettingsCard IconGlyph="CogOutline"
-                                   Header="兼容透明模式"
-                                   Description="若启用，应用将使用资源占用更高的备选方法（AllowTransparency）而非默认方法（WindowChrome）实现窗口透明，且不支持全屏提醒特效等功能。可能会解决叠加异常、黑底等部分显示问题。"
-                                   IsOn="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Mode=TwoWay}"
+                             Header="兼容透明模式"
+                             Description="若启用，应用将使用资源占用更高的备选方法（AllowTransparency）而非默认方法（WindowChrome）实现窗口透明，且不支持全屏提醒特效等功能。可能会解决叠加异常、黑底等部分显示问题。"
+                             IsOn="{Binding SettingsService.Settings.IsCompatibleWindowTransparentEnabled, Mode=TwoWay}"
+                             Margin="0 0 0 6" />
+            
+            <!-- 使用原始屏幕尺寸 -->
+            <ci:SettingsCard IconGlyph="DockWindow"
+                                   Header="使用原始屏幕尺寸"
+                                   Description="若启用，主界面调整位置时将忽略系统工作区设置（通常包括任务栏和部分顶栏应用）。"
+                                   IsOn="{Binding SettingsService.Settings.IsIgnoreWorkAreaEnabled, Mode=TwoWay}"
                                    Margin="0 0 0 6" />
 
             <!-- 指针穿透 --><!--


### PR DESCRIPTION
两个比较小的改动🤔(?
主要是ExtraIsland新功能实现的需要
> #### 关于 ⌈使用原始屏幕尺寸⌋ 选项
> 在注册 `MainWindow` 成为 `AppBar` 后,工作区改变, `MainWindow`遂偏离原计划位置
> 启用此选项时,由于直接使用屏幕尺寸进行计算,表现正常.
> 对本体,潜在的应用:于第三方AppBar软件上显示岛屿

已测试,不改变正常使用行为😋