### PR TITLE
fix:Retcode.proto 命名导致的 Python 关键字冲突问题 | 解决无法执行集控服务器的 DataUpdated 指令问题

### DIFF
--- a/ClassIsland.Shared/Protobuf/Enum/Retcode.proto
+++ b/ClassIsland.Shared/Protobuf/Enum/Retcode.proto
@@ -3,7 +3,7 @@ package ClassIsland.Shared.Protobuf.Enum;
 option csharp_namespace = "ClassIsland.Shared.Protobuf.Enum";
 
 enum Retcode {
-    None = 0;
+    Unspecified = 0; // None = 0;
     Success = 200;
     ServerInternalError = 500;
     InvalidRequest = 404;

--- a/ClassIsland/Services/Management/ManagementService.cs
+++ b/ClassIsland/Services/Management/ManagementService.cs
@@ -121,9 +121,17 @@ public class ManagementService : IManagementService
 
     private void ConnectionOnCommandReceived(object? sender, ClientCommandEventArgs e)
     {
-        if (e.Type == CommandTypes.RestartApp)
+        switch (e.Type)
         {
-            AppBase.Current.Restart(true);
+            case CommandTypes.RestartApp:
+            {
+                AppBase.Current.Restart(true);
+                break;
+            }
+            case CommandTypes.DataUpdated:
+                Logger.LogInformation("Received DataUpdated command.");
+                SetupManagement();
+                break;
         }
     }
 

--- a/ClassIsland/Services/Management/ManagementService.cs
+++ b/ClassIsland/Services/Management/ManagementService.cs
@@ -130,8 +130,8 @@ public class ManagementService : IManagementService
             }
             case CommandTypes.DataUpdated:
                 Logger.LogInformation("Received DataUpdated command.");
-                SetupManagement();
-                break;
+                ReloadManagementAsync();
+            break;
         }
     }
 
@@ -151,21 +151,30 @@ public class ManagementService : IManagementService
             SetupLocalManagement();
             return;
         }
-        
-        Logger.LogInformation("正在初始化集控");
-        // 读取集控清单
-        Manifest = LoadConfig<ManagementManifest>(ManagementManifestPath);
-        Policy = LoadConfig<ManagementPolicy>(ManagementPolicyPath);
-        Versions = LoadConfig<ManagementVersions>(ManagementVersionsPath);
 
+        Logger.LogInformation("正在初始化集控");
+
+        await ReloadManagementAsync();
+    }
+
+    public async Task ReloadManagementAsync()
+    {
+        Logger.LogInformation("正在重载集控配置");
         if (Connection == null)
         {
             return;
         }
 
+        //Load old config
+        ManagementManifest oldManifest = Manifest;
+        ManagementPolicy oldPolicy = Policy;
+        ManagementVersions oldVersions = Versions;
+
         try
         {
-            // 拉取集控清单
+            Manifest = LoadConfig<ManagementManifest>(ManagementManifestPath);
+            Policy = LoadConfig<ManagementPolicy>(ManagementPolicyPath);
+            Versions = LoadConfig<ManagementVersions>(ManagementVersionsPath);
             Manifest = await Connection.GetManifest();
             SaveConfig(ManagementManifestPath, Manifest);
             // 拉取策略
@@ -176,8 +185,14 @@ public class ManagementService : IManagementService
         }
         catch (Exception e)
         {
+            Manifest = oldManifest;
+            Policy = oldPolicy;
+            Versions = oldVersions;
             Logger.LogError(e, "拉取集控清单与策略失败");
+            return;
         }
+
+
     }
 
     public void SaveSettings()
@@ -227,6 +242,7 @@ public class ManagementService : IManagementService
         }
         SaveConfig(ManagementSettingsPath, w);
         CommonDialog.ShowInfo($"已加入组织 {mf.OrganizationName} 的管理。应用将重启以应用更改。");
+        await SetupManagement();
 
         AppBase.Current.Restart();
     }

--- a/ClassIsland/Services/Management/ManagementService.cs
+++ b/ClassIsland/Services/Management/ManagementService.cs
@@ -192,7 +192,6 @@ public class ManagementService : IManagementService
             return;
         }
 
-
     }
 
     public void SaveSettings()


### PR DESCRIPTION
变更 Retcode.proto 以规避 Python 关键字问题；

合并时注意考虑该变更对集控相关接口的影响，尽管已经对项目做了充分的检查；
考虑到 gRPC 传递的数据是对应的值，不予变更也可以正常运行，但可能导致 ClassIsland 的 Proto 更新时无法及时跟进的问题，请予以谨慎解决；

~~通过将 DataUpdated 指令定向到 SetupManagement() 以临时解决 DataUpdated 无法执行的问题，或者是否考虑使用更好的解决方案？~~