### PR TITLE
fix: 预警发布地点和遮罩显示不匹配的问题 #809

### DIFF
--- a/ClassIsland.Core/Models/Weather/WeatherAlert.cs
+++ b/ClassIsland.Core/Models/Weather/WeatherAlert.cs
@@ -19,4 +19,17 @@ public class WeatherAlert
         or "http://f5.market.xiaomi.com/download/Weather/06db501333e6d4075a3364a66cdf23ba5733111b3/a.webp" // 橙色预警默认图标
         or "http://f3.market.xiaomi.com/download/Weather/03e3e096d3d9e485fa33bbf833fc3b3c96c23d014/a.webp" // 红色预警默认图标
         ? 1 : 0;
+
+    public void TitleFix()
+    {
+        var publishIndex = Title.IndexOf("发布", StringComparison.Ordinal);
+        if (publishIndex > 0)
+        {
+            Title = Title.Substring(publishIndex + 2);
+        }
+
+        var detailEndIndex = Detail.IndexOf("气象", StringComparison.Ordinal);
+        var detailPart = detailEndIndex > 0 ? Detail.Substring(0, detailEndIndex) : Detail;
+        Title = $"{detailPart}发布{Title}";
+    }
 }

--- a/ClassIsland.Core/Models/Weather/WeatherAlert.cs
+++ b/ClassIsland.Core/Models/Weather/WeatherAlert.cs
@@ -19,17 +19,4 @@ public class WeatherAlert
         or "http://f5.market.xiaomi.com/download/Weather/06db501333e6d4075a3364a66cdf23ba5733111b3/a.webp" // 橙色预警默认图标
         or "http://f3.market.xiaomi.com/download/Weather/03e3e096d3d9e485fa33bbf833fc3b3c96c23d014/a.webp" // 红色预警默认图标
         ? 1 : 0;
-
-    public void TitleFix()
-    {
-        var publishIndex = Title.IndexOf("发布", StringComparison.Ordinal);
-        if (publishIndex > 0)
-        {
-            Title = Title.Substring(publishIndex + 2);
-        }
-
-        var detailEndIndex = Detail.IndexOf("气象", StringComparison.Ordinal);
-        var detailPart = detailEndIndex > 0 ? Detail.Substring(0, detailEndIndex) : Detail;
-        Title = $"{detailPart}发布{Title}";
-    }
 }

--- a/ClassIsland/Services/NotificationProviders/WeatherNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/WeatherNotificationProvider.cs
@@ -182,7 +182,18 @@ public class WeatherNotificationProvider : INotificationProvider, IHostedService
             if (t >= 90) t = 90.0;
             var ts = TimeSpan.FromSeconds(t);
             IAppHost.GetService<ILogger<WeatherNotificationProvider>>().LogTrace("单次预警显示时长：{}", ts);
-            i.TitleFix();
+
+            // TitleFix logic moved here
+            var publishIndex = i.Title.IndexOf("发布", StringComparison.Ordinal);
+            if (publishIndex > 0)
+            {
+                i.Title = i.Title.Substring(publishIndex + 2);
+            }
+
+            var detailEndIndex = i.Detail.IndexOf("气象", StringComparison.Ordinal);
+            var detailPart = detailEndIndex > 0 ? i.Detail.Substring(0, detailEndIndex) : i.Detail;
+            i.Title = $"{detailPart}发布{i.Title}";
+
             NotificationHostService.ShowNotification(new NotificationRequest()
             {
                 MaskContent = new WeatherNotificationProviderControl(true, i, ts),

--- a/ClassIsland/Services/NotificationProviders/WeatherNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/WeatherNotificationProvider.cs
@@ -182,6 +182,7 @@ public class WeatherNotificationProvider : INotificationProvider, IHostedService
             if (t >= 90) t = 90.0;
             var ts = TimeSpan.FromSeconds(t);
             IAppHost.GetService<ILogger<WeatherNotificationProvider>>().LogTrace("单次预警显示时长：{}", ts);
+            i.TitleFix();
             NotificationHostService.ShowNotification(new NotificationRequest()
             {
                 MaskContent = new WeatherNotificationProviderControl(true, i, ts),
@@ -203,3 +204,4 @@ public class WeatherNotificationProvider : INotificationProvider, IHostedService
     {
     }
 }
+

--- a/ClassIsland/Services/WeatherService.cs
+++ b/ClassIsland/Services/WeatherService.cs
@@ -134,6 +134,21 @@ public class WeatherService : IHostedService, IWeatherService
             var info = await WebRequestHelper.GetJson<WeatherInfo>(new Uri(uri));
             info.Alerts.RemoveAll(i => Settings.ExcludedWeatherAlerts.FirstOrDefault(x =>
                 (!string.IsNullOrWhiteSpace(x)) && i.Title.Contains(x)) != null);
+            
+            // Apply TitleFix logic to each alert
+            foreach (var alert in info.Alerts)
+            {
+                var publishIndex = alert.Title.IndexOf("发布", StringComparison.Ordinal);
+                if (publishIndex > 0)
+                {
+                    alert.Title = alert.Title.Substring(publishIndex + 2);
+                }
+
+                var detailEndIndex = alert.Detail.IndexOf("气象", StringComparison.Ordinal);
+                var detailPart = detailEndIndex > 0 ? alert.Detail.Substring(0, detailEndIndex) : alert.Detail;
+                alert.Title = $"{detailPart}发布{alert.Title}";
+            }
+
             Settings.LastWeatherInfo = info;
             IsWeatherRefreshed = true;
         }
@@ -195,3 +210,4 @@ public class WeatherService : IHostedService, IWeatherService
     {
     }
 }
+


### PR DESCRIPTION
修复 #809 的问题。

不是很会写啊 果然看书学习理论和实际不太一样

![image](https://github.com/user-attachments/assets/552f6173-0b58-4e18-82dd-0f96055a6e6b)

~诚惶诚恐的开了PR，在没解决之前还是草案吧先（）~ 解决了