### PR TITLE
feat: 优化户外课程默认提示语文本表述

### DIFF
--- a/ClassIsland/Models/AttachedSettings/ClassNotificationAttachedSettings.cs
+++ b/ClassIsland/Models/AttachedSettings/ClassNotificationAttachedSettings.cs
@@ -12,7 +12,7 @@ public class ClassNotificationAttachedSettings : ObservableRecipient, IAttachedS
     private int _classPreparingDeltaTime = 60;
     private string _classOnPreparingText = "准备上课，请回到座位并保持安静，做好上课准备。";
     private bool _isAttachSettingsEnabled;
-    private string _outdoorClassOnPreparingText = "下节课程为户外课程，请合理规划，做好上课准备。";
+    private string _outdoorClassOnPreparingText = "下节课程为户外课程，请合理规划时间，做好上课准备。";
     private string _classOnPreparingMaskText = "即将上课";
     private string _outdoorClassOnPreparingMaskText = "即将上课";
     private string _classOnMaskText = "上课";

--- a/ClassIsland/Models/NotificationProviderSettings/ClassNotificationSettings.cs
+++ b/ClassIsland/Models/NotificationProviderSettings/ClassNotificationSettings.cs
@@ -10,7 +10,7 @@ public class ClassNotificationSettings : ObservableRecipient, IClassNotification
     private int _inDoorClassPreparingDeltaTime = 60;
     private int _outDoorClassPreparingDeltaTime = 600;
     private string _classOnPreparingText = "准备上课，请回到座位并保持安静，做好上课准备。";
-    private string _outdoorClassOnPreparingText = "下节课程为户外课程，请合理规划，做好上课准备。";
+    private string _outdoorClassOnPreparingText = "下节课程为户外课程，请合理规划时间，做好上课准备。";
     private bool _isSpeechEnabledOnClassPreparing = true;
     private bool _isSpeechEnabledOnClassOn = true;
     private bool _isSpeechEnabledOnClassOff = true;


### PR DESCRIPTION
将`outdoorClassOnPreparingText`的默认提示语进行修改
下节课程为户外课程，请合理规划，做好上课准备。 -> 下节课程为户外课程，请合理规划时间，做好上课准备。

该 PR 提交到 `dev` 分支