### PR TITLE
引入对教师复姓处理的增强，改进通知中语音内容的格式

### DIFF
--- a/ClassIsland.Shared/Models/Profile/Subject.cs
+++ b/ClassIsland.Shared/Models/Profile/Subject.cs
@@ -11,6 +11,7 @@ public class Subject : AttachableSettingsObject
     private string _initial = "";
     private string _teacherName = "";
     private bool _isOutDoor = false;
+    private static readonly HashSet<string> commonCompoundSurnames = new() { "万俟", "司马", "上官", "欧阳", "夏侯", "诸葛", "闻人", "东方", "赫连", "皇甫", "尉迟", "公羊", "澹台", "公冶", "宗政", "濮阳", "淳于", "单于", "太叔", "申屠", "公孙", "仲孙", "轩辕", "令狐", "钟离", "宇文", "长孙", "慕容", "鲜于", "闾丘", "司徒", "司空", "亓官", "司寇", "子车", "颛孙", "端木", "巫马", "公西", "漆雕", "乐正", "壤驷", "公良", "拓跋", "夹谷", "宰父", "谷梁", "段干", "百里", "东郭", "南门", "呼延", "羊舌", "微生", "梁丘", "左丘", "东门", "西门", "南宫", "第五" };
 
     /// <summary>
     /// 科目名
@@ -87,7 +88,7 @@ public class Subject : AttachableSettingsObject
         Initial = "休",
         Name = "课间休息"
     };
-    
+
     /// <summary>
     /// 获取当前科目任课老师姓名的姓氏，如果没有填写任课老师信息，则返回空字符串。
     /// </summary>
@@ -104,6 +105,16 @@ public class Subject : AttachableSettingsObject
 
         if (containsChinese)
         {
+            // 中文姓名，处理复姓
+            if (TeacherName.Length >= 2)
+            {
+                var teacherSurname = TeacherName.Substring(0, 2);
+                if (commonCompoundSurnames.Contains(teacherSurname))
+                {
+                    return teacherSurname;
+                }
+            }
+
             // 中文姓名，假设姓氏为第一个字符
             if (TeacherName.Length >= 1) return TeacherName.Substring(0, 1);
         }

--- a/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
+++ b/ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs
@@ -151,7 +151,7 @@ public class ClassNotificationProvider : NotificationProviderBase<ClassNotificat
                 ShowTeacherName = Settings.ShowTeacherName
             })
             {
-                SpeechContent = $"{message} 下节课是：{LessonsService.NextClassSubject.Name} {(Settings.ShowTeacherName ? FormatTeacher(LessonsService.NextClassSubject) : "")}。",
+                SpeechContent = $"{message} 下节课是：{LessonsService.NextClassSubject.Name}{(Settings.ShowTeacherName ? $"，{FormatTeacher(LessonsService.NextClassSubject)}" : "")}。",
                 EndTime = DateTimeToCurrentDateTimeConverter.Convert(LessonsService.NextClassTimeLayoutItem.StartSecond),
                 IsSpeechEnabled = Settings.IsSpeechEnabledOnClassPreparing
             },
@@ -217,7 +217,7 @@ public class ClassNotificationProvider : NotificationProviderBase<ClassNotificat
             })
             {
                 Duration = showOverlayText ? TimeSpan.FromSeconds(20) : TimeSpan.FromSeconds(10),
-                SpeechContent = $"本节{LessonsService.CurrentTimeLayoutItem.BreakNameText}常{TimeSpanFormatHelper.Format(LessonsService.CurrentTimeLayoutItem.Last)}，下节课是：{LessonsService.NextClassSubject.Name} {(Settings.ShowTeacherName ? FormatTeacher(LessonsService.NextClassSubject) : "")}。{overlayText}",
+                SpeechContent = $"本节{LessonsService.CurrentTimeLayoutItem.BreakNameText}常{TimeSpanFormatHelper.Format(LessonsService.CurrentTimeLayoutItem.Last)}，下节课是：{LessonsService.NextClassSubject.Name}{(Settings.ShowTeacherName ? $"，{FormatTeacher(LessonsService.NextClassSubject)}" : "")}。{overlayText}",
                 IsSpeechEnabled = Settings.IsSpeechEnabledOnClassOff
             }
         });


### PR DESCRIPTION
此拉取请求引入了对教师复姓处理的增强，并改进了通知中语音内容的格式。这些更改提升了功能性和用户体验。

### 对姓名处理的增强：

* 在 `Subject` 类中新增了一个静态 `HashSet`，包含常见的中文复姓，以支持准确提取具有复姓的教师的姓氏。(`ClassIsland.Shared/Models/Profile/Subject.cs`, [ClassIsland.Shared/Models/Profile/Subject.csR14](diffhunk://#diff-c365b93ed61eabe97c7e96384541aff7f63358f544cac73741468945f929b10dR14))
* 更新了 `GetFirstName` 方法，在处理中文姓名时检查复姓匹配，若匹配则返回完整的复姓。(`ClassIsland.Shared/Models/Profile/Subject.cs`, [ClassIsland.Shared/Models/Profile/Subject.csR108-R115](diffhunk://#diff-c365b93ed61eabe97c7e96384541aff7f63358f544cac73741468945f929b10dR108-R115))

### 对语音内容格式的改进：

* 调整了 `BuildNotificationRequest` 中的 `SpeechContent`，当启用 `ShowTeacherName` 时，在教师姓名前添加逗号以提高可读性。(`ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs`, [ClassIsland/Services/NotificationProviders/ClassNotificationProvider.csL154-R154](diffhunk://#diff-e39027d81197e8d303d8a1fed17387e2b364d0a5111d0f6d3297fc07da4767dfL154-R154))
* 对 `OnBreakingTime` 中的 `SpeechContent` 进行了类似调整，确保在提到下一节课和教师姓名的通知中格式一致。(`ClassIsland/Services/NotificationProviders/ClassNotificationProvider.cs`, [ClassIsland/Services/NotificationProviders/ClassNotificationProvider.csL220-R220](diffhunk://#diff-e39027d81197e8d303d8a1fed17387e2b364d0a5111d0f6d3297fc07da4767dfL220-R220))
