### PR TITLE
[2.0] feat: 自定义用户数据文件位置

### DIFF
--- a/ClassIsland/Models/ApplicationCommand.cs
+++ b/ClassIsland/Models/ApplicationCommand.cs
@@ -2,23 +2,11 @@ namespace ClassIsland.Models;
 
 public class ApplicationCommand
 {
-    public string? UpdateReplaceTarget
-    {
-        get;
-        set;
-    }
-    
-    public string? UpdateDeleteTarget
-    {
-        get;
-        set;
-    }
+    public string? UpdateReplaceTarget { get; set; }
 
-    public bool WaitMutex
-    {
-        get;
-        set;
-    } = false;
+    public string? UpdateDeleteTarget { get; set; }
+
+    public bool WaitMutex { get; set; } = false;
 
     public bool Quiet { get; set; } = false;
 
@@ -30,6 +18,8 @@ public class ApplicationCommand
 
     public string ExternalPluginPath { get; set; } = "";
 
+    public string? Userfile { get; set; } = null;
+
     public bool EnableSentryDebug { get; set; } = false;
 
     public bool Verbose { get; set; } = false;
@@ -39,5 +29,6 @@ public class ApplicationCommand
     public bool Recovery { get; set; } = false;
 
     public bool Diagnostic { get; set; } = false;
+    
     public bool Safe { get; set; } = false;
 }

--- a/ClassIsland/Program.cs
+++ b/ClassIsland/Program.cs
@@ -41,6 +41,7 @@ public static class Program
             new Option<bool>(["-prevSessionMemoryKilled", "-psmk"], "上个会话因MLE结束。"),
             new Option<bool>(["-disableManagement", "-dm"], "在本次会话禁用集控。"),
             new Option<string>(["-externalPluginPath", "-epp"], "外部插件路径"),
+            new Option<string>(["--userfile", "-uf"], "用户数据文件路径"),
             new Option<bool>(["--enableSentryDebug", "-esd"], "启用 Sentry 调试"),
             new Option<bool>(["--verbose", "-v"], "启用详细输出"),
             new Option<bool>(["--showOssWatermark", "-ossw"], "显示开源地址水印"),

--- a/ClassIsland/Services/AppUpdating/UpdateService.cs
+++ b/ClassIsland/Services/AppUpdating/UpdateService.cs
@@ -59,7 +59,7 @@ public class UpdateService : IHostedService, INotifyPropertyChanged
 #if IsMsix
         Path.Combine(ApplicationData.Current.TemporaryFolder.Path, "UpdateTemp");
 #else
-        Path.Combine(App.AppRootFolderPath, "UpdateTemp");
+        Path.Combine(App.AppUserFilePath, "UpdateTemp");
 #endif
 
     public VersionsIndex Index { get; set; }

--- a/ClassIsland/Services/DiagnosticService.cs
+++ b/ClassIsland/Services/DiagnosticService.cs
@@ -93,7 +93,7 @@ public class DiagnosticService(SettingsService settingsService, FileFolderServic
             var logs = string.Join('\n', AppLogService.Logs);
             //await File.WriteAllTextAsync(Path.Combine(temp, "Logs.log"), logs);
             await File.WriteAllTextAsync(Path.Combine(temp, "DiagnosticInfo.txt"), GetDiagnosticInfo());
-            File.Copy(Path.Combine(App.AppRootFolderPath, "Settings.json"), Path.Combine(temp, "Settings.json"));
+            File.Copy(Path.Combine(App.AppUserFilePath, "Settings.json"), Path.Combine(temp, "Settings.json"));
             var profile = App.GetService<IProfileService>().CurrentProfilePath;
             Directory.CreateDirectory(Path.Combine(temp, "Profiles/"));
             Directory.CreateDirectory(Path.Combine(temp, "Management/"));
@@ -103,7 +103,7 @@ public class DiagnosticService(SettingsService settingsService, FileFolderServic
             {
                 File.Copy(file, Path.Combine(temp, "Management/", Path.GetFileName(file)));
             }
-            File.Copy(Path.Combine(App.AppRootFolderPath, "./Profiles", profile), Path.Combine(temp, "Profiles/",  profile));
+            File.Copy(Path.Combine(App.AppUserFilePath, "./Profiles", profile), Path.Combine(temp, "Profiles/",  profile));
             FileFolderService.CopyFolder(Path.Combine(App.AppConfigPath), Path.Combine(temp, "Config/"));
             FileFolderService.CopyFolder(Path.Combine(App.AppLogFolderPath), Path.Combine(temp, "Logs/"));
 

--- a/ClassIsland/Services/FileFolderService.cs
+++ b/ClassIsland/Services/FileFolderService.cs
@@ -31,7 +31,7 @@ public class FileFolderService(SettingsService settingsService, ILogger<FileFold
         PluginService.PluginsRootPath,
         PluginService.PluginConfigsFolderPath,
         PluginService.PluginsIndexPath,
-        Path.Combine(App.AppRootFolderPath, "Backups"),
+        Path.Combine(App.AppUserFilePath, "Backups"),
         App.AppLogFolderPath,
         AutomationService.AutomationConfigsFolderPath,
         ManagementService.LocalManagementConfigureFolderPath,
@@ -95,7 +95,7 @@ public class FileFolderService(SettingsService settingsService, ILogger<FileFold
         await CreateBackupAsync(true);
         SettingsService.Settings.LastAutoBackupTime = DateTime.Now;
 
-        if (!Directory.Exists(Path.Combine(App.AppRootFolderPath, "Backups")))
+        if (!Directory.Exists(Path.Combine(App.AppUserFilePath, "Backups")))
         {
             return;
         }
@@ -104,7 +104,7 @@ public class FileFolderService(SettingsService settingsService, ILogger<FileFold
         {
             return;
         }
-        var outdatedBackups = Directory.EnumerateDirectories(Path.Combine(App.AppRootFolderPath, "Backups"), "Auto_*").OrderByDescending(Directory.GetLastWriteTime).Skip(SettingsService.Settings.AutoBackupLimit).ToList();
+        var outdatedBackups = Directory.EnumerateDirectories(Path.Combine(App.AppUserFilePath, "Backups"), "Auto_*").OrderByDescending(Directory.GetLastWriteTime).Skip(SettingsService.Settings.AutoBackupLimit).ToList();
         foreach (var i in outdatedBackups)
         {
             Directory.Delete(i, true);
@@ -122,7 +122,7 @@ public class FileFolderService(SettingsService settingsService, ILogger<FileFold
         [
             "Settings.json"
         ];
-        rootPath ??= App.AppRootFolderPath;
+        rootPath ??= App.AppUserFilePath;
         var backupFolder = Path.Combine(rootPath, "Backups/");
         var backupFilename = string.IsNullOrWhiteSpace(filename) ? $"Backup_{DateTime.Now:yy-MMM-dd_HH-mm-ss}.zip" : filename + ".zip";
         if (isAuto)

--- a/ClassIsland/Services/Management/ManagementService.cs
+++ b/ClassIsland/Services/Management/ManagementService.cs
@@ -36,7 +36,7 @@ public class ManagementService : IManagementService
 
     public static ManagementService? Instance { get; private set; }
 
-    public static readonly string ManagementPresetPath = Path.Combine(App.AppRootFolderPath, "./ManagementPreset.json");
+    public static readonly string ManagementPresetPath = Path.Combine(App.AppUserFilePath, "./ManagementPreset.json");
     public static readonly string ManagementConfigureFolderPath =
         Path.Combine(App.AppDataFolderPath, "Management");
     public static readonly string LocalManagementConfigureFolderPath =
@@ -246,7 +246,7 @@ public class ManagementService : IManagementService
         var w = CopyObject(settings);
         w.IsManagementEnabled = true;
         // 清空旧的配置
-        foreach (var i in new List<string>([ManagementManifestPath, ManagementPolicyPath, ManagementVersionsPath, ProfileService.ManagementClassPlanPath, ProfileService.ManagementSubjectsPath, ProfileService.ManagementTimeLayoutPath, Path.Combine(App.AppRootFolderPath, "./Profiles/_management-profile.json"), ManagementCredentialsPath]).Where(File.Exists))
+        foreach (var i in new List<string>([ManagementManifestPath, ManagementPolicyPath, ManagementVersionsPath, ProfileService.ManagementClassPlanPath, ProfileService.ManagementSubjectsPath, ProfileService.ManagementTimeLayoutPath, Path.Combine(App.AppUserFilePath, "./Profiles/_management-profile.json"), ManagementCredentialsPath]).Where(File.Exists))
         {
             File.Delete(i);
             if (File.Exists(i + ".bak"))

--- a/ClassIsland/Services/PluginService.cs
+++ b/ClassIsland/Services/PluginService.cs
@@ -27,7 +27,7 @@ namespace ClassIsland.Services;
 
 public class PluginService : IPluginService
 {
-    public static readonly string PluginsRootPath = Path.Combine(App.AppRootFolderPath, @"Plugins\");
+    public static readonly string PluginsRootPath = Path.Combine(App.AppUserFilePath, "Plugins");
 
     public static readonly string PluginsIndexPath = Path.Combine(App.AppConfigPath, "PluginsIndex");
 

--- a/ClassIsland/Services/ProfileService.cs
+++ b/ClassIsland/Services/ProfileService.cs
@@ -33,7 +33,7 @@ public class ProfileService : IProfileService, INotifyPropertyChanged
     public string CurrentProfilePath { 
         get; 
         set;
-    } = Path.Combine(App.AppRootFolderPath, @"Default.json");
+    } = Path.Combine(App.AppUserFilePath, "Default.json");
 
     public static readonly string ManagementClassPlanPath =
         Path.Combine(Management.ManagementService.ManagementConfigureFolderPath, "ClassPlans.json");
@@ -44,7 +44,7 @@ public class ProfileService : IProfileService, INotifyPropertyChanged
     public static readonly string ManagementSubjectsPath =
         Path.Combine(Management.ManagementService.ManagementConfigureFolderPath, "Subjects.json");
 
-    public static readonly string ProfilePath = Path.Combine(App.AppRootFolderPath, "Profiles");
+    public static readonly string ProfilePath = Path.Combine(App.AppUserFilePath, "Profiles");
 
     public Profile Profile {
         get;

--- a/ClassIsland/Services/SettingsService.cs
+++ b/ClassIsland/Services/SettingsService.cs
@@ -70,7 +70,7 @@ public class SettingsService(ILogger<SettingsService> Logger, IManagementService
         }
         try
         {
-            if (!File.Exists(Path.Combine(App.AppRootFolderPath, "Settings.json")))
+            if (!File.Exists(Path.Combine(App.AppUserFilePath, "Settings.json")))
             {
                 SkipMigration = true; // 如果是新的配置文件，那么就需要跳过迁移。
                 Logger.LogInformation("配置文件不存在，跳过加载。");
@@ -78,7 +78,7 @@ public class SettingsService(ILogger<SettingsService> Logger, IManagementService
             else
             {
                 Logger.LogInformation("加载配置文件。");
-                var r = ConfigureFileHelper.LoadConfig<Settings>(Path.Combine(App.AppRootFolderPath, "Settings.json"));
+                var r = ConfigureFileHelper.LoadConfig<Settings>(Path.Combine(App.AppUserFilePath, "Settings.json"));
                 Settings = r;
                 Settings.PropertyChanged += (sender, args) => SettingsChanged(args.PropertyName!);
             }
@@ -149,7 +149,7 @@ public class SettingsService(ILogger<SettingsService> Logger, IManagementService
             return;
         }
         Logger.LogInformation(note == "" ? "写入配置文件。" : $"写入配置文件：{note}");
-        ConfigureFileHelper.SaveConfig(Path.Combine(App.AppRootFolderPath, "Settings.json"), Settings);
+        ConfigureFileHelper.SaveConfig(Path.Combine(App.AppUserFilePath, "Settings.json"), Settings);
     }
 
     /// <summary>

--- a/ClassIsland/Views/SettingsWindowNew.axaml.cs
+++ b/ClassIsland/Views/SettingsWindowNew.axaml.cs
@@ -553,7 +553,7 @@ public partial class SettingsWindowNew : MyWindow, INavigationPageFactory
     {
         Process.Start(new ProcessStartInfo()
         {
-            FileName = Path.GetFullPath(App.AppRootFolderPath) ?? "",
+            FileName = Path.GetFullPath(App.AppUserFilePath) ?? "",
             UseShellExecute = true
         });
     }


### PR DESCRIPTION
之前CI一直把档案和配置文件等数据放在软件安装目录，这对于Windows上的self-contained应用来说没有问题，但是不符合linux平台的常规操作，并且给包管理器打包软件带来困难。为了推进CI的跨平台工作，现希望贡献以下更改：

- 使用`--userfile`或`-uf`命令行参数可以修改档案、设置等用户文件位置；
- 在Linux平台上将这些文件的默认位置移动到`$XDG_CONFIG_HOME/ClassIsland`（默认为`~/.config/ClassIsland`）；
- Windows上的默认行为无任何变化。