### PR TITLE
fix: 修正插件目录位置

### DIFF
--- a/ClassIsland/Services/PluginService.cs
+++ b/ClassIsland/Services/PluginService.cs
@@ -27,7 +27,7 @@ namespace ClassIsland.Services;
 
 public class PluginService : IPluginService
 {
-    public static readonly string PluginsRootPath = Path.Combine(CommonDirectories.AppRootFolderPath, @"Plugins\");
+    public static readonly string PluginsRootPath = Path.Combine(CommonDirectories.AppRootFolderPath, "Plugins");
 
     public static readonly string PluginsIndexPath = Path.Combine(CommonDirectories.AppConfigPath, "PluginsIndex");
 


### PR DESCRIPTION
linux文件系统下反斜杠`\`会被认为是文件夹名称的一部分，导致如图：
<img width="760" height="578" alt="图片" src="https://github.com/user-attachments/assets/ad29cfb4-4f3b-4984-bbd3-fd6af65484c9" />
