### PR TITLE
chore: Set CFBundleExecutable to ClassIsland in Info.plist

### DIFF
--- a/ClassIsland.Desktop/Info.plist
+++ b/ClassIsland.Desktop/Info.plist
@@ -27,7 +27,7 @@
 	<key>NSSystemAdministrationUsageDescription</key>
 	<string></string>
 	<key>CFBundleExecutable</key>
-	<string></string>
+	<string>ClassIsland</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
Updated the Info.plist to specify 'ClassIsland' as the value for CFBundleExecutable. This ensures the correct executable name is set for the application bundle.

解决了 Mac 端应用名为 ClassIsland.Desktop 的问题