### PR TITLE
修复设置界面 - 基本 的主界面隐藏规则集不可用及HiedRules的命名错误

### DIFF
--- a/ClassIsland/MainWindow.axaml.cs
+++ b/ClassIsland/MainWindow.axaml.cs
@@ -227,7 +227,7 @@ public partial class MainWindow : Window
     {
         if (ViewModel.Settings.HideMode == 1)
         {
-            ViewModel.IsHideRuleSatisfied = RulesetService.IsRulesetSatisfied(ViewModel.Settings.HiedRules);
+            ViewModel.IsHideRuleSatisfied = RulesetService.IsRulesetSatisfied(ViewModel.Settings.HideRules);
         }
         // Detect fullscreen
         var screen = GetSelectedScreenSafe();

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -192,6 +192,7 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private double _radiusY = 0.0;
     private int _hideMode = 0;
     private Ruleset _hiedRules = new();
+    private Ruleset _hideRules = new();
     private bool _isAutoBackupEnabled = true;
     private DateTime _lastAutoBackupTime = DateTime.Now;
     private string _backupFilesSize = "计算中...";
@@ -466,6 +467,17 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         {
             if (Equals(value, _hiedRules)) return;
             _hiedRules = value;
+            OnPropertyChanged();
+        }
+    }
+    
+    public Ruleset HideRules
+    {
+        get => _hideRules;
+        set
+        {
+            if (Equals(value, _hideRules)) return;
+            _hideRules = value;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Services/SettingsService.cs
+++ b/ClassIsland/Services/SettingsService.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using Avalonia.Controls;
 using ClassIsland.Core.Abstractions.Services.SpeechService;
+using ClassIsland.Core.Models.Ruleset;
 using ClassIsland.Services.Management;
 using ClassIsland.Shared.Protobuf.AuditEvent;
 using ClassIsland.Shared.Protobuf.Enum;
@@ -136,6 +137,21 @@ public class SettingsService(ILogger<SettingsService> Logger, IManagementService
         requiresRestarting = false;
         if (Assembly.GetExecutingAssembly().GetName().Version < Version.Parse("1.4.1.0"))
         {
+            return;
+        }
+        if (Assembly.GetExecutingAssembly().GetName().Version <= Version.Parse("1.7.105.0"))
+        { 
+            bool NotEmpty(Ruleset? ruleset)
+            {
+                return ruleset?.Groups?.Any(g => g?.Rules?.Any(r => !string.IsNullOrEmpty(r?.Id)) == true) == true;
+            }
+            
+            if (NotEmpty(Settings.HiedRules) && !NotEmpty(Settings.HideRules))
+            {
+                Logger.LogInformation("正在迁移 1.7.105.0 及以下版本的设置文件。");
+                Settings.HideRules = Settings.HiedRules;
+                Settings.HiedRules = new Ruleset();
+            }
             return;
         }
         

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml
@@ -25,7 +25,7 @@
 
         <ci:RulesetControl x:Key="RulesetControl"
                            Classes="in-drawer"
-                           Ruleset="{Binding ViewModel.SettingsService.Settings.HiedRules, Mode=TwoWay}"/>
+                           Ruleset="{Binding ViewModel.SettingsService.Settings.HideRules, Mode=TwoWay}"/>
     </controls:SettingsPageBase.Resources>
     <ScrollViewer>
         <StackPanel Classes="settings-container animated-intro">

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using ClassIsland.Core.Abstractions.Controls;
 using ClassIsland.Core.Attributes;
+using ClassIsland.Core.Controls.Ruleset;
 using ClassIsland.Core.Enums.SettingsWindow;
 using ClassIsland.Services;
 using ClassIsland.Shared;
@@ -24,6 +25,7 @@ public partial class GeneralSettingsPage : SettingsPageBase
     {
         InitializeComponent();
         DataContext = this;
+        ((RulesetControl)this.FindResource("RulesetControl")).Ruleset = this.ViewModel.SettingsService.Settings.HideRules;
     }
 
     private void SettingsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
修复了

<img width="2469" height="1339" alt="image" src="https://github.com/user-attachments/assets/cbfa4e8e-07ed-45c3-8dcb-899c4509b52b" />

修复了

<img width="951" height="426" alt="image" src="https://github.com/user-attachments/assets/e1927b31-1a7e-4e83-ae9d-725d356faa85" />

同时加了相关的配置文件迁移

~~（虽然由于前一个问题毫无鸟用）~~

~~写的很抽象 Powered by me&DS&Claude~~

~~试过了，能用（~~