### PR TITLE
fix: CLassIsland.Services.MemoryWatchDogService 在非 Windows 环境下返回的数据为0

### DIFF
--- a/ClassIsland/Services/MemoryWatchDogService.cs
+++ b/ClassIsland/Services/MemoryWatchDogService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
@@ -30,15 +31,65 @@ public class MemoryWatchDogService(ILogger<MemoryWatchDogService> logger) : Back
         return Task.CompletedTask;
     }
 
+    private long GetMemoryUsage()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Process.GetCurrentProcess().PrivateMemorySize64;
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            try
+            {
+                var statmPath = "/proc/self/statm";
+                if (File.Exists(statmPath))
+                {
+                    var contents = File.ReadAllText(statmPath);
+                    var memoryPages = contents.Split(' ')[0];
+                    var pageSize = Environment.SystemPageSize;
+                    return long.Parse(memoryPages) * pageSize;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "无法读取 /proc/self/statm 获取内存使用情况");
+            }
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "sysctl",
+                    Arguments = "hw.memsize",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                if (process != null)
+                {
+                    var output = process.StandardOutput.ReadToEnd();
+                    var memorySize = output.Split(':')[1].Trim();
+                    return long.Parse(memorySize);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "无法通过 sysctl 获取内存使用情况");
+            }
+        }
+        return 0;
+    }
+
     private void TimerOnElapsed(object? sender, ElapsedEventArgs e)
     {
-        var size = Process.GetCurrentProcess().PrivateMemorySize64;
-        //Console.WriteLine(size);
+        var size = GetMemoryUsage();
         Logger.LogInformation("当前内存使用: {}", Helpers.StorageSizeHelper.FormatSize((ulong)size)+$"({size} Bytes)");
         if (size < MemoryLimitBytes) 
             return;
         Logger.LogCritical("达到内存使用上限！ {} / {}", Helpers.StorageSizeHelper.FormatSize((ulong)size)+$"({size} Bytes)", Helpers.StorageSizeHelper.FormatSize((ulong)MemoryLimitBytes)+$"({MemoryLimitBytes} Bytes)");
-        //var startInfo = Process.GetCurrentProcess().StartInfo;
         var path = Environment.ProcessPath;
         if (path != null)
         {
@@ -52,7 +103,6 @@ public class MemoryWatchDogService(ILogger<MemoryWatchDogService> logger) : Back
             };
             Process.Start(startInfo);
         }
-        //Process.Start(startInfo);
         AppBase.Current.Stop();
     }
 }


### PR DESCRIPTION
Introduced a GetMemoryUsage method to support memory usage detection on Windows, Linux, and macOS. This improves the MemoryWatchDogService to work correctly across different operating systems by using platform-specific approaches to retrieve memory usage.