### PR TITLE
feat: 适配 Liquid Glass 应用图标

### DIFF
--- a/ClassIsland.Desktop/Assets/AppIcon.icon/icon.json
+++ b/ClassIsland.Desktop/Assets/AppIcon.icon/icon.json
@@ -1,5 +1,7 @@
 {
-  "fill" : "system-dark",
+  "fill" : {
+    "automatic-gradient" : "srgb:0.92143,0.92145,0.92144,1.00000"
+  },
   "groups" : [
     {
       "layers" : [

--- a/ClassIsland.Desktop/ClassIsland.Desktop.csproj
+++ b/ClassIsland.Desktop/ClassIsland.Desktop.csproj
@@ -40,8 +40,10 @@
     </ItemGroup>
     <ItemGroup Condition="'$(Platforms_MacOs)'=='true'">
         <ProjectReference Include="..\platforms\ClassIsland.Platforms.MacOs\ClassIsland.Platforms.MacOs.csproj" />
+        <!-- Add Liquid Glass icon for macOS Tahoe and above -->
+        <BundleResource Include="Assets\AppIcon.icon\**" />
+        <!-- Keep xcassets for fallback in older macOS versions -->
         <BundleResource Include="Assets\AppLogo.xcassets\**" />
-        <MauiIcon Include="Assets\AppLogo.svg"/>
     </ItemGroup>
     <ItemGroup Condition="'$(Platforms_Linux)'=='true' and '$(PublishBuilding)'=='true'">
         <PackageReference Include="Packaging.DebUOS" Version="3.17.6"/>

--- a/ClassIsland.Desktop/Info.plist
+++ b/ClassIsland.Desktop/Info.plist
@@ -33,7 +33,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleIconFile</key>
-	<string>Assets/AppIcon.icns</string>
+	<string>Assets/AppIcon</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
在 macOS 中实现了应用图标 Liquid Glass 效果。

同时，由于 Icon Composer 具有向下兼容机制，在 macOS 26 Tahoe 以下的系统版本中会为此 Icon 提供 Flattened 版本，同时保留了 AppLogo.xcassets 作为备选，Avalonia 本身没有自动解析 .icon 的逻辑，但 macOS 系统层面的优先级是 .icon > .icns。

<img width="1886" height="108" alt="截屏2025-08-27 上午11 29 46" src="https://github.com/user-attachments/assets/8f1dcae4-45bf-4598-949a-291b5556bc90" />
<img width="1886" height="108" alt="截屏2025-08-27 上午11 29 52" src="https://github.com/user-attachments/assets/f5dc675f-a6f3-4312-b142-307b09220c6b" />
<img width="1870" height="100" alt="截屏2025-08-27 上午11 29 59" src="https://github.com/user-attachments/assets/6531b89a-66f5-4d34-bcaf-2d7509420245" />
<img width="1870" height="100" alt="截屏2025-08-27 上午11 30 05" src="https://github.com/user-attachments/assets/0d77dd93-478e-43cc-8621-d29fc4f24803" />
