### PR TITLE
feat&fix: 为开启调试界面提供隐藏方式, 修复组件呈现器内Shimmer对组件的裁切, 启动非调试构建时关闭主界面调试模式

### DIFF
--- a/ClassIsland.Core/Controls/ComponentPresenter.axaml
+++ b/ClassIsland.Core/Controls/ComponentPresenter.axaml
@@ -28,6 +28,7 @@
     </UserControl.Styles>
     <Panel>
         <local:Shimmer x:Name="Shimmer" AutoDetectContentLoadState="False"
+                       ClipToBounds="False"
                        Padding="0 8">
             <Border x:Name="ComponentRootBorder"
                     SizeChanged="ComponentRootBorder_OnSizeChanged"

--- a/ClassIsland/App.axaml.cs
+++ b/ClassIsland/App.axaml.cs
@@ -952,6 +952,11 @@ public partial class App : AppBase, IAppHost
             return;
         }
 
+        // 如果不是开发构建, 则自动重置部分可能影响使用的调试选项
+        #if !DEBUG
+        Settings.IsMainWindowDebugEnabled = false;
+        #endif
+        
         var spanLoadMainWindow = spanLaunching.StartChild("span-loading-mainWindow");
         Logger.LogInformation("正在初始化MainWindow。");
         GetService<ISplashService>().SetDetailedStatus("正在启动主界面所需的服务");

--- a/ClassIsland/Views/SettingPages/AboutSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/AboutSettingsPage.axaml.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -236,6 +237,14 @@ public partial class AboutSettingsPage : SettingsPageBase
 
 #if !DEBUG
             var textBox = new TextBox();
+            var textBlock = new TextBlock {
+                TextWrapping = TextWrapping.Wrap,
+                Text = "您正在发布版本的 ClassIsland 中启用仅供开发使用的调试菜单。请注意此功能仅限于开发和调试用途，ClassIsland 开发者不对以非开发用途使用此页面中功能造成的任何后果负责，也不接受以非开发用途使用时产生的 Bug 的反馈。\n"
+            };
+            var timesBlockClicked = 0;
+            textBlock.PointerPressed += (_,_) => {
+                timesBlockClicked++;
+            };
             var r = await new ContentDialog()
             {
                 Title = "启用调试菜单",
@@ -244,11 +253,11 @@ public partial class AboutSettingsPage : SettingsPageBase
                     Spacing = 4,
                     Children =
                     {
+                        textBlock,
                         new TextBlock()
                         {
                             TextWrapping = TextWrapping.Wrap,
-                            Text =
-                                "您正在发布版本的 ClassIsland 中启用仅供开发使用的调试菜单。请注意此功能仅限于开发和调试用途，ClassIsland 开发者不对以非开发用途使用此页面中功能造成的任何后果负责，也不接受以非开发用途使用时产生的 Bug 的反馈。\n\n如果您确实要启用此功能，请在下方文本框输入⌈我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈⌋，然后点击【继续】。"
+                            Text = "如果您确实要启用此功能，请在下方文本框输入⌈我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈⌋，然后点击【继续】。"
                         },
                         textBox
                     }
@@ -264,7 +273,7 @@ public partial class AboutSettingsPage : SettingsPageBase
                 return;
             }
 
-            if (textBox.Text != "我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈")
+            if (timesBlockClicked != 3 & textBox.Text != "我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈")
             {
                 this.ShowWarningToast("验证结果不正确，请重新输入。");
                 return;


### PR DESCRIPTION
*被折磨了一下就搞了这个* 😭😭😭

- [x] 所有功能已经过测试, 完全按照预期工作

> [!NOTE]
> 关于 `开启调试界面的隐藏方式`:
> 点击上半部分文本内容恰好三次后, 直接点击确认即可, 此时不会检查文本框内容

> **关于为什么期望自动重置 `主界面调试模式`**
> 还是神人多啊 😭😭😭

> - [x] 本提交完全由人类生成