### PR TITLE
fix(ProfileTransferProviders): 统一使用ProfileService路径

### DIFF
--- a/ClassIsland/Controls/ProfileTransferProviders/ClassIsland1ImportProvider.cs
+++ b/ClassIsland/Controls/ProfileTransferProviders/ClassIsland1ImportProvider.cs
@@ -6,6 +6,7 @@ using ClassIsland.Core.Abstractions.Controls.ProfileTransferProviders;
 using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Core.Helpers.UI;
 using ClassIsland.Helpers.ProfileTransferHelpers;
+using ClassIsland.Services;
 using ClassIsland.Shared;
 using ClassIsland.Shared.Helpers;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ public class ClassIsland1ImportProvider : GenericImportProviderBase
             var profile = ClassIslandV1ProfileTransferHelper.TransferClassIslandV1ProfileToClassIslandProfile(SourceFilePath);
             if (ImportType == 1)
             {
-                var path = Path.Combine("./Profiles", NewProfileName + ".json");
+                var path = Path.Combine(Services.ProfileService.ProfilePath, NewProfileName + ".json");
                 if (File.Exists(path))
                 {
                     throw new InvalidOperationException($"无法导入课表：{path} 已存在。");

--- a/ClassIsland/Controls/ProfileTransferProviders/ClassWidgets1ImportProvider.cs
+++ b/ClassIsland/Controls/ProfileTransferProviders/ClassWidgets1ImportProvider.cs
@@ -6,6 +6,7 @@ using ClassIsland.Core.Abstractions.Controls.ProfileTransferProviders;
 using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Core.Helpers.UI;
 using ClassIsland.Helpers.ProfileTransferHelpers;
+using ClassIsland.Services;
 using ClassIsland.Shared;
 using ClassIsland.Shared.Helpers;
 using Microsoft.Extensions.Logging;
@@ -34,7 +35,7 @@ public class ClassWidgets1ImportProvider : GenericImportProviderBase
             var profile = ClassWidgetsProfileTransferHelper.ConvertClassWidgets1ProfileToClassIslandProfile(SourceFilePath, ImportType == 0 ? ProfileService.Profile : null);
             if (ImportType == 1)
             {
-                var path = Path.Combine("./Profiles", NewProfileName + ".json");
+                var path = Path.Combine(Services.ProfileService.ProfilePath, NewProfileName + ".json");
                 if (File.Exists(path))
                 {
                     throw new InvalidOperationException($"无法导入课表：{path} 已存在。");

--- a/ClassIsland/Controls/ProfileTransferProviders/CsesImportProvider.cs
+++ b/ClassIsland/Controls/ProfileTransferProviders/CsesImportProvider.cs
@@ -50,7 +50,7 @@ public partial class CsesImportProvider : GenericImportProviderBase
             var profile = csesProfile.ToClassIslandObject(ImportType == 0 ? ProfileService.Profile : templateProfile);
             if (ImportType == 1)
             {
-                var path = System.IO.Path.Combine("./Profiles", NewProfileName + ".json");
+                var path = System.IO.Path.Combine(Services.ProfileService.ProfilePath, NewProfileName + ".json");
                 if (File.Exists(path))
                 {
                     throw new InvalidOperationException($"无法导入课表：{path} 已存在。");


### PR DESCRIPTION
观察到action构建产物最终的路径变更导致找不到正确路径。
```bash
> tre
 .
 ├── app-1.7.105.1
 │   ├── Profiles  # 错误导入的路径
 │   └── ...
 ├── data
 │   ├── Profiles  # 正常导入的路径
 │   └── ...
 ├── ClassIsland.exe
 └── PackageType
```