### PR TITLE
fix: 安全卸载WinEventHook

### DIFF
--- a/ClassIsland/App.axaml.cs
+++ b/ClassIsland/App.axaml.cs
@@ -964,6 +964,10 @@ public partial class App : AppBase, IAppHost
                 IAppHost.Host?.Services.GetService<IProfileService>()?.SaveProfile();
                 IAppHost.Host?.Services.GetService<IComponentsService>()?.SaveConfig();
             }
+            if (PlatformServices.WindowPlatformService is IDisposable d)
+            {
+                d.Dispose();
+            }
             DesktopLifetime?.Shutdown();
             try
             {

--- a/platforms/ClassIsland.Platforms.Windows/Services/WindowPlatformService.cs
+++ b/platforms/ClassIsland.Platforms.Windows/Services/WindowPlatformService.cs
@@ -53,9 +53,9 @@ public class WindowPlatformService : IWindowPlatformService, IDisposable
     
     private void InitEventHook()
     {
-        lock (_hookLock) 
+        lock (_hookLock)
         {
-            if (_hooksUnhooked) 
+            if (_hooksUnhooked)
             {
                 return;
             }
@@ -239,7 +239,7 @@ public class WindowPlatformService : IWindowPlatformService, IDisposable
     public bool IsForegroundWindowFullscreen(Screen screen)
     {
         var win = GetForegroundWindow();
-        if (win == HWND.Null || new HandleRef(null, win).Handle == IntPtr.Zero) 
+        if (win == HWND.Null || new HandleRef(null, win).Handle == IntPtr.Zero)
         {
             return false;
         }
@@ -247,7 +247,7 @@ public class WindowPlatformService : IWindowPlatformService, IDisposable
         var pClassName = NativeHelpers.BuildPWSTR(PwstrCapcity, out var nClassName);
         try
         {
-            GetClassName(win, pClassName, PwstrCapcity  - 1);
+            GetClassName(win, pClassName, PwstrCapcity - 1);
             var className = pClassName.ToString();
             if (className is "WorkerW" or "Progman")
             {
@@ -265,7 +265,7 @@ public class WindowPlatformService : IWindowPlatformService, IDisposable
     public bool IsForegroundWindowMaximized(Screen screen)
     {
         var win = GetForegroundWindow();
-        if (win == HWND.Null || new HandleRef(null, win).Handle == IntPtr.Zero) 
+        if (win == HWND.Null || new HandleRef(null, win).Handle == IntPtr.Zero)
         {
             return false;
         }


### PR DESCRIPTION
*析构函数改成 Dispose()
* 前台窗口判空 空句柄返回 `false`
* 尝试加了机制避免重复释放钩子

按自己理解写的,嗯。可能有点偏差。。。

---
分离于 #1430 

<details><summary>Details</summary>
<p>

 
```shell
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at System.SpanHelpers.IndexOfNullCharacter(Char*)
   at System.String.Ctor(Char*)
   at Windows.Win32.Foundation.PCWSTR.ToString()
   at Windows.Win32.Foundation.PWSTR.ToString()
   at ClassIsland.Platform.Windows.Services.WindowPlatformService.IsForegroundWindowFullscreen(Avalonia.Platform.Screen)
   at ClassIsland.MainWindow.RulesetServiceOnStatusUpdated(System.Object, System.EventArgs)
   at ClassIsland.Services.RulesetService.NotifyStatusChanged()
   at ClassIsland.Services.WindowRuleService.<.ctor>b__10_0(System.Object, ClassIsland.Platforms.Abstraction.Models.ForegroundWindowChangedEventArgs)
   at ClassIsland.Services.WindowRuleService.<.ctor>b__10_1(System.Object, ClassIsland.Platforms.Abstraction.Models.ForegroundWindowChangedEventArgs)
   at ClassIsland.Platform.Windows.Services.WindowPlatformService+<>c__DisplayClass11_0.<PfnWinEventProc>b__0()
   at Avalonia.Threading.Dispatcher.Invoke(System.Action, Avalonia.Threading.DispatcherPriority, System.Threading.CancellationToken, System.TimeSpan)
   at Avalonia.Threading.Dispatcher.Invoke(System.Action)
   at ClassIsland.Platform.Windows.Services.WindowPlatformService.PfnWinEventProc(Windows.Win32.UI.Accessibility.HWINEVENTHOOK, UInt32, Windows.Win32.Foundation.HWND, Int32, Int32, UInt32, UInt32)
   at Avalonia.Win32.Interop.UnmanagedMethods.GetMessage(MSG ByRef, IntPtr, UInt32, UInt32)
   at Avalonia.Win32.Interop.UnmanagedMethods.GetMessage(MSG ByRef, IntPtr, UInt32, UInt32)
   at Avalonia.Win32.Win32DispatcherImpl.RunLoop(System.Threading.CancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(Avalonia.Threading.IControlledDispatcherImpl)
   at Avalonia.Threading.Dispatcher.PushFrame(Avalonia.Threading.DispatcherFrame)
   at Avalonia.Threading.Dispatcher.MainLoop(System.Threading.CancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(System.String[])
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(System.String[])
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(Avalonia.AppBuilder, System.String[], System.Action`1<Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime>)
   at ClassIsland.Desktop.Program+<Main>d__0.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[[System.Int32, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Start[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
   at ClassIsland.Desktop.Program.Main(System.String[])
   at ClassIsland.Desktop.Program.<Main>(System.String[])

```

</p>
</details>