### PR TITLE
chore: 修复global.json对.NET SDK的版本要求

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "8.0.0",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }


### PR DESCRIPTION
要求使用.NET 8 SDK而不是.NET 9，匹配项目运行平台。

~~（顺便一问，考虑升10吗）~~