### PR TITLE
fix: 修复了字体选择ComboBox的异常表现

### DIFF
--- a/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
@@ -418,7 +418,6 @@
                             </Style>
                             <Style Selector="#FontComboBox /template/ Popup#PART_Popup">
                                 <Setter Property="Width" Value="280"/>
-                                <Setter Property="MinWidth" Value="280"/>
                                 <Setter Property="PlacementMode" Value="BottomEdgeAlignedRight"/>
                             </Style>
                         </ComboBox.Styles>


### PR DESCRIPTION
## 这个 Pull Request 做了什么？
将字体选择组件的逻辑更改为：
drop-down button：宽度随当前字体名自适应。
drop-down list：大小固定，弹出位置与drop-down button右侧对齐。
经过测试，本修改在Windows 11 x64平台上，分别以2560x1600 150%缩放、2560x1600 200%缩放、1920x1080 100%缩放与1920x1080 150%缩放的鼠标和触屏操作测试无功能异常。
## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


