### PR TITLE
Fix for Potentially dangerous use of non-short-circuit logic

### DIFF
--- a/ClassIsland/Views/SettingPages/AboutSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/AboutSettingsPage.axaml.cs
@@ -268,7 +268,7 @@ public partial class AboutSettingsPage : SettingsPageBase
                 return;
             }
 
-            if (timesBlockClicked != 3 & textBox.Text != "我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈")
+            if (timesBlockClicked != 3 && textBox.Text != "我已知晓并同意，开发者不对以非开发用途使用此页面功能造成的任何后果负责，也不接受以非开发用途使用此页面功能产生的 Bug 的反馈")
             {
                 this.ShowWarningToast("验证结果不正确，请重新输入。");
                 return;


### PR DESCRIPTION
In general, to fix this kind of problem you should replace non–short-circuit boolean operators (`&` and `|`) with their short-circuiting logical counterparts (`&&` and `||`) when combining boolean conditions, unless you explicitly need both sides to be evaluated for their side effects.

Concretely in `AboutSettingsPage.axaml.cs`, line 271 should be updated so that the two boolean comparisons are combined using `&&` instead of `&`. This preserves the existing logic—“if the click count is not 3 and the text does not match the exact confirmation string, then show a warning”—while ensuring short-circuit behavior and aligning with standard C# usage. No new methods, imports, or definitions are needed; it is a one-character operator change within the existing `if` statement. Only the line containing the `if` condition in that region needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._