### PR TITLE
Fix for Potentially dangerous use of non-short-circuit logic

### DIFF
--- a/ClassIsland.Core/Controls/MyWindow.cs
+++ b/ClassIsland.Core/Controls/MyWindow.cs
@@ -105,7 +105,7 @@ public class MyWindow : AppWindow
     
     private void OnPointerUpdated(object? sender, PointerEventArgs e)
     {
-        PointerStateAssist.SetIsTouchMode(this, _suppressTouchMode | e.Pointer.Type == PointerType.Touch);
+        PointerStateAssist.SetIsTouchMode(this, _suppressTouchMode || e.Pointer.Type == PointerType.Touch);
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)


### PR DESCRIPTION
In general, to fix this kind of issue you should replace bitwise boolean operators (`&`, `|`) used with `bool` operands in condition-like expressions with their logical, short-circuiting counterparts (`&&`, `||`), unless there is a clear need to always evaluate both sides. This restores idiomatic, safer semantics and avoids unnecessary evaluation and potential runtime errors.

In this case, the method `OnPointerUpdated` sets the touch mode flag by calling:

```csharp
PointerStateAssist.SetIsTouchMode(this, _suppressTouchMode | e.Pointer.Type == PointerType.Touch);
```

Both `_suppressTouchMode` and `e.Pointer.Type == PointerType.Touch` are boolean expressions, and there are no side effects. The correct logical operation is “OR,” but we want normal boolean OR semantics, so we should change `|` to `||`. The operator precedence is already correct (`==` binds tighter than `||`), so no additional parentheses are required. The only code change needed is on line 108 of `ClassIsland.Core/Controls/MyWindow.cs`, replacing `|` with `||`. No new methods, fields, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._