### PR TITLE
fix: 纠正天气设置页面重复「使用」的笔误

### DIFF
--- a/ClassIsland/Views/SettingPages/WeatherSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/WeatherSettingsPage.axaml
@@ -273,7 +273,7 @@
                 </controls3:SettingsExpander.Footer>
             </controls3:SettingsExpander>
             <controls3:SettingsExpander IconSource="{ci:FluentIconSource &#xEAB0;}"
-                                       Header="不使用使用TLS协议获取天气"
+                                       Header="不使用TLS协议获取天气"
                                        Description="不建议，但可能改善兼容性较差的网络环境下的天气获取。启用后，应用将通过不安全的HTTP协议获取天气信息。">
                 <controls3:SettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding ViewModel.SettingsService.Settings.NoTLSWeatherRequests, Mode=TwoWay}"/>


### PR DESCRIPTION
## 这个 Pull Request 做了什么？
修正 a71a6aa939f11cc073b485a7f9c87a15136c25a5 引入的「不使用使用TLS协议」重复用词，改为正确的「不使用TLS协议」。

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。