### PR TITLE
fix(converters): 修复 ControlPreventNullConverter 因静态控件重复使用导致的视觉树冲突

### DIFF
--- a/ClassIsland.Core/Converters/ElementConverters.cs
+++ b/ClassIsland.Core/Converters/ElementConverters.cs
@@ -5,11 +5,9 @@ namespace ClassIsland.Core.Converters;
 
 public class ElementConverters
 {
-    private static Border? _border;
 
     public static readonly FuncValueConverter<object?, object> ControlPreventNullConverter = new(x =>
     {
-        _border ??= new Border();
-        return x ?? _border;
+        return x ?? new Border();
     });
 }

--- a/ClassIsland.Core/Converters/ElementConverters.cs
+++ b/ClassIsland.Core/Converters/ElementConverters.cs
@@ -5,7 +5,6 @@ namespace ClassIsland.Core.Converters;
 
 public class ElementConverters
 {
-
     public static readonly FuncValueConverter<object?, object> ControlPreventNullConverter = new(x =>
     {
         return x ?? new Border();


### PR DESCRIPTION
## 这个 Pull Request 做了什么？
修复因  ControlPreventNullConverter 使用静态单例导致的视觉树冲突。

## 相关 Issue
Fixes  #1747 

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


