### PR TITLE
fix: Use File Enumeration/Deletion for Auto-Backup Limit Cleanup

### DIFF
--- a/ClassIsland/Services/FileFolderService.cs
+++ b/ClassIsland/Services/FileFolderService.cs
@@ -105,10 +105,10 @@ public class FileFolderService(SettingsService settingsService, ILogger<FileFold
         {
             return;
         }
-        var outdatedBackups = Directory.EnumerateDirectories(Path.Combine(CommonDirectories.AppRootFolderPath, "Backups"), "Auto_*").OrderByDescending(Directory.GetLastWriteTime).Skip(SettingsService.Settings.AutoBackupLimit).ToList();
+        var outdatedBackups = Directory.EnumerateFiles(Path.Combine(CommonDirectories.AppRootFolderPath, "Backups"), "Auto_*").OrderByDescending(File.GetLastWriteTime).Skip(SettingsService.Settings.AutoBackupLimit).ToList();
         foreach (var i in outdatedBackups)
         {
-            Directory.Delete(i, true);
+            File.Delete(i);
         }        
     }
 


### PR DESCRIPTION
## 这个 Pull Request 做了什么？

自动备份清理逻辑原本使用 `Directory.EnumerateDirectories` 查找旧备份，但自动备份实际均为 `.zip` 文件，导致查询结果始终为空，`AutoBackupLimit` 限制未生效，备份文件会无限累积。这个 PR 将 `Directory.EnumerateDirectories` 改为 `Directory.EnumerateFiles`、`Directory.Delete` 改为 `File.Delete`，以正确识别并清理过期备份文件，使备份数量限制正常生效。

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。