### PR TITLE
feat(CountDown): 添加 %p 变量支持两位小数百分比

### DIFF
--- a/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
+++ b/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
@@ -274,6 +274,9 @@ public partial class CountDownComponent : ComponentBase<CountDownComponentSettin
             .Replace("%P",
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
                     .ToString("P0", CultureInfo.InvariantCulture))
+            .Replace("%p",
+                Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
+                    .ToString("P2", CultureInfo.InvariantCulture))
             .Replace("%L",
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : delta / totalTime, 2)
                     .ToString("P0", CultureInfo.InvariantCulture))


### PR DESCRIPTION
## Summary

- 添加新的格式化变量 `%p`，用于显示已过时间的两位小数百分比（如 `12.34%`）
- 对应 issue #1516

## Changes

在 `CountDownComponent` 的自定义字符串格式中添加 `%p` 变量支持，使用 `P2` 格式显示两位小数百分比。

## Demo

使用 `%p` 可以在到数日组件中显示精细的周进度，例如：`12.34%`