### PR TITLE
feat: 倒计时组件进度显示添加新的格式化变量 %p显示两位小数 （#1516）

### DIFF
--- a/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
+++ b/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
@@ -275,7 +275,7 @@ public partial class CountDownComponent : ComponentBase<CountDownComponentSettin
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
                     .ToString("P0", CultureInfo.InvariantCulture))
             .Replace("%p",
-                Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
+                (totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime)
                     .ToString("P2", CultureInfo.InvariantCulture))
             .Replace("%L",
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : delta / totalTime, 2)

--- a/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
+++ b/ClassIsland/Controls/Components/CountDownComponent.axaml.cs
@@ -274,6 +274,9 @@ public partial class CountDownComponent : ComponentBase<CountDownComponentSettin
             .Replace("%P",
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
                     .ToString("P0", CultureInfo.InvariantCulture))
+            .Replace("%p",
+                Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : (totalTime - delta) / totalTime, 2)
+                    .ToString("P2", CultureInfo.InvariantCulture))
             .Replace("%L",
                 Math.Round(totalTime <= TimeSpan.Zero ? 0.0 : delta / totalTime, 2)
                     .ToString("P0", CultureInfo.InvariantCulture))

--- a/ClassIsland/Controls/Components/CountDownComponentSettingsControl.axaml
+++ b/ClassIsland/Controls/Components/CountDownComponentSettingsControl.axaml
@@ -1,4 +1,4 @@
-﻿<controls2:ComponentBase x:TypeArguments="componentSettings:CountDownComponentSettings"
+<controls2:ComponentBase x:TypeArguments="componentSettings:CountDownComponentSettings"
                          x:Class="ClassIsland.Controls.Components.CountDownComponentSettingsControl"
                          xmlns="https://github.com/avaloniaui"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -361,6 +361,7 @@
                                                 <Run Text="以上数值向上取整。" FontWeight="Medium"/><LineBreak/><LineBreak/>
                                                 <Run Text="%L - 剩余百分比"/><LineBreak/>
                                                 <Run Text="%P - 已过百分比"/><LineBreak/>
+                                                <Run Text="%p - 已过百分比(两位小数)"/><LineBreak/>
                                                 <Run Text="以上数值四舍五入取整。" FontWeight="Medium"/>
                                             </SelectableTextBlock>
                                             <SelectableTextBlock Grid.Row="1" Grid.Column="1">


### PR DESCRIPTION


## 这个 Pull Request 做了什么？
添加新的格式化变量 %p，用于显示已过时间的两位小数百分比（如 12.34%）
对应 issue #1516

## 破坏性变更
<!--- 在这里列出所有破坏性变更，没有则可删除这一节。 -->

## 相关 Issue
Fixes #1516 

## 检查清单

- [ ] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
无构建环境，暂时无法测试

