### PR TITLE
feat(profile-editor): 为时间表编辑器添加撤销/重做功能

### DIFF
--- a/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
@@ -82,6 +82,9 @@ public partial class ProfileSettingsViewModel : ObservableRecipient
     [ObservableProperty] private TimeLayout? _selectedTimeLayout;
     [ObservableProperty] private int _selectedTimePointIndex = -1;
     [ObservableProperty] private bool _canUndo = false;
+    [ObservableProperty] private bool _canRedo = false;
+    public ObservableCollection<string> UndoDescriptions { get; } = [];
+    public ObservableCollection<string> RedoDescriptions { get; } = [];
     [ObservableProperty] private ToastMessage? _currentTimePointDeleteRevertToast;
     [ObservableProperty] private ToastMessage? _currentClassPlanEditDoneToast = null;
     [ObservableProperty] private KeyValuePair<Guid, TimeLayout>? _classPlanInfoSelectedTimeLayoutKvp;

--- a/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/ProfileSettingsViewModel.cs
@@ -81,6 +81,7 @@ public partial class ProfileSettingsViewModel : ObservableRecipient
     [ObservableProperty] private int _masterPageTabSelectIndex = 0;
     [ObservableProperty] private TimeLayout? _selectedTimeLayout;
     [ObservableProperty] private int _selectedTimePointIndex = -1;
+    [ObservableProperty] private bool _canUndo = false;
     [ObservableProperty] private ToastMessage? _currentTimePointDeleteRevertToast;
     [ObservableProperty] private ToastMessage? _currentClassPlanEditDoneToast = null;
     [ObservableProperty] private KeyValuePair<Guid, TimeLayout>? _classPlanInfoSelectedTimeLayoutKvp;

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -1180,6 +1180,12 @@
                                                                        ToolTip.Tip="添加行动时间点。"
                                                                        Label="行动" />
                                             <controls:CommandBarSeparator />
+                                            <controls:CommandBarButton Click="ButtonUndoAdd_OnClick"
+                                                                       IconSource="{ci:FluentIconSource &#xE10E;}"
+                                                                       ToolTip.Tip="撤销上一步操作 (Ctrl+Z)"
+                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanUndo}"
+                                                                       Label="撤销" />
+                                            <controls:CommandBarSeparator />
                                             <controls:CommandBarButton Click="ButtonRemoveTimePoint_OnClick"
                                                                        ToolTip.Tip="删除选中的时间点。"
                                                                        IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.SelectedTimePoint, Converter={x:Static ObjectConverters.IsNotNull}}"

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -1180,10 +1180,9 @@
                                                                        ToolTip.Tip="添加行动时间点。"
                                                                        Label="行动" />
                                             <controls:CommandBarSeparator />
-                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE10E;}"
+                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE195;}"
                                                                        ToolTip.Tip="撤销 (Ctrl+Z 单步)"
-                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanUndo}"
-                                                                       Label="撤销">
+                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanUndo}">
                                                 <controls:CommandBarButton.Flyout>
                                                     <Flyout Placement="BottomEdgeAlignedLeft">
                                                         <StackPanel Spacing="4" MinWidth="180">
@@ -1201,10 +1200,9 @@
                                                     </Flyout>
                                                 </controls:CommandBarButton.Flyout>
                                             </controls:CommandBarButton>
-                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE10D;}"
+                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE121;}"
                                                                        ToolTip.Tip="重做 (Ctrl+Y 单步)"
-                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanRedo}"
-                                                                       Label="重做">
+                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanRedo}">
                                                 <controls:CommandBarButton.Flyout>
                                                     <Flyout Placement="BottomEdgeAlignedLeft">
                                                         <StackPanel Spacing="4" MinWidth="180">

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -1180,16 +1180,48 @@
                                                                        ToolTip.Tip="添加行动时间点。"
                                                                        Label="行动" />
                                             <controls:CommandBarSeparator />
-                                            <controls:CommandBarButton Click="ButtonUndoAdd_OnClick"
-                                                                       IconSource="{ci:FluentIconSource &#xE10E;}"
-                                                                       ToolTip.Tip="撤销上一步操作 (Ctrl+Z)"
+                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE10E;}"
+                                                                       ToolTip.Tip="撤销 (Ctrl+Z 单步)"
                                                                        IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanUndo}"
-                                                                       Label="撤销" />
-                                            <controls:CommandBarButton Click="ButtonRedoAdd_OnClick"
-                                                                       IconSource="{ci:FluentIconSource &#xE10D;}"
-                                                                       ToolTip.Tip="重做上一步操作 (Ctrl+Y)"
+                                                                       Label="撤销">
+                                                <controls:CommandBarButton.Flyout>
+                                                    <Flyout Placement="BottomEdgeAlignedLeft">
+                                                        <StackPanel Spacing="4" MinWidth="180">
+                                                            <Button Content="撤销上一步 (Ctrl+Z)"
+                                                                    Click="ButtonUndoAdd_OnClick"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    HorizontalContentAlignment="Left" />
+                                                            <Separator />
+                                                            <TextBlock Text="撤销历史" Opacity="0.6" FontSize="11" />
+                                                            <ScrollViewer MaxHeight="200">
+                                                                <ListBox ItemsSource="{Binding $parent[views:ProfileSettingsWindow].ViewModel.UndoDescriptions}"
+                                                                         SelectionChanged="UndoHistoryList_OnSelectionChanged" />
+                                                            </ScrollViewer>
+                                                        </StackPanel>
+                                                    </Flyout>
+                                                </controls:CommandBarButton.Flyout>
+                                            </controls:CommandBarButton>
+                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE10D;}"
+                                                                       ToolTip.Tip="重做 (Ctrl+Y 单步)"
                                                                        IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanRedo}"
-                                                                       Label="重做" />
+                                                                       Label="重做">
+                                                <controls:CommandBarButton.Flyout>
+                                                    <Flyout Placement="BottomEdgeAlignedLeft">
+                                                        <StackPanel Spacing="4" MinWidth="180">
+                                                            <Button Content="重做上一步 (Ctrl+Y)"
+                                                                    Click="ButtonRedoAdd_OnClick"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    HorizontalContentAlignment="Left" />
+                                                            <Separator />
+                                                            <TextBlock Text="重做历史" Opacity="0.6" FontSize="11" />
+                                                            <ScrollViewer MaxHeight="200">
+                                                                <ListBox ItemsSource="{Binding $parent[views:ProfileSettingsWindow].ViewModel.RedoDescriptions}"
+                                                                         SelectionChanged="RedoHistoryList_OnSelectionChanged" />
+                                                            </ScrollViewer>
+                                                        </StackPanel>
+                                                    </Flyout>
+                                                </controls:CommandBarButton.Flyout>
+                                            </controls:CommandBarButton>
                                             <controls:CommandBarSeparator />
                                             <controls:CommandBarButton Click="ButtonRemoveTimePoint_OnClick"
                                                                        ToolTip.Tip="删除选中的时间点。"

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -1185,6 +1185,11 @@
                                                                        ToolTip.Tip="撤销上一步操作 (Ctrl+Z)"
                                                                        IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanUndo}"
                                                                        Label="撤销" />
+                                            <controls:CommandBarButton Click="ButtonRedoAdd_OnClick"
+                                                                       IconSource="{ci:FluentIconSource &#xE10D;}"
+                                                                       ToolTip.Tip="重做上一步操作 (Ctrl+Y)"
+                                                                       IsEnabled="{Binding $parent[views:ProfileSettingsWindow].ViewModel.CanRedo}"
+                                                                       Label="重做" />
                                             <controls:CommandBarSeparator />
                                             <controls:CommandBarButton Click="ButtonRemoveTimePoint_OnClick"
                                                                        ToolTip.Tip="删除选中的时间点。"

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -51,6 +51,7 @@ public partial class ProfileSettingsWindow : MyWindow
     private bool _isOpen = false;
     private record UndoEntry(bool IsAdd, TimeLayoutItem Item, TimeLayout Layout, int Index);
     private readonly Stack<UndoEntry> _undoStack = new();
+    private readonly Stack<UndoEntry> _redoStack = new();
 
     public static readonly FuncValueConverter<ProfileTransferProviderType, string>
         ProfileTransferProviderTypeToImportButtonTextConverter = new(x => x switch
@@ -81,7 +82,7 @@ public partial class ProfileSettingsWindow : MyWindow
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
             .Subscribe(_ => TimeLineListControl?.ScrollIntoViewCentered(ViewModel.SelectedTimeLayout?.Layouts.FirstOrDefault()));
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
-            .Subscribe(_ => { _undoStack.Clear(); ViewModel.CanUndo = false; });
+            .Subscribe(_ => { _undoStack.Clear(); _redoStack.Clear(); ViewModel.CanUndo = false; ViewModel.CanRedo = false; });
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
@@ -124,6 +125,10 @@ public partial class ProfileSettingsWindow : MyWindow
                 break;
             case Key.Z when e.KeyModifiers == KeyModifiers.Control:
                 UndoLastAction();
+                e.Handled = true;
+                break;
+            case Key.Y when e.KeyModifiers == KeyModifiers.Control:
+                RedoLastAction();
                 e.Handled = true;
                 break;
         }
@@ -820,26 +825,53 @@ public partial class ProfileSettingsWindow : MyWindow
     {
         var index = layout.Layouts.IndexOf(item);
         _undoStack.Push(new UndoEntry(IsAdd: true, item, layout, index));
+        _redoStack.Clear();
         ViewModel.CanUndo = true;
+        ViewModel.CanRedo = false;
     }
 
     private void PushDeleteUndo(TimeLayoutItem item, TimeLayout layout, int index)
     {
         _undoStack.Push(new UndoEntry(IsAdd: false, item, layout, index));
+        _redoStack.Clear();
         ViewModel.CanUndo = true;
+        ViewModel.CanRedo = false;
     }
 
     private void UndoLastAction()
     {
         if (!_undoStack.TryPop(out var entry)) return;
+        var undoneIndex = entry.IsAdd ? entry.Layout.Layouts.IndexOf(entry.Item) : entry.Index;
         if (entry.IsAdd)
             entry.Layout.RemoveTimePoint(entry.Item);
         else
             entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+        _redoStack.Push(entry with { Index = undoneIndex });
         ViewModel.CanUndo = _undoStack.Count > 0;
+        ViewModel.CanRedo = true;
+    }
+
+    private void RedoLastAction()
+    {
+        if (!_redoStack.TryPop(out var entry)) return;
+        int redoneIndex;
+        if (entry.IsAdd)
+        {
+            entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+            redoneIndex = entry.Index;
+        }
+        else
+        {
+            redoneIndex = entry.Layout.Layouts.IndexOf(entry.Item);
+            entry.Layout.RemoveTimePoint(entry.Item);
+        }
+        _undoStack.Push(entry with { Index = redoneIndex });
+        ViewModel.CanRedo = _redoStack.Count > 0;
+        ViewModel.CanUndo = true;
     }
 
     private void ButtonUndoAdd_OnClick(object? sender, RoutedEventArgs e) => UndoLastAction();
+    private void ButtonRedoAdd_OnClick(object? sender, RoutedEventArgs e) => RedoLastAction();
 
 
     private void AddTimePoint(TimeLayoutItem item)

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -53,15 +53,6 @@ public partial class ProfileSettingsWindow : MyWindow
     private readonly Stack<UndoEntry> _undoStack = new();
     private readonly Stack<UndoEntry> _redoStack = new();
 
-    private static string DescribeItem(TimeLayoutItem item) => item.TimeType switch
-    {
-        0 => $"上课 {item.StartTime:hh\\:mm}",
-        1 => $"课间 {item.StartTime:hh\\:mm}",
-        2 => "分割线",
-        3 => $"行动 {item.StartTime:hh\\:mm}",
-        _ => "时间点"
-    };
-
     public static readonly FuncValueConverter<ProfileTransferProviderType, string>
         ProfileTransferProviderTypeToImportButtonTextConverter = new(x => x switch
         {
@@ -850,7 +841,7 @@ public partial class ProfileSettingsWindow : MyWindow
     private void PushAddUndo(TimeLayoutItem item, TimeLayout layout)
     {
         var index = layout.Layouts.IndexOf(item);
-        var desc = $"添加{DescribeItem(item)}";
+        var desc = $"添加{item}";
         _undoStack.Push(new UndoEntry(IsAdd: true, item, layout, index, desc));
         ViewModel.UndoDescriptions.Insert(0, desc);
         _redoStack.Clear();
@@ -861,7 +852,7 @@ public partial class ProfileSettingsWindow : MyWindow
 
     private void PushDeleteUndo(TimeLayoutItem item, TimeLayout layout, int index)
     {
-        var desc = $"删除{DescribeItem(item)}";
+        var desc = $"删除{item}";
         _undoStack.Push(new UndoEntry(IsAdd: false, item, layout, index, desc));
         ViewModel.UndoDescriptions.Insert(0, desc);
         _redoStack.Clear();

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -49,9 +49,18 @@ namespace ClassIsland.Views;
 public partial class ProfileSettingsWindow : MyWindow
 {
     private bool _isOpen = false;
-    private record UndoEntry(bool IsAdd, TimeLayoutItem Item, TimeLayout Layout, int Index);
+    private record UndoEntry(bool IsAdd, TimeLayoutItem Item, TimeLayout Layout, int Index, string Description);
     private readonly Stack<UndoEntry> _undoStack = new();
     private readonly Stack<UndoEntry> _redoStack = new();
+
+    private static string DescribeItem(TimeLayoutItem item) => item.TimeType switch
+    {
+        0 => $"上课 {item.StartTime:hh\\:mm}",
+        1 => $"课间 {item.StartTime:hh\\:mm}",
+        2 => "分割线",
+        3 => $"行动 {item.StartTime:hh\\:mm}",
+        _ => "时间点"
+    };
 
     public static readonly FuncValueConverter<ProfileTransferProviderType, string>
         ProfileTransferProviderTypeToImportButtonTextConverter = new(x => x switch
@@ -82,7 +91,12 @@ public partial class ProfileSettingsWindow : MyWindow
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
             .Subscribe(_ => TimeLineListControl?.ScrollIntoViewCentered(ViewModel.SelectedTimeLayout?.Layouts.FirstOrDefault()));
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
-            .Subscribe(_ => { _undoStack.Clear(); _redoStack.Clear(); ViewModel.CanUndo = false; ViewModel.CanRedo = false; });
+            .Subscribe(_ =>
+            {
+                _undoStack.Clear(); _redoStack.Clear();
+                ViewModel.CanUndo = false; ViewModel.CanRedo = false;
+                ViewModel.UndoDescriptions.Clear(); ViewModel.RedoDescriptions.Clear();
+            });
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
@@ -824,16 +838,22 @@ public partial class ProfileSettingsWindow : MyWindow
     private void PushAddUndo(TimeLayoutItem item, TimeLayout layout)
     {
         var index = layout.Layouts.IndexOf(item);
-        _undoStack.Push(new UndoEntry(IsAdd: true, item, layout, index));
+        var desc = $"添加{DescribeItem(item)}";
+        _undoStack.Push(new UndoEntry(IsAdd: true, item, layout, index, desc));
+        ViewModel.UndoDescriptions.Insert(0, desc);
         _redoStack.Clear();
+        ViewModel.RedoDescriptions.Clear();
         ViewModel.CanUndo = true;
         ViewModel.CanRedo = false;
     }
 
     private void PushDeleteUndo(TimeLayoutItem item, TimeLayout layout, int index)
     {
-        _undoStack.Push(new UndoEntry(IsAdd: false, item, layout, index));
+        var desc = $"删除{DescribeItem(item)}";
+        _undoStack.Push(new UndoEntry(IsAdd: false, item, layout, index, desc));
+        ViewModel.UndoDescriptions.Insert(0, desc);
         _redoStack.Clear();
+        ViewModel.RedoDescriptions.Clear();
         ViewModel.CanUndo = true;
         ViewModel.CanRedo = false;
     }
@@ -846,7 +866,9 @@ public partial class ProfileSettingsWindow : MyWindow
             entry.Layout.RemoveTimePoint(entry.Item);
         else
             entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+        if (ViewModel.UndoDescriptions.Count > 0) ViewModel.UndoDescriptions.RemoveAt(0);
         _redoStack.Push(entry with { Index = undoneIndex });
+        ViewModel.RedoDescriptions.Insert(0, entry.Description);
         ViewModel.CanUndo = _undoStack.Count > 0;
         ViewModel.CanRedo = true;
     }
@@ -865,13 +887,52 @@ public partial class ProfileSettingsWindow : MyWindow
             redoneIndex = entry.Layout.Layouts.IndexOf(entry.Item);
             entry.Layout.RemoveTimePoint(entry.Item);
         }
+        if (ViewModel.RedoDescriptions.Count > 0) ViewModel.RedoDescriptions.RemoveAt(0);
         _undoStack.Push(entry with { Index = redoneIndex });
+        ViewModel.UndoDescriptions.Insert(0, entry.Description);
         ViewModel.CanRedo = _redoStack.Count > 0;
         ViewModel.CanUndo = true;
     }
 
-    private void ButtonUndoAdd_OnClick(object? sender, RoutedEventArgs e) => UndoLastAction();
-    private void ButtonRedoAdd_OnClick(object? sender, RoutedEventArgs e) => RedoLastAction();
+    private void UndoToIndex(int count)
+    {
+        for (var i = 0; i < count; i++) UndoLastAction();
+    }
+
+    private void RedoToIndex(int count)
+    {
+        for (var i = 0; i < count; i++) RedoLastAction();
+    }
+
+    private void ButtonUndoAdd_OnClick(object? sender, RoutedEventArgs e)
+    {
+        FlyoutHelper.CloseAncestorFlyout(sender as Control);
+        UndoLastAction();
+    }
+
+    private void ButtonRedoAdd_OnClick(object? sender, RoutedEventArgs e)
+    {
+        FlyoutHelper.CloseAncestorFlyout(sender as Control);
+        RedoLastAction();
+    }
+
+    private void UndoHistoryList_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is not ListBox lb || lb.SelectedIndex < 0) return;
+        var count = lb.SelectedIndex + 1;
+        lb.SelectedIndex = -1;
+        FlyoutHelper.CloseAncestorFlyout(lb);
+        UndoToIndex(count);
+    }
+
+    private void RedoHistoryList_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is not ListBox lb || lb.SelectedIndex < 0) return;
+        var count = lb.SelectedIndex + 1;
+        lb.SelectedIndex = -1;
+        FlyoutHelper.CloseAncestorFlyout(lb);
+        RedoToIndex(count);
+    }
 
 
     private void AddTimePoint(TimeLayoutItem item)

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -149,7 +149,6 @@ public partial class ProfileSettingsWindow : MyWindow
                     e.Handled = true;
                 }
                 break;
-                break;
         }
     }
 
@@ -948,7 +947,6 @@ public partial class ProfileSettingsWindow : MyWindow
         FlyoutHelper.CloseAncestorFlyout(lb);
         RedoToIndex(count);
     }
-
 
     private void AddTimePoint(TimeLayoutItem item)
     {

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -101,6 +101,18 @@ public partial class ProfileSettingsWindow : MyWindow
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
     {
+        switch (e.Key)
+        {
+            case Key.Z when e.KeyModifiers == KeyModifiers.Control:
+                UndoLastAction();
+                e.Handled = true;
+                return;
+            case Key.Y when e.KeyModifiers == KeyModifiers.Control:
+                RedoLastAction();
+                e.Handled = true;
+                return;
+        }
+
         var layouts = ViewModel.SelectedTimeLayout?.Layouts;
         if (layouts == null || layouts.Count == 0)
             return;
@@ -137,13 +149,6 @@ public partial class ProfileSettingsWindow : MyWindow
                     e.Handled = true;
                 }
                 break;
-            case Key.Z when e.KeyModifiers == KeyModifiers.Control:
-                UndoLastAction();
-                e.Handled = true;
-                break;
-            case Key.Y when e.KeyModifiers == KeyModifiers.Control:
-                RedoLastAction();
-                e.Handled = true;
                 break;
         }
     }

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -868,9 +868,16 @@ public partial class ProfileSettingsWindow : MyWindow
         if (!_undoStack.TryPop(out var entry)) return;
         var undoneIndex = entry.IsAdd ? entry.Layout.Layouts.IndexOf(entry.Item) : entry.Index;
         if (entry.IsAdd)
+        {
             entry.Layout.RemoveTimePoint(entry.Item);
+            if (ViewModel.SelectedTimePoint == entry.Item)
+                ViewModel.SelectedTimePoint = entry.Layout.Layouts.Count > 0 ? entry.Layout.Layouts[Math.Max(0, undoneIndex - 1)] : null;
+        }
         else
+        {
             entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+            ViewModel.SelectedTimePoint = entry.Item;
+        }
         if (ViewModel.UndoDescriptions.Count > 0) ViewModel.UndoDescriptions.RemoveAt(0);
         _redoStack.Push(entry with { Index = undoneIndex });
         ViewModel.RedoDescriptions.Insert(0, entry.Description);
@@ -885,12 +892,15 @@ public partial class ProfileSettingsWindow : MyWindow
         if (entry.IsAdd)
         {
             entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+            ViewModel.SelectedTimePoint = entry.Item;
             redoneIndex = entry.Index;
         }
         else
         {
             redoneIndex = entry.Layout.Layouts.IndexOf(entry.Item);
             entry.Layout.RemoveTimePoint(entry.Item);
+            if (ViewModel.SelectedTimePoint == entry.Item)
+                ViewModel.SelectedTimePoint = entry.Layout.Layouts.Count > 0 ? entry.Layout.Layouts[Math.Max(0, redoneIndex - 1)] : null;
         }
         if (ViewModel.RedoDescriptions.Count > 0) ViewModel.RedoDescriptions.RemoveAt(0);
         _undoStack.Push(entry with { Index = redoneIndex });

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -49,6 +49,8 @@ namespace ClassIsland.Views;
 public partial class ProfileSettingsWindow : MyWindow
 {
     private bool _isOpen = false;
+    private record UndoEntry(bool IsAdd, TimeLayoutItem Item, TimeLayout Layout, int Index);
+    private readonly Stack<UndoEntry> _undoStack = new();
 
     public static readonly FuncValueConverter<ProfileTransferProviderType, string>
         ProfileTransferProviderTypeToImportButtonTextConverter = new(x => x switch
@@ -78,6 +80,8 @@ public partial class ProfileSettingsWindow : MyWindow
             .Subscribe(_ => OnDrawerStateChanged());
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
             .Subscribe(_ => TimeLineListControl?.ScrollIntoViewCentered(ViewModel.SelectedTimeLayout?.Layouts.FirstOrDefault()));
+        ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
+            .Subscribe(_ => { _undoStack.Clear(); ViewModel.CanUndo = false; });
     }
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
@@ -117,6 +121,10 @@ public partial class ProfileSettingsWindow : MyWindow
                     TimeLineListControl?.ScrollIntoViewCentered(ViewModel.SelectedTimePoint);
                     e.Handled = true;
                 }
+                break;
+            case Key.Z when e.KeyModifiers == KeyModifiers.Control:
+                UndoLastAction();
+                e.Handled = true;
                 break;
         }
     }
@@ -808,6 +816,32 @@ public partial class ProfileSettingsWindow : MyWindow
         FlyoutHelper.CloseAncestorFlyout(sender);
     }
     
+    private void PushAddUndo(TimeLayoutItem item, TimeLayout layout)
+    {
+        var index = layout.Layouts.IndexOf(item);
+        _undoStack.Push(new UndoEntry(IsAdd: true, item, layout, index));
+        ViewModel.CanUndo = true;
+    }
+
+    private void PushDeleteUndo(TimeLayoutItem item, TimeLayout layout, int index)
+    {
+        _undoStack.Push(new UndoEntry(IsAdd: false, item, layout, index));
+        ViewModel.CanUndo = true;
+    }
+
+    private void UndoLastAction()
+    {
+        if (!_undoStack.TryPop(out var entry)) return;
+        if (entry.IsAdd)
+            entry.Layout.RemoveTimePoint(entry.Item);
+        else
+            entry.Layout.InsertTimePoint(entry.Index, entry.Item);
+        ViewModel.CanUndo = _undoStack.Count > 0;
+    }
+
+    private void ButtonUndoAdd_OnClick(object? sender, RoutedEventArgs e) => UndoLastAction();
+
+
     private void AddTimePoint(TimeLayoutItem item)
     {
         var timeLayout = ViewModel.SelectedTimeLayout;
@@ -915,6 +949,7 @@ public partial class ProfileSettingsWindow : MyWindow
         AddTimePoint(newItem);
         // ReSortTimeLayout(newItem);
         ViewModel.SelectedTimePoint = newItem;
+        PushAddUndo(newItem, timeLayout);
         //OpenDrawer("TimePointEditor");
         SentrySdk.Metrics.EmitCounter("views.ProfileSettingsWindow.timePoint.create", 1,
         [
@@ -964,47 +999,17 @@ public partial class ProfileSettingsWindow : MyWindow
 
     private void RemoveSelectedTimePoint()
     {
-        if (ViewModel.SelectedTimePoint == null) 
+        if (ViewModel.SelectedTimePoint == null)
             return;
         var timePoint = ViewModel.SelectedTimePoint;
         var timeLayout = ViewModel.SelectedTimeLayout;
-        if (timeLayout == null)
-        {
-            return;
-        }
+        if (timeLayout == null) return;
         var i = timeLayout.Layouts.IndexOf(timePoint);
         timeLayout.RemoveTimePoint(timePoint);
         if (i > 0)
             ViewModel.SelectedTimePoint = timeLayout.Layouts[i - 1];
-        var revertButton = new Button()
-        {
-            Content = "撤销"
-        };
-
-        ViewModel.CurrentTimePointDeleteRevertToast?.Close();
-        var message = ViewModel.CurrentTimePointDeleteRevertToast = new ToastMessage()
-        {
-            Message = $"已删除时间点 {timePoint}。",
-            Duration = TimeSpan.FromSeconds(10),
-            ActionContent = revertButton
-        };
-        revertButton.Click += RevertButtonOnClick;
-        message.ClosedCancellationTokenSource.Token.Register(() =>
-        {
-            revertButton.Click -= RevertButtonOnClick;
-            ViewModel.CurrentTimePointDeleteRevertToast = null;
-        });
-        ViewModel.ObservableForProperty(x => x.SelectedTimeLayout).Subscribe(_ => message.Close());
-        this.ShowToast(message);
-        
+        PushDeleteUndo(timePoint, timeLayout, i);
         SentrySdk.Metrics.EmitCounter("views.ProfileSettingsWindow.timePoint.remove", 1);
-        return;
-
-        void RevertButtonOnClick(object? o, RoutedEventArgs routedEventArgs)
-        {
-            AddTimePoint(timePoint);
-            message.Close();
-        }
     }
 
     private void ButtonRefreshTimeLayout_OnClick(object sender, RoutedEventArgs e)

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -86,6 +86,8 @@ public partial class ProfileSettingsWindow : MyWindow
         TimeLineListControl.SelectionChanged += TimeLineListControl_OnSelectionChanged;
         TimeLineListControl.KeyDown += OnKeyDown;
         ListViewTimePoints.KeyDown += OnKeyDown;
+        // 撤销/重做使用窗口级快捷键，避免依赖时间点列表是否获得焦点
+        AddHandler(KeyDownEvent, OnGlobalUndoRedoKeyDown, RoutingStrategies.Tunnel);
         ViewModel.ObservableForProperty(x => x.IsDrawerOpen)
             .Subscribe(_ => OnDrawerStateChanged());
         ViewModel.ObservableForProperty(x => x.SelectedTimeLayout)
@@ -99,20 +101,26 @@ public partial class ProfileSettingsWindow : MyWindow
             });
     }
 
-    private void OnKeyDown(object? sender, KeyEventArgs e)
+    private void OnGlobalUndoRedoKeyDown(object? sender, KeyEventArgs e)
     {
+        // 焦点位于文本输入框时，保留其自身的撤销/重做行为
+        if (FocusManager?.GetFocusedElement() is TextBox)
+            return;
         switch (e.Key)
         {
             case Key.Z when e.KeyModifiers == KeyModifiers.Control:
                 UndoLastAction();
                 e.Handled = true;
-                return;
+                break;
             case Key.Y when e.KeyModifiers == KeyModifiers.Control:
                 RedoLastAction();
                 e.Handled = true;
-                return;
+                break;
         }
+    }
 
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
         var layouts = ViewModel.SelectedTimeLayout?.Layouts;
         if (layouts == null || layouts.Count == 0)
             return;


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？

为时间表编辑器添加撤销（Ctrl+Z）和重做（Ctrl+Y）功能：

- 支持撤销/重做添加、删除时间点操作
- 工具栏新增撤销/重做按钮，点击可展开历史记录列表，支持跳转到指定步骤
- 切换时间表时自动清空历史记录

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
