### PR TITLE
feat(plugin): 优化插件加载上下文的程序集解析逻辑

### DIFF
--- a/ClassIsland/PluginLoadContext.cs
+++ b/ClassIsland/PluginLoadContext.cs
@@ -45,6 +45,18 @@ public class PluginLoadContext : AssemblyLoadContext
         "Microsoft.Windows.SDK.NET"
     ];
 
+    private static IReadOnlyList<string> SharedAssemblyPrefixes { get; } = [
+        "ClassIsland",
+        "Avalonia",
+        "FluentAvalonia",
+        "Microsoft.Extensions.Configuration",
+        "Microsoft.Extensions.DependencyInjection",
+        "Microsoft.Extensions.Hosting",
+        "Microsoft.Extensions.Logging",
+        "Microsoft.Extensions.Options",
+        "Microsoft.Extensions.Primitives"
+    ];
+
     /// <summary>
     /// 在需要加载程序集时被调用。优先从已加载的插件依赖项上下文中解析，如果在插件目录中找到对应的程序集则从路径加载。
     /// 对 WinRT 相关依赖会使用宿主的实现。
@@ -57,6 +69,14 @@ public class PluginLoadContext : AssemblyLoadContext
             // 这里将插件要的加载的 WinRT 相关程序集替换为应用自带的 WinRT 相关程序集。
             return null;
         }
+
+        if (assemblyName.Name != null &&
+            SharedAssemblyPrefixes.Any(prefix => assemblyName.Name.StartsWith(prefix, StringComparison.Ordinal)) &&
+            AssemblyLoadContext.Default.Assemblies.FirstOrDefault(x => x.GetName().Name == assemblyName.Name) is { } sharedAssembly)
+        {
+            return sharedAssembly;
+        }
+
         // 尝试查找依赖
         foreach (var dep in Info.Manifest.Dependencies)
         {


### PR DESCRIPTION
- 添加共享程序集前缀列表配置，包括 ClassIsland、Avalonia 等核心框架组件
- 实现基于前缀匹配的程序集共享机制，优先使用默认加载上下文中的现有程序集
- 避免重复加载相同名称的程序集，减少内存占用和潜在冲突
- 保持对 WinRT 相关依赖的特殊处理逻辑不变
- 提升插件系统稳定性和性能表现

<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？

在本地使用源码调试 ClassIsland 时，通过以下命令启动应用：

```bash
dotnet run --project ClassIsland.Desktop/ClassIsland.Desktop.csproj -c Debug /p:NIX=true
```

安装基于 `ClassIsland.PluginSdk 1.7.105.1-dev-v2` 编译的插件后，插件初始化阶段会失败：

```text
System.IO.FileNotFoundException: Could not load file or assembly 'ClassIsland.Core, Version=1.7.105.1, Culture=neutral, PublicKeyToken=null'.
   at System.Reflection.RuntimeAssembly.GetExportedTypes()
   at ClassIsland.Services.PluginService.InitializePlugins(...)
```

问题发生在 `PluginService.InitializePlugins()` 扫描插件入口程序集的 `ExportedTypes` 时。插件程序集依赖 `ClassIsland.Core`，但当前插件加载上下文没有优先复用宿主进程中已经加载的 ClassIsland 基础程序集，导致运行时尝试在插件上下文中解析精确版本的 `ClassIsland.Core`，最终找不到程序集而加载失败。

这个问题并不是具体插件业务代码导致的；同类基于较新 Plugin SDK 编译、且依赖宿主基础程序集的插件都可能遇到类似问题。

## 修复内容

在 `PluginLoadContext.Load()` 中增加宿主基础程序集复用逻辑：

- 对 `ClassIsland*` 程序集优先复用默认加载上下文中已加载的宿主程序集。
- 对 Avalonia、FluentAvalonia、Microsoft.Extensions 相关基础程序集同样优先复用宿主实例。
- 保留原有插件依赖解析和插件目录解析逻辑，只有在宿主中已存在对应基础程序集时才提前返回。

这样可以避免插件加载上下文重复解析或找不到宿主基础程序集，也避免将 `ClassIsland.Core.dll` 等宿主程序集打包进插件后造成类型身份不一致的问题，例如 `PluginBase` 来自不同 AssemblyLoadContext。

## 验证

已验证：

```bash
dotnet build VoiceHubComponent/VoiceHubComponent.csproj -c Debug
dotnet build ClassIsland.Desktop/ClassIsland.Desktop.csproj -c Debug /p:NIX=true
dotnet run --project ClassIsland.Desktop/ClassIsland.Desktop.csproj -c Debug /p:NIX=true
```

安装并加载插件后，插件可以正常进入，不再出现 `ClassIsland.Core` 加载失败。

## 检查清单

- [X] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


