### PR TITLE
fix(ui): 限制开发构建水印显示范围

### DIFF
--- a/ClassIsland.Core/Controls/MyWindow.cs
+++ b/ClassIsland.Core/Controls/MyWindow.cs
@@ -48,6 +48,14 @@ public partial class MyWindow : AppWindow
     public static readonly DirectProperty<MyWindow, bool> EnableMicaWindowProperty = AvaloniaProperty.RegisterDirect<MyWindow, bool>(
         nameof(EnableMicaWindow), o => o.EnableMicaWindow, (o, v) => o.EnableMicaWindow = v);
 
+    private bool _showDevelopmentBuildWatermark;
+
+    public static readonly DirectProperty<MyWindow, bool> ShowDevelopmentBuildWatermarkProperty =
+        AvaloniaProperty.RegisterDirect<MyWindow, bool>(
+            nameof(ShowDevelopmentBuildWatermark),
+            o => o.ShowDevelopmentBuildWatermark,
+            (o, v) => o.ShowDevelopmentBuildWatermark = v);
+
     private bool _isMicaSupported;
 
     public static readonly DirectProperty<MyWindow, bool> IsMicaSupportedProperty = AvaloniaProperty.RegisterDirect<MyWindow, bool>(
@@ -67,6 +75,15 @@ public partial class MyWindow : AppWindow
     {
         get => _enableMicaWindow;
         set => SetAndRaise(EnableMicaWindowProperty, ref _enableMicaWindow, value);
+    }
+
+    /// <summary>
+    /// 是否在窗口中显示开发构建水印。
+    /// </summary>
+    public bool ShowDevelopmentBuildWatermark
+    {
+        get => _showDevelopmentBuildWatermark;
+        set => SetAndRaise(ShowDevelopmentBuildWatermarkProperty, ref _showDevelopmentBuildWatermark, value);
     }
 
     public static readonly AttachedProperty<MyWindowState?> StateProperty =
@@ -187,9 +204,11 @@ public partial class MyWindow : AppWindow
             layer?.Children.Add(appToastAdorner);
             AdornerLayer.SetAdornedElement(appToastAdorner, window);
 
-            if ((AppBase.Current.IsDevelopmentBuild || ShowOssWatermark))
+            var showDevelopmentBuildWatermark =
+                window is MyWindow myWindow && myWindow.ShowDevelopmentBuildWatermark && AppBase.Current.IsDevelopmentBuild;
+            if (showDevelopmentBuildWatermark || ShowOssWatermark)
             {
-                var adorner = new DevelopmentBuildAdorner(AppBase.Current.IsDevelopmentBuild, ShowOssWatermark);
+                var adorner = new DevelopmentBuildAdorner(showDevelopmentBuildWatermark, ShowOssWatermark);
                 layer?.Children.Add(adorner);
                 AdornerLayer.SetAdornedElement(adorner, window);
             }

--- a/ClassIsland/Views/SettingsWindowNew.axaml
+++ b/ClassIsland/Views/SettingsWindowNew.axaml
@@ -16,6 +16,7 @@
         MinWidth="560"
         Title="应用设置" Height="550" Width="1240"
         EnableMicaWindow="True"
+        ShowDevelopmentBuildWatermark="True"
         windowing:AppWindow.AllowInteractionInTitleBar="True"
         SizeChanged="SettingsWindowNew_OnSizeChanged"
         Closing="SettingsWindowNew_OnClosing"


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？
- 修复开发构建水印会在主界面/屏幕边缘长期显示的问题（这是一个BUG吗？应该不是刻意的吧）。

<img width="2484" height="1160" alt="image" src="https://github.com/user-attachments/assets/8af8e36a-25dc-47bc-8af7-bc3e39caa59b" />

- 为 `MyWindow` 增加实例级 `ShowDevelopmentBuildWatermark` 开关，默认不显示开发构建水印。
- 仅在应用设置窗口 `SettingsWindowNew` 中显式开启开发构建水印。
- 保留 `--showOssWatermark` 对开源地址水印的全局显示能力。

## 检查清单

- [X] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


