### PR TITLE
fix(TimeLayoutItem):修复了在时间表中点击刷新按钮时，若时间表中存在两个起始时间相同的项就会发生顺序跳变的问题(issue#1820)

### DIFF
--- a/ClassIsland.Shared/Models/Profile/TimeLayoutItem.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayoutItem.cs
@@ -220,11 +220,23 @@ public class TimeLayoutItem : AttachableSettingsObject, IComparable
         if (o.StartTime < StartTime)
         {
             return -1;
-        }
+        } 
+        
         if (o.StartTime > StartTime)
         {
             return 1;
         }
+        
+        if (o.EndTime < EndTime)
+        {
+            return -1;
+        }
+        
+        if (o.EndTime > EndTime)
+        {
+            return 1;
+        }
+        
         return 0;
     }
 


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？
<!--- 简要介绍这个 PR 做的工作，可以附上相关 issue 的链接等。 -->
### 问题复现
编辑档案 -> 时间表 -> 添加一个开始时间和结束时间相同的项（如分割线） -> 再添加一个开始时间和刚刚添加的那个相同的项 -> 反复点击“刷新”按钮 -> 每次点击“刷新”按钮，这两个项的顺序都会发生变化
### 问题溯源
当“刷新”按钮被点击时，调用了`ClassIsland.Views.ProfileSettingsWindow.UpdateTimeLayout()`方法，该方法内会对`TimeLayout.Layouts`集合进行排序，由于该集合内部的元素实现了`IComparable`接口，排序时会调用`CompareTo()`方法对集合内部的各项元素进行比较，但是该方法只比较了每个`TimeLayoutItem`的`StartTime`（开始时间）而没有比较`EndTime`（结束时间），导致在排序时两个开始时间相同的项会在点击“刷新”按钮后发生顺序跳变
### 修复
在`CompareTo()`方法内加入对`EndTime`的比较
## 相关 Issue
<!--- 如果这个 PR 可以关闭某些 issue，请像这样列出： 
Fixes #123
Fixes #456
详见：https://docs.github.com/zh/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Fixes #1820 
## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


