### PR TITLE
fix(build): 排除重复的 AvaloniaResource .axaml 条目

### DIFF
--- a/ClassIsland/ClassIsland.csproj
+++ b/ClassIsland/ClassIsland.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <UseWPF>false</UseWPF>
@@ -113,6 +113,7 @@
     </ItemGroup>
     <ItemGroup>
         <AvaloniaResource Include="Assets\**" />
+        <AvaloniaResource Remove="Assets\**\*.axaml" />
         <AvaloniaResource Remove="Assets\Localization\SettingsPage\General\Localization.SettingsPage.General.resx" />
         <AvaloniaResource Remove="Assets\Localization\SettingsPage\Localization.SettingsPage.resx" />
         <AvaloniaResource Remove="Assets\Localization\TrayMenu\Localization.TrayMenu.resx" />


### PR DESCRIPTION
Avalonia NuGet 包的 AvaloniaBuildTasks.props 已通过 AvaloniaXaml 自动收集 **\*.axaml 文件，而 ClassIsland.csproj 的
<AvaloniaResource Include="Assets\**" /> 又把同一批 .axaml 文件 包含了进来。GenerateAvaloniaResources target 执行时将AvaloniaXaml 合并入 AvaloniaResource，导致 .axaml 文件在资源索引中出现两次。AssemblyDescriptor 的 ToDictionary 遇到重复键抛出 ArgumentException，应用启动崩溃。

在 ClassIsland.csproj 中移除 AvaloniaResource 的 .axaml 文件， 避免重复，与 AvaloniaShared.props 已排除 .xaml 的方式保持一致。

## 检查清单

- [X] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


