### PR TITLE
fix(profile): 使时间表分割线等变更实时同步到课程表组件

### DIFF
--- a/ClassIsland.Shared/Models/Profile/ClassPlan.cs
+++ b/ClassIsland.Shared/Models/Profile/ClassPlan.cs
@@ -102,7 +102,6 @@ public class ClassPlan : AttachableSettingsObject
     /// </summary>
     public event EventHandler? ClassesChanged;
 
-
     private void NotifyClassesChanged()
     {
         ClassesChanged?.Invoke(this, EventArgs.Empty);

--- a/ClassIsland.Shared/Models/Profile/ClassPlan.cs
+++ b/ClassIsland.Shared/Models/Profile/ClassPlan.cs
@@ -290,6 +290,21 @@ public class ClassPlan : AttachableSettingsObject
                 }
                 break;
             case NotifyCollectionChangedAction.Replace:
+                if (e.RemoveIndexClasses >= 0 && e.RemoveIndexClasses < Classes.Count)
+                {
+                    Classes.RemoveAt(e.RemoveIndexClasses);
+                }
+
+                if (e.AddIndexClasses >= 0 && e.AddIndexClasses <= Classes.Count)
+                {
+                    var classInfo = new ClassInfo();
+                    if (TimeLayout != null)
+                    {
+                        classInfo.CurrentTimeLayout = TimeLayout;
+                        classInfo.Index = e.AddIndexClasses;
+                    }
+                    Classes.Insert(e.AddIndexClasses, classInfo);
+                }
                 break;
             case NotifyCollectionChangedAction.Move:
                 break;
@@ -299,6 +314,7 @@ public class ClassPlan : AttachableSettingsObject
                 throw new ArgumentOutOfRangeException();
         }
 
+        RefreshClassesList();
         NotifyClassesChanged();
     }
 

--- a/ClassIsland.Shared/Models/Profile/ClassPlan.cs
+++ b/ClassIsland.Shared/Models/Profile/ClassPlan.cs
@@ -218,6 +218,7 @@ public class ClassPlan : AttachableSettingsObject
     {
         if (TimeLayout != null)
         {
+            TimeLayout.Layouts.CollectionChanged -= LayoutsOnCollectionChanged;
             TimeLayout.Layouts.CollectionChanged += LayoutsOnCollectionChanged;
         }
         RefreshClassesList(true);
@@ -298,6 +299,8 @@ public class ClassPlan : AttachableSettingsObject
             default:
                 throw new ArgumentOutOfRangeException();
         }
+
+        NotifyClassesChanged();
     }
 
     private void LayoutsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace ClassIsland.Shared.Models.Profile;
@@ -51,7 +53,8 @@ public class TimeLayout : AttachableSettingsObject
     public TimeLayout()
     {
         PropertyChanged += OnPropertyChanged;
-        Layouts.CollectionChanged += (sender, args) => OnPropertyChanged(nameof(Layouts));
+        Layouts.CollectionChanged += LayoutsOnCollectionChanged;
+        AttachLayoutItems(Layouts);
     }
 
     /// <summary>
@@ -78,6 +81,48 @@ public class TimeLayout : AttachableSettingsObject
                 //LayoutObjectChanged?.Invoke(this, EventArgs.Empty);
                 break;
         }
+    }
+
+    private void LayoutsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems != null)
+        {
+            foreach (var item in e.OldItems.OfType<TimeLayoutItem>())
+            {
+                item.PropertyChanged -= TimeLayoutItemOnPropertyChanged;
+            }
+        }
+
+        if (e.NewItems != null)
+        {
+            foreach (var item in e.NewItems.OfType<TimeLayoutItem>())
+            {
+                item.PropertyChanged += TimeLayoutItemOnPropertyChanged;
+            }
+        }
+
+        OnPropertyChanged(nameof(Layouts));
+    }
+
+    private void AttachLayoutItems(IEnumerable<TimeLayoutItem> items)
+    {
+        foreach (var item in items)
+        {
+            item.PropertyChanged += TimeLayoutItemOnPropertyChanged;
+        }
+    }
+
+    private void DetachLayoutItems(IEnumerable<TimeLayoutItem> items)
+    {
+        foreach (var item in items)
+        {
+            item.PropertyChanged -= TimeLayoutItemOnPropertyChanged;
+        }
+    }
+
+    private void TimeLayoutItemOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        LayoutObjectChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -157,7 +202,11 @@ public class TimeLayout : AttachableSettingsObject
         set
         {
             if (Equals(value, _layouts)) return;
+            _layouts.CollectionChanged -= LayoutsOnCollectionChanged;
+            DetachLayoutItems(_layouts);
             _layouts = value;
+            _layouts.CollectionChanged += LayoutsOnCollectionChanged;
+            AttachLayoutItems(_layouts);
             OnPropertyChanged();
         }
     }

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -13,6 +13,7 @@ namespace ClassIsland.Shared.Models.Profile;
 public class TimeLayout : AttachableSettingsObject
 {
     private ObservableCollection<TimeLayoutItem> _layouts = new();
+    private readonly Dictionary<TimeLayoutItem, int> _timeTypeChangeClassIndexes = new();
     private string _name = "新时间表";
     private bool _isActivated = false;
     private bool _isActivatedManually = false;
@@ -89,7 +90,9 @@ public class TimeLayout : AttachableSettingsObject
         {
             foreach (var item in e.OldItems.OfType<TimeLayoutItem>())
             {
+                item.PropertyChanging -= TimeLayoutItemOnPropertyChanging;
                 item.PropertyChanged -= TimeLayoutItemOnPropertyChanged;
+                _timeTypeChangeClassIndexes.Remove(item);
             }
         }
 
@@ -97,6 +100,7 @@ public class TimeLayout : AttachableSettingsObject
         {
             foreach (var item in e.NewItems.OfType<TimeLayoutItem>())
             {
+                item.PropertyChanging += TimeLayoutItemOnPropertyChanging;
                 item.PropertyChanged += TimeLayoutItemOnPropertyChanged;
             }
         }
@@ -108,6 +112,7 @@ public class TimeLayout : AttachableSettingsObject
     {
         foreach (var item in items)
         {
+            item.PropertyChanging += TimeLayoutItemOnPropertyChanging;
             item.PropertyChanged += TimeLayoutItemOnPropertyChanged;
         }
     }
@@ -116,15 +121,65 @@ public class TimeLayout : AttachableSettingsObject
     {
         foreach (var item in items)
         {
+            item.PropertyChanging -= TimeLayoutItemOnPropertyChanging;
             item.PropertyChanged -= TimeLayoutItemOnPropertyChanged;
+            _timeTypeChangeClassIndexes.Remove(item);
         }
+    }
+
+    private void TimeLayoutItemOnPropertyChanging(object? sender, PropertyChangingEventArgs e)
+    {
+        if (sender is not TimeLayoutItem item || e.PropertyName != nameof(TimeLayoutItem.TimeType))
+        {
+            return;
+        }
+
+        _timeTypeChangeClassIndexes[item] = GetClassIndex(item);
     }
 
     private void TimeLayoutItemOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        if (sender is TimeLayoutItem item && e.PropertyName == nameof(TimeLayoutItem.TimeType))
+        {
+            NotifyTimeLayoutItemTypeChanged(item);
+            return;
+        }
+
         LayoutObjectChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    private void NotifyTimeLayoutItemTypeChanged(TimeLayoutItem item)
+    {
+        if (!_timeTypeChangeClassIndexes.TryGetValue(item, out var removeIndexClasses))
+        {
+            removeIndexClasses = GetClassIndex(item);
+        }
+        else
+        {
+            _timeTypeChangeClassIndexes.Remove(item);
+        }
+
+        LayoutItemChanged?.Invoke(this, new TimeLayoutUpdateEventArgs()
+        {
+            Action = NotifyCollectionChangedAction.Replace,
+            AddedItems = { item },
+            RemovedItems = { item },
+            AddIndex = Layouts.IndexOf(item),
+            RemoveIndex = Layouts.IndexOf(item),
+            AddIndexClasses = GetClassIndex(item),
+            RemoveIndexClasses = removeIndexClasses
+        });
+    }
+
+    private int GetClassIndex(TimeLayoutItem item)
+    {
+        if (item.TimeType != 0)
+        {
+            return -1;
+        }
+
+        return Layouts.Where(x => x.TimeType == 0).ToList().IndexOf(item);
+    }
     /// <summary>
     /// 在指定索引处插入时间点
     /// </summary>


### PR DESCRIPTION
分割线（TimeType==2）增删修改后，ValidTimeLayoutItems 缓存未失效，主界面课程表组件保持旧渲染结果，需要重启才更新。

修复方式：
- TimeLayout：订阅每个 TimeLayoutItem 的属性变化，属性变更时触发 LayoutObjectChanged 通知关联课表
- ClassPlan：TimeLayoutOnLayoutItemChanged 末尾补充 NotifyClassesChanged()，使分割线等非上课时间点增删也令 ValidTimeLayoutItems 标脏并通知绑定

<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？
档案编辑器中修改时间表（增删分割线、修改时间点属性等）后，主界面课程表组件无法实时更新，需重启应用才能生效。  
根因在于 `ClassPlan.ValidTimeLayoutItems` 存在缓存，而分割线（`TimeType == 2`）及时间点属性变化不会触发 `ClassesChanged`，导致缓存未标脏，界面仍显示旧数据。  
修复方案保持在模型层，无需在编辑器窗口额外手动刷新：  
- `TimeLayout`：监听每个 `TimeLayoutItem` 的属性变化，任何字段（`StartTime`、`EndTime`、`TimeType`、`BreakName` 等）变动时，通过 `LayoutObjectChanged` 通知所有关联课表；  
- `ClassPlan`：在 `TimeLayoutOnLayoutItemChanged` 末尾补充 `NotifyClassesChanged()`，确保新增/删除分割线或非上课时间点时，`ValidTimeLayoutItems` 缓存失效。  

该改动对所有使用 `ValidTimeLayoutItems` 的位置（课程表组件、明日课表、倒计时组件、通知提供方等）均生效，编辑器修改后即同步更新。

## 检查清单

- [X] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。

https://github.com/user-attachments/assets/384b7278-6469-47ab-95db-0ecbe68e87fc