### PR TITLE
fix(ui/setting/plugin): 插件清单解析失败时覆盖层未消除

### DIFF
--- a/ClassIsland/Views/SettingPages/PluginsSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/PluginsSettingsPage.axaml.cs
@@ -323,6 +323,7 @@ public partial class PluginsSettingsPage : SettingsPageBase
         manifests = await GetPluginManifestsAsync(paths);
         if (manifests.Count == 0)
         {
+            ViewModel.IsInstallingLocalPlugin = false;
             this.ShowWarningToast("未能从选择的文件中解析出任何可安装的插件包。");
             return;
         }


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？

#### 表现:
<img width="988" height="571" alt="image" src="https://github.com/user-attachments/assets/206c01de-d4a3-455a-af22-51b64af89e89" />

```shell 
fail | ClassIsland.Views.SettingPages.PluginsSettingsPage | 无法读取插件清单：xxxxxxx.cipx
(Line: 10, Col: 13, Idx: 273) - (Line: 10, Col: 14, Idx: 274): While scanning an anchor or alias, found value containing disallowed: []{},
```



## 检查清单

- [X] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


