### PR TITLE
fix:修复更新已禁用的插件后被启用的问题

### DIFF
--- a/ClassIsland/Services/PluginService.cs
+++ b/ClassIsland/Services/PluginService.cs
@@ -74,6 +74,7 @@ public class PluginService : IPluginService
         {
             try
             {
+                bool isEnabledBefore = true;
                 using var pkg = ZipFile.OpenRead(pkgPath);
                 var mf = pkg.GetEntry(PluginManifestFileName);
                 if (mf == null)
@@ -84,10 +85,15 @@ public class PluginService : IPluginService
                 Console.Write($"正在处理插件安装: {manifest.Name}({manifest.Id},{manifest.Version})...");
                 if (Directory.Exists(targetPath))
                 {
+                    if(File.Exists(Path.Combine(targetPath,".disabled")))
+                    {
+                        isEnabledBefore = false;
+                    }
                     Directory.Delete(targetPath, true);
                 }
                 Directory.CreateDirectory(targetPath);
                 ZipFile.ExtractToDirectory(pkgPath, targetPath);
+                if(!isEnabledBefore) File.WriteAllText(Path.Combine(targetPath, ".disabled"), "");
                 InstalledPlugins.Add(manifest);
             }
             catch (Exception e)


### PR DESCRIPTION
## 这个 Pull Request 做了什么？
此Pull Request更改了以下内容：
[fix:修复更新已禁用的插件后被启用的问题](https://github.com/ClassIsland/ClassIsland/commit/937fdf2daebe73dcab2bbb68f33b34efb046ee57)
## 相关 Issue
Fixes #1886 

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


