### PR TITLE
feat: 完成了新建时间表自动添加递增序号的功能

### DIFF
--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -14,10 +14,11 @@ public class TimeLayout : AttachableSettingsObject
 {
     private ObservableCollection<TimeLayoutItem> _layouts = new();
     private readonly Dictionary<TimeLayoutItem, int> _timeTypeChangeClassIndexes = new();
-    private string _name = "新时间表";
+    private string _name;
     private bool _isActivated = false;
     private bool _isActivatedManually = false;
     private bool _isOverlay = false;
+    private bool _isRenamed = false;
     private Guid? _overlaySourceId;
 
     /// <summary>
@@ -30,6 +31,20 @@ public class TimeLayout : AttachableSettingsObject
         {
             if (value == _isOverlay) return;
             _isOverlay = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 是否重命名过
+    /// </summary>
+    public bool IsRenamed
+    {
+        get => _isRenamed;
+        set
+        {
+            if (value == _isRenamed) return;
+            _isRenamed = value;
             OnPropertyChanged();
         }
     }
@@ -56,6 +71,7 @@ public class TimeLayout : AttachableSettingsObject
         PropertyChanged += OnPropertyChanged;
         Layouts.CollectionChanged += LayoutsOnCollectionChanged;
         AttachLayoutItems(Layouts);
+        CheckIsRenamed();
     }
 
     /// <summary>
@@ -84,6 +100,22 @@ public class TimeLayout : AttachableSettingsObject
         }
     }
 
+    /// <summary>
+    /// 用于兼容已创建的时间表
+    /// </summary>
+    private void CheckIsRenamed()
+    {
+        if (string.IsNullOrEmpty(Name) || IsRenamed)
+        {
+            return;
+        }
+
+        if (Name.Length != 5 || !Name.Contains("新时间表"))
+        {
+            IsRenamed = true;
+        }
+    }
+    
     private void LayoutsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (e.OldItems != null)
@@ -243,6 +275,10 @@ public class TimeLayout : AttachableSettingsObject
         set
         {
             if (value == _name) return;
+            if (!string.IsNullOrEmpty(Name))
+            {
+                IsRenamed = true;
+            }
             _name = value;
             OnPropertyChanged();
         }

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -148,7 +148,7 @@ public class TimeLayout : AttachableSettingsObject
             return;
         }
 
-        if (Name!.Length != 5 || !Name.Contains("新时间表"))
+        if (Name!.Length <= 5 || !Name.Contains("新时间表"))
         {
             IsRenamed = true;
             IsRenamedChecked = true;

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -14,12 +14,14 @@ public class TimeLayout : AttachableSettingsObject
 {
     private ObservableCollection<TimeLayoutItem> _layouts = new();
     private readonly Dictionary<TimeLayoutItem, int> _timeTypeChangeClassIndexes = new();
-    private string _name;
+    private string? _name;
     private bool _isActivated = false;
     private bool _isActivatedManually = false;
     private bool _isOverlay = false;
     private bool _isRenamed = false;
+    private bool _isRenamedCheckIgnore = false;
     private Guid? _overlaySourceId;
+    private bool _isRenamedChecked = false;
 
     /// <summary>
     /// 是否是临时层时间表
@@ -31,6 +33,34 @@ public class TimeLayout : AttachableSettingsObject
         {
             if (value == _isOverlay) return;
             _isOverlay = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 是否检查过有没有重命名
+    /// </summary>
+    public bool IsRenamedChecked
+    {
+        get => _isRenamedChecked;
+        set
+        {
+            if  (value == _isRenamedChecked) return;
+            _isRenamedChecked = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// 是否忽略重命名检查
+    /// </summary>
+    public bool IsRenamedCheckIgnore
+    {
+        get => _isRenamedCheckIgnore;
+        set
+        {
+            if  (value == _isRenamedCheckIgnore) return;
+            _isRenamedCheckIgnore = value;
             OnPropertyChanged();
         }
     }
@@ -71,7 +101,6 @@ public class TimeLayout : AttachableSettingsObject
         PropertyChanged += OnPropertyChanged;
         Layouts.CollectionChanged += LayoutsOnCollectionChanged;
         AttachLayoutItems(Layouts);
-        CheckIsRenamed();
     }
 
     /// <summary>
@@ -97,22 +126,32 @@ public class TimeLayout : AttachableSettingsObject
             case nameof(Layouts):
                 //LayoutObjectChanged?.Invoke(this, EventArgs.Empty);
                 break;
+            case nameof(Name):
+                CheckIsRenamed();
+                break;
         }
     }
 
     /// <summary>
-    /// 用于兼容已创建的时间表
+    /// 重命名检查，用于兼容已创建的时间表
     /// </summary>
     private void CheckIsRenamed()
     {
-        if (string.IsNullOrEmpty(Name) || IsRenamed)
+        if (IsRenamedCheckIgnore)
+        {
+            IsRenamedCheckIgnore = false;
+            return;
+        }
+        
+        if (IsRenamed || IsRenamedChecked)
         {
             return;
         }
 
-        if (Name.Length != 5 || !Name.Contains("新时间表"))
+        if (Name!.Length != 5 || !Name.Contains("新时间表"))
         {
             IsRenamed = true;
+            IsRenamedChecked = true;
         }
     }
     
@@ -269,7 +308,7 @@ public class TimeLayout : AttachableSettingsObject
     /// <summary>
     /// 时间表名称
     /// </summary>
-    public string Name
+    public string? Name
     {
         get => _name;
         set

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -14,7 +14,7 @@ public class TimeLayout : AttachableSettingsObject
 {
     private ObservableCollection<TimeLayoutItem> _layouts = new();
     private readonly Dictionary<TimeLayoutItem, int> _timeTypeChangeClassIndexes = new();
-    private string _name = "新时间表";
+    private string? _name;
     private bool _isActivated = false;
     private bool _isActivatedManually = false;
     private bool _isOverlay = false;
@@ -149,7 +149,7 @@ public class TimeLayout : AttachableSettingsObject
             return;
         }
 
-        if (Name.Length <= 5 || !Name.Contains("新时间表"))
+        if (Name!.Length <= 5 || !Name.Contains("新时间表"))
         {
             IsRenamed = true;
             IsRenamedChecked = true;
@@ -309,7 +309,7 @@ public class TimeLayout : AttachableSettingsObject
     /// <summary>
     /// 时间表名称
     /// </summary>
-    public string Name
+    public string? Name
     {
         get => _name;
         set

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -54,6 +54,7 @@ public class TimeLayout : AttachableSettingsObject
     /// <summary>
     /// 是否忽略重命名检查
     /// </summary>
+    [JsonIgnore]
     public bool IsRenamedCheckIgnore
     {
         get => _isRenamedCheckIgnore;

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -14,7 +14,7 @@ public class TimeLayout : AttachableSettingsObject
 {
     private ObservableCollection<TimeLayoutItem> _layouts = new();
     private readonly Dictionary<TimeLayoutItem, int> _timeTypeChangeClassIndexes = new();
-    private string? _name;
+    private string _name = "新时间表";
     private bool _isActivated = false;
     private bool _isActivatedManually = false;
     private bool _isOverlay = false;
@@ -149,7 +149,7 @@ public class TimeLayout : AttachableSettingsObject
             return;
         }
 
-        if (Name!.Length <= 5 || !Name.Contains("新时间表"))
+        if (Name.Length <= 5 || !Name.Contains("新时间表"))
         {
             IsRenamed = true;
             IsRenamedChecked = true;
@@ -309,7 +309,7 @@ public class TimeLayout : AttachableSettingsObject
     /// <summary>
     /// 时间表名称
     /// </summary>
-    public string? Name
+    public string Name
     {
         get => _name;
         set

--- a/ClassIsland.Shared/Models/Profile/TimeLayout.cs
+++ b/ClassIsland.Shared/Models/Profile/TimeLayout.cs
@@ -149,7 +149,7 @@ public class TimeLayout : AttachableSettingsObject
             return;
         }
 
-        if (Name!.Length <= 5 || !Name.Contains("新时间表"))
+        if (Name!.Length < 5 || !Name.Contains("新时间表"))
         {
             IsRenamed = true;
             IsRenamedChecked = true;

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -825,7 +825,7 @@ public partial class ProfileSettingsWindow : MyWindow
         {
             if (timeLayout.IsRenamed == false)
             {
-                if (int.TryParse(timeLayout.Name[4..], out int result))
+                if (int.TryParse(timeLayout.Name![4..], out int result))
                 {
                     if (result >= maxIndex)
                     {
@@ -846,7 +846,8 @@ public partial class ProfileSettingsWindow : MyWindow
     {
         var timeLayout = new TimeLayout()
         {
-            Name = NameTimeLayout()
+            IsRenamedCheckIgnore = true,
+            Name = NameTimeLayout(),
         };
         ViewModel.ProfileService.Profile.TimeLayouts.Add(Guid.NewGuid(), timeLayout);
         OpenDrawer("TimeLayoutInfoEditor");

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -825,14 +825,21 @@ public partial class ProfileSettingsWindow : MyWindow
         {
             if (timeLayout.IsRenamed == false)
             {
-                if (int.TryParse(timeLayout.Name![4..], out int result))
+                try
                 {
-                    if (result >= maxIndex)
+                    if (int.TryParse(timeLayout.Name[4..], out int result))
                     {
-                        maxIndex = result + 1;
+                        if (result >= maxIndex)
+                        {
+                            maxIndex = result + 1;
+                        }
+                    }
+                    else
+                    {
+                        timeLayout.IsRenamed = true;
                     }
                 }
-                else
+                catch (NullReferenceException e)
                 {
                     timeLayout.IsRenamed = true;
                 }

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -825,9 +825,9 @@ public partial class ProfileSettingsWindow : MyWindow
         {
             if (timeLayout.IsRenamed == false)
             {
-                if (int.TryParse(timeLayout.Name[4].ToString(), out int result))
+                if (int.TryParse(timeLayout.Name[4..], out int result))
                 {
-                    if (result > maxIndex || maxIndex == result)
+                    if (result >= maxIndex)
                     {
                         maxIndex = result + 1;
                     }

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -817,11 +817,32 @@ public partial class ProfileSettingsWindow : MyWindow
         timeLayout.SortCompleted();
     }
 
+    private string NameTimeLayout()
+    {
+        var maxIndex = 1;
+        var timeLayouts = ViewModel.ProfileService.Profile.TimeLayouts.Values;
+        foreach (var timeLayout in timeLayouts)
+        {
+            if (timeLayout.IsRenamed == false)
+            {
+                if (int.TryParse(timeLayout.Name[4].ToString(), out int result))
+                {
+                    if (result > maxIndex || maxIndex == result)
+                    {
+                        maxIndex = result + 1;
+                    }
+                }
+            }
+        }
+        
+        return "新时间表" + maxIndex;
+    }
+
     private void ButtonAddTimeLayout_OnClick(object sender, RoutedEventArgs e)
     {
         var timeLayout = new TimeLayout()
         {
-            Name = "新时间表"
+            Name = NameTimeLayout()
         };
         ViewModel.ProfileService.Profile.TimeLayouts.Add(Guid.NewGuid(), timeLayout);
         OpenDrawer("TimeLayoutInfoEditor");

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -825,21 +825,14 @@ public partial class ProfileSettingsWindow : MyWindow
         {
             if (timeLayout.IsRenamed == false)
             {
-                try
+                if (int.TryParse(timeLayout.Name![4..], out int result))
                 {
-                    if (int.TryParse(timeLayout.Name[4..], out int result))
+                    if (result >= maxIndex)
                     {
-                        if (result >= maxIndex)
-                        {
-                            maxIndex = result + 1;
-                        }
-                    }
-                    else
-                    {
-                        timeLayout.IsRenamed = true;
+                        maxIndex = result + 1;
                     }
                 }
-                catch (NullReferenceException e)
+                else
                 {
                     timeLayout.IsRenamed = true;
                 }

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -832,6 +832,10 @@ public partial class ProfileSettingsWindow : MyWindow
                         maxIndex = result + 1;
                     }
                 }
+                else
+                {
+                    timeLayout.IsRenamed = true;
+                }
             }
         }
         


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？
<!--- 简要介绍这个 PR 做的工作，可以附上相关 issue 的链接等。 -->
### 提要
该PR完成了新建时间表自动添加递增序号的功能。
### 变更文件

| 文件名 | 变更内容 |
|--------|---------|
| `ClassIsland.Shared/Models/Profile/TimeLayout.cs` | 新增 `IsRenamed` / `IsRenamedChecked` / `IsRenamedCheckIgnore` 属性；在 `Name` setter 中标记重命名状态；新增 `CheckIsRenamed()` 方法 |
| `ClassIsland/Views/ProfileSettingsWindow.axaml.cs` | 新增 `NameTimeLayout()` 方法 |

### 新增成员概要
| 成员 | 文件 | 说明 |
|------|------|------|
| `IsRenamed` | `TimeLayout.cs` | 标记该时间表是否已被用户手动重命名。`Name` setter 在非空名称覆盖时自动设为 `true` |
| `IsRenamedChecked` | `TimeLayout.cs` | 标记该时间表是否已完成兼容性检查（反序列化后只检查一次） |
| `IsRenamedCheckIgnore` | `TimeLayout.cs` | 瞬态属性，新建时间表时跳过当次命名回调触发的重命名检查 |
| `CheckIsRenamed()` | `TimeLayout.cs` | 兼容检查 |
| `NameTimeLayout()` | `ProfileSettingsWindow.axaml.cs` | 遍历所有未重命名的时间表，解析 `Name[4..]` 的数值后缀，返回 `"新时间表" + (最大序号 + 1)` |


## 相关 Issue
<!--- 如果这个 PR 可以关闭某些 issue，请像这样列出： 
Fixes #123
Fixes #456
详见：https://docs.github.com/zh/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Revolves #1864 

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。


