### PR TITLE
feat: 组件库按来源分组展示，区分内置与插件提供

### DIFF
--- a/ClassIsland.Core/Attributes/ComponentInfo.cs
+++ b/ClassIsland.Core/Attributes/ComponentInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using ClassIsland.Core.Helpers.UI;
+using ClassIsland.Core.Models.Plugin;
 using FluentAvalonia.UI.Controls;
 
 namespace ClassIsland.Core.Attributes;
@@ -61,6 +62,21 @@ public class ComponentInfo : Attribute
     public bool IsComponentContainer { get; internal set; } = false;
 
     internal List<string> MigrateSources { get; } = new();
+
+    /// <summary>
+    /// 组件来源插件。<c>null</c> 表示 ClassIsland 内置组件。
+    /// </summary>
+    public PluginInfo? SourcePlugin { get; internal set; }
+
+    /// <summary>
+    /// 是否为内置组件。
+    /// </summary>
+    public bool IsBuiltIn => SourcePlugin is null;
+
+    /// <summary>
+    /// 用于 UI 展示的来源名称。
+    /// </summary>
+    public string SourceName => SourcePlugin?.Manifest.Name ?? "内置";
 
     /// <inheritdoc />
     public ComponentInfo(string guid, string name, string iconSource, string description = "") : this(guid, name,

--- a/ClassIsland.Core/Extensions/Registry/ComponentRegistryExtensions.cs
+++ b/ClassIsland.Core/Extensions/Registry/ComponentRegistryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Core.Abstractions.Controls;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Models.Components;
 using ClassIsland.Core.Services.Registry;
@@ -62,6 +62,7 @@ public static class ComponentRegistryExtensions
             services.AddTransient(settings);
             info.SettingsType = settings;
         }
+        info.SourcePlugin = ComponentRegistryService.CurrentRegisteringPlugin.Value;
         ComponentRegistryService.Registered.Add(info);
         ComponentRegistryService.RegisteredSettings.Add(new ComponentSettings()
         {

--- a/ClassIsland.Core/Models/Components/ComponentGroup.cs
+++ b/ClassIsland.Core/Models/Components/ComponentGroup.cs
@@ -1,0 +1,12 @@
+using ClassIsland.Core.Attributes;
+using ClassIsland.Core.Models.Plugin;
+
+namespace ClassIsland.Core.Models.Components;
+
+/// <summary>
+/// 组件库分组。每个分组对应一个组件来源（内置或某个插件）。
+/// </summary>
+public record ComponentGroup(
+    string GroupName,
+    PluginInfo? Plugin,
+    IReadOnlyList<ComponentInfo> Components);

--- a/ClassIsland.Core/Services/Registry/ComponentRegistryService.cs
+++ b/ClassIsland.Core/Services/Registry/ComponentRegistryService.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Reflection.Metadata;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Models.Components;
+using ClassIsland.Core.Models.Plugin;
 
 namespace ClassIsland.Core.Services.Registry;
 
@@ -18,4 +19,38 @@ public class ComponentRegistryService
     public static ObservableCollection<ComponentSettings> RegisteredSettings { get; } = new();
 
     public static Dictionary<Guid, Guid> MigrationPairs { get; } = new();
+
+    /// <summary>
+    /// 当前正在注册组件的插件上下文。在插件 Initialize 期间由 PluginService 设置，
+    /// 供 ComponentRegistryExtensions.Register 读取以标记组件来源。
+    /// 内置组件注册时此值为 null。
+    /// </summary>
+    public static AsyncLocal<PluginInfo?> CurrentRegisteringPlugin { get; } = new();
+
+    /// <summary>
+    /// 获取按来源分组的组件列表，内置组在最前
+    /// 已加载但未注册任何组件的插件不会产生空分组。
+    /// </summary>
+    public static IReadOnlyList<ComponentGroup> GetGroupedSortedComponents()
+    {
+        var groups = Registered
+            .GroupBy(c => c.SourcePlugin?.Manifest.Id ?? Guid.Empty.ToString())
+            .Select(g =>
+            {
+                var first = g.First();
+                return new ComponentGroup(
+                    GroupName: first.SourceName,
+                    Plugin: first.SourcePlugin,
+                    Components: g.ToList());
+            })
+            .ToList();
+
+        // 内置组排最前，其余按 GroupName 升序（即插件名升序）；同为插件组时按 Plugin Id 二次排序
+        var ordered = groups
+            .OrderBy(g => g.Plugin is null ? 0 : 1)
+            .ThenBy(g => g.GroupName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(g => g.Plugin?.Manifest.Id ?? "")
+            .ToList();
+        return ordered;
+    }
 }

--- a/ClassIsland/Controls/EditMode/EditModeView.axaml
+++ b/ClassIsland/Controls/EditMode/EditModeView.axaml
@@ -145,69 +145,83 @@
         </ScrollViewer>
         <Grid x:Key="ComponentsDrawer" MaxWidth="{StaticResource SettingsContainerWidth}"
               RowDefinitions="* Auto Auto">
-            <ListBox ItemsSource="{Binding ViewModel.ComponentInfos}"
-                     SelectedItem="{Binding ViewModel.SelectedComponentInfo}"
-                     Classes="drag-source">
-                <ListBox.Styles>
-                    <Style Selector="ListBox.drag-source ListBoxItem">
-                        <Setter Property="Interaction.Behaviors">
-                            <BehaviorCollectionTemplate>
-                                <BehaviorCollection>
-                                    <ci:AdvancedManagedContextDragBehavior 
-                                        PreviewOpacity="0.5"
-                                        HorizontalDragThreshold="3" VerticalDragThreshold="3" Context="{Binding }">
-                                    </ci:AdvancedManagedContextDragBehavior>
-                                </BehaviorCollection>
-                            </BehaviorCollectionTemplate>
-                        </Setter>
-                    </Style>
-                </ListBox.Styles>
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <Grid HorizontalAlignment="Stretch" RowDefinitions="Auto,*" ColumnDefinitions="Auto,Auto,*,Auto"
-                              Margin="0 8" Height="50">
-                            <ci:TouchDragThumb Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                                               Width="24"/>
-                            <controls:IconSourceElement Grid.Column="1" Grid.Row="0"
-                                                        Grid.RowSpan="2"
-                                                        Width="32" Height="32"
-                                                        VerticalAlignment="Center"
-                                                        ClipToBounds="False"
-                                                        TextElement.FontSize="32"
-                                                        Classes="repair-fontsize"
-                                                        Margin="0 -4 4 0"
-                                                        IconSource="{Binding IconSource}"/>
-                            <TextBlock Grid.Row="0" Grid.Column="2"
-                                       Text="{Binding Name}"
-                                       HorizontalAlignment="Left"
-                                       VerticalAlignment="Top"
-                                       Margin="0 0 0 1"
-                                       TextTrimming="CharacterEllipsis"/>
-                            <TextBlock Grid.Row="1" Grid.Column="2"
-                                       Text="{Binding Description}"
-                                       Opacity="0.75"
-                                       FontSize="12"
-                                       FontWeight="Regular"
-                                       TextWrapping="Wrap"
-                                       HorizontalAlignment="Stretch"
-                                       TextAlignment="Left"
-                                       TextTrimming="CharacterEllipsis"/>
-                            
-                        </Grid>
+            <ScrollViewer Grid.Row="0" Padding="0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                <ItemsControl ItemsSource="{Binding ViewModel.ComponentGroups}">
+                    <ItemsControl.Styles>
+                        <Style Selector="ListBox.drag-source ListBoxItem">
+                            <Setter Property="Interaction.Behaviors">
+                                <BehaviorCollectionTemplate>
+                                    <BehaviorCollection>
+                                        <ci:AdvancedManagedContextDragBehavior
+                                            PreviewOpacity="0.5"
+                                            HorizontalDragThreshold="3" VerticalDragThreshold="3" Context="{Binding }">
+                                        </ci:AdvancedManagedContextDragBehavior>
+                                    </BehaviorCollection>
+                                </BehaviorCollectionTemplate>
+                            </Setter>
+                        </Style>
+                    </ItemsControl.Styles>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="components:ComponentGroup">
+                            <StackPanel Margin="0 0 0 12">
+                                <TextBlock Text="{Binding GroupName}"
+                                           FontWeight="SemiBold"
+                                           Margin="0 0 0 4"/>
+                                <ListBox ItemsSource="{Binding Components}"
+                                         SelectedItem="{Binding $parent[editMode:EditModeView].ViewModel.SelectedComponentInfo, Mode=OneWayToSource}"
+                                         Classes="drag-source"
+                                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                    <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid HorizontalAlignment="Stretch" RowDefinitions="Auto,*" ColumnDefinitions="Auto,Auto,*,Auto"
+                                              Margin="0 8" Height="50">
+                                            <ci:TouchDragThumb Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                                                               Width="24"/>
+                                            <controls:IconSourceElement Grid.Column="1" Grid.Row="0"
+                                                                        Grid.RowSpan="2"
+                                                                        Width="32" Height="32"
+                                                                        VerticalAlignment="Center"
+                                                                        ClipToBounds="False"
+                                                                        TextElement.FontSize="32"
+                                                                        Classes="repair-fontsize"
+                                                                        Margin="0 -4 4 0"
+                                                                        IconSource="{Binding IconSource}"/>
+                                            <TextBlock Grid.Row="0" Grid.Column="2"
+                                                       Text="{Binding Name}"
+                                                       HorizontalAlignment="Left"
+                                                       VerticalAlignment="Top"
+                                                       Margin="0 0 0 1"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="2"
+                                                       Text="{Binding Description}"
+                                                       Opacity="0.75"
+                                                       FontSize="12"
+                                                       FontWeight="Regular"
+                                                       TextWrapping="Wrap"
+                                                       HorizontalAlignment="Stretch"
+                                                       TextAlignment="Left"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel>
+                                            <Interaction.Behaviors>
+                                                <BehaviorCollection>
+                                                    <ci:WrapPanelAutoResizeBehavior TargetWidth="225"/>
+                                                </BehaviorCollection>
+                                            </Interaction.Behaviors>
+                                        </WrapPanel>
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                            </ListBox>
+                        </StackPanel>
                     </DataTemplate>
-                </ListBox.ItemTemplate>
-                <ListBox.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <WrapPanel>
-                            <Interaction.Behaviors>
-                                <BehaviorCollection>
-                                    <ci:WrapPanelAutoResizeBehavior TargetWidth="225"/>
-                                </BehaviorCollection>
-                            </Interaction.Behaviors>
-                        </WrapPanel>
-                    </ItemsPanelTemplate>
-                </ListBox.ItemsPanel>
-            </ListBox>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
             <Separator Grid.Row="1" Margin="0 4" />
             <TextBlock Grid.Row="2" HorizontalAlignment="Left" VerticalAlignment="Center"
                        Text="将组件拖动到主界面上即可添加组件。" Classes="l-instructive"

--- a/ClassIsland/Controls/EditMode/EditModeView.axaml.cs
+++ b/ClassIsland/Controls/EditMode/EditModeView.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -130,8 +130,8 @@ public partial class EditModeView : UserControl
         OpenDrawer("ComponentsDrawer", "组件库");
         ViewModel.TargetComponentsList = target;
         // 重载组件库列表项目，修复切换视图后无法拖拽的问题。
-        ViewModel.ComponentInfos = [];
-        ViewModel.ComponentInfos = ComponentRegistryService.Registered;
+        ViewModel.ComponentGroups = [];
+        ViewModel.ComponentGroups = ComponentRegistryService.GetGroupedSortedComponents();
         ViewModel.TutorialService.PushToNextSentenceByTag("classisland.mainwindow.editMode.componentsLib.open");
     }
     

--- a/ClassIsland/Services/PluginService.cs
+++ b/ClassIsland/Services/PluginService.cs
@@ -5,6 +5,7 @@ using ClassIsland.Core.Abstractions.Services.Management;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Enums;
 using ClassIsland.Core.Models.Plugin;
+using ClassIsland.Core.Services.Registry;
 using ClassIsland.Models.Plugins;
 using ClassIsland.Services.Management;
 using ClassIsland.Shared;
@@ -201,7 +202,17 @@ public class PluginService : IPluginService
                 if (!Directory.Exists(entranceObj.PluginConfigFolder))
                     Directory.CreateDirectory(entranceObj.PluginConfigFolder);
                 entranceObj.Info = info;
-                entranceObj.Initialize(context, services);
+                // 在插件 Initialize 期间设置当前注册插件上下文，以便组件注册时自动捕获来源
+                var previousPlugin = ComponentRegistryService.CurrentRegisteringPlugin.Value;
+                ComponentRegistryService.CurrentRegisteringPlugin.Value = info;
+                try
+                {
+                    entranceObj.Initialize(context, services);
+                }
+                finally
+                {
+                    ComponentRegistryService.CurrentRegisteringPlugin.Value = previousPlugin;
+                }
                 services.AddSingleton(typeof(PluginBase), entranceObj);
                 services.AddSingleton(entrance, entranceObj);
                 info.LoadStatus = PluginLoadStatus.Loaded;

--- a/ClassIsland/ViewModels/EditMode/EditModeViewModel.cs
+++ b/ClassIsland/ViewModels/EditMode/EditModeViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using ClassIsland.Controls.EditMode;
 using ClassIsland.Core.Abstractions.Services;
@@ -30,6 +30,7 @@ public partial class EditModeViewModel(
     [ObservableProperty] private VerticalDrawerOpenState _mainDrawerState;
     [ObservableProperty] private bool _isDrawerTempCollapsed;
     [ObservableProperty] private IReadOnlyList<ComponentInfo> _componentInfos = [];
+    [ObservableProperty] private IReadOnlyList<ComponentGroup> _componentGroups = [];
     [ObservableProperty] private int _componentSettingsTabIndex = 0;
     [ObservableProperty] private string _filterText = "";
     [ObservableProperty] private string _createProfileName = "";

--- a/ClassIsland/ViewModels/SettingsPages/ComponentsSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/ComponentsSettingsViewModel.cs
@@ -45,6 +45,12 @@ public partial class ComponentsSettingsViewModel : ObservableRecipient
     public IReadOnlyList<ComponentInfo> ContainerComponents { get; } =
         ComponentRegistryService.Registered.Where(x => x.IsComponentContainer).ToList();
 
+    /// <summary>
+    /// 按来源分组，供"组件库"Tab 展示。
+    /// </summary>
+    public IReadOnlyList<ComponentGroup> GroupedComponents { get; } =
+        ComponentRegistryService.GetGroupedSortedComponents();
+
     /// <inheritdoc/>
     public ComponentsSettingsViewModel(IComponentsService componentsService, SettingsService settingsService)
     {

--- a/ClassIsland/Views/SettingPages/ComponentsSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/ComponentsSettingsPage.axaml
@@ -346,54 +346,70 @@
                         Classes="compact"
                         SelectedIndex="{Binding ViewModel.SettingsTabControlIndex}">
                 <TabItem Header="组件库">
-                    <ListBox ItemsSource="{x:Static registry:ComponentRegistryService.Registered}"
-                             Classes="drag-source">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <Grid HorizontalAlignment="Stretch" RowDefinitions="Auto,*" ColumnDefinitions="Auto,Auto,*,Auto"
-                                      Margin="0 8" Height="50">
-                                    <ci:TouchDragThumb Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                                                       Width="24"/>
-                                    
-                                    <controls:IconSourceElement Grid.Column="1" Grid.Row="0"
-                                                                Grid.RowSpan="2"
-                                                                Width="32" Height="32"
-                                                                VerticalAlignment="Center"
-                                                                ClipToBounds="False"
-                                                                TextElement.FontSize="32"
-                                                                Classes="repair-fontsize"
-                                                                Margin="0 -4 4 0"
-                                                                IconSource="{Binding IconSource}"/>
-                                    <TextBlock Grid.Row="0" Grid.Column="2"
-                                               Text="{Binding Name}"
-                                               HorizontalAlignment="Left"
-                                               VerticalAlignment="Top"
-                                               Margin="0 0 0 1"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Row="1" Grid.Column="2"
-                                               Text="{Binding Description}"
-                                               Opacity="0.75"
-                                               FontSize="12"
-                                               FontWeight="Regular"
-                                               TextWrapping="Wrap"
-                                               HorizontalAlignment="Stretch"
-                                               TextAlignment="Left"
-                                               TextTrimming="CharacterEllipsis"/>
-                                </Grid>
+                    <!-- 按来源分组展示组件库 -->
+                    <ScrollViewer Padding="0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding ViewModel.GroupedComponents}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="components:ComponentGroup">
+                                    <StackPanel Margin="0 4 0 8">
+                                        <TextBlock Text="{Binding GroupName}"
+                                                   FontWeight="SemiBold"
+                                                   Margin="0 8 0 4"/>
+                                        <ListBox ItemsSource="{Binding Components}"
+                                                 Classes="drag-source"
+                                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                            <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid HorizontalAlignment="Stretch" RowDefinitions="Auto,*" ColumnDefinitions="Auto,Auto,*,Auto"
+                                                      Margin="0 8" Height="50">
+                                                    <ci:TouchDragThumb Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                                                                       Width="24"/>
+
+                                                    <controls:IconSourceElement Grid.Column="1" Grid.Row="0"
+                                                                                Grid.RowSpan="2"
+                                                                                Width="32" Height="32"
+                                                                                VerticalAlignment="Center"
+                                                                                ClipToBounds="False"
+                                                                                TextElement.FontSize="32"
+                                                                                Classes="repair-fontsize"
+                                                                                Margin="0 -4 4 0"
+                                                                                IconSource="{Binding IconSource}"/>
+                                                    <TextBlock Grid.Row="0" Grid.Column="2"
+                                                               Text="{Binding Name}"
+                                                               HorizontalAlignment="Left"
+                                                               VerticalAlignment="Top"
+                                                               Margin="0 0 0 1"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                    <TextBlock Grid.Row="1" Grid.Column="2"
+                                                               Text="{Binding Description}"
+                                                               Opacity="0.75"
+                                                               FontSize="12"
+                                                               FontWeight="Regular"
+                                                               TextWrapping="Wrap"
+                                                               HorizontalAlignment="Stretch"
+                                                               TextAlignment="Left"
+                                                               TextTrimming="CharacterEllipsis"/>
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                        <ListBox.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel>
+                                                    <Interaction.Behaviors>
+                                                        <BehaviorCollection>
+                                                            <ci:WrapPanelAutoResizeBehavior TargetWidth="225"/>
+                                                        </BehaviorCollection>
+                                                    </Interaction.Behaviors>
+                                                </WrapPanel>
+                                            </ItemsPanelTemplate>
+                                        </ListBox.ItemsPanel>
+                                    </ListBox>
+                                </StackPanel>
                             </DataTemplate>
-                        </ListBox.ItemTemplate>
-                        <ListBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel>
-                                    <Interaction.Behaviors>
-                                        <BehaviorCollection>
-                                            <ci:WrapPanelAutoResizeBehavior TargetWidth="225"/>
-                                        </BehaviorCollection>
-                                    </Interaction.Behaviors>
-                                </WrapPanel>
-                            </ItemsPanelTemplate>
-                        </ListBox.ItemsPanel>
-                    </ListBox>
+                        </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </TabItem>
                 <TabItem Header="组件设置" IsVisible="{Binding ViewModel.IsComponentSettingsVisible}">
                     <ci:ComponentPresenter Settings="{Binding ViewModel.SelectedComponentSettings}"


### PR DESCRIPTION
<!-- 感谢您参与 ClassIsland 的代码贡献！在贡献代码之前，请先阅读贡献准则 https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md -->

## 这个 Pull Request 做了什么？
在安装部分插件后，这些插件可以提供一些新增的组件，出现在`应用设置`-`主界面`-`组件`-`组件库`中，目前有两个问题：
1. 不知道某个组件是 ClassIsland 自带的，还是由某个插件提供的；
2. 当安装的插件过多，导致新增的组件过多，问题 1 更明显的同时会显得组件库非常乱。

> 如图，这是我在安装了一堆插件后的组件库：
> 
> <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/799ba631-6d79-4ae7-b285-3bc3840fb733" />

这个 Pull Request 对组件库进行了一系列变更，使其支持按来源分组展示组件，ClassIsland 自带组件将置顶展示在`内置`分组中，由某个插件提供的组件会展示在`(插件名)`分组中。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a7e74ecf-fb3a-4be4-97e7-808731bcc9fe" />

`编辑模式`也支持此特性。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3749a212-817f-42f2-af00-c5dc3716dd7f" />

~看了一看 issues 好像没人提这个需求~

## 检查清单

- [x] 我已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。

