### PR TITLE
fix(build): 修正开发环境变量路径

### DIFF
--- a/tools/plugin/build.ps1
+++ b/tools/plugin/build.ps1
@@ -37,7 +37,7 @@ catch {
 
 Write-Host "🔧 正在设置开发环境变量…" -ForegroundColor Cyan
 
-[Environment]::SetEnvironmentVariable("ClassIsland_DebugBinaryFile", [System.IO.Path]::GetFullPath("${classIslandRoot}\bin\Debug\net8.0-windows10.0.19041.0\ClassIsland.Desktop.exe"), 1)
-[Environment]::SetEnvironmentVariable("ClassIsland_DebugBinaryDirectory", [System.IO.Path]::GetFullPath("${classIslandRoot}/bin\Debug\net8.0-windows10.0.19041.0\"), 1)
+[Environment]::SetEnvironmentVariable("ClassIsland_DebugBinaryFile", [System.IO.Path]::GetFullPath("${classIslandRoot}\bin\Debug\net10.0-windows10.0.19041.0\ClassIsland.Desktop.exe"), 1)
+[Environment]::SetEnvironmentVariable("ClassIsland_DebugBinaryDirectory", [System.IO.Path]::GetFullPath("${classIslandRoot}/bin\Debug\net10.0-windows10.0.19041.0\"), 1)
 
 Write-Host "构建完成" -ForegroundColor Green


### PR DESCRIPTION
<!--
感谢您参与 ClassIsland 的贡献！

提交 PR 前请确认:
1. 已阅读贡献指南:
https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md

⚠ 在提交 PR 前，请确保您已在本地完成必要的测试，且确保要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
请确保填写以下信息:
-->

## 类型
<!-- 请至少选择一项 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
修复了插件开发环境配置工具将环境变量设置为旧版的 `bin\Debug\net8.0-windows10.0.19041.0\` 导致无法加载ClassIsland或加载到旧版ClassIsland的问题


## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
