### PR TITLE
fix(ui): prevent Markdown text from overlapping scrollbar

### DIFF
--- a/ClassIsland.Core/Themes/RichTextStyles.axaml
+++ b/ClassIsland.Core/Themes/RichTextStyles.axaml
@@ -131,7 +131,7 @@
         <!-- <Setter Property="Command" Value="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"/> -->
     </Style>
     
-    <Style Selector="mdxaml|MarkdownScrollViewer /template/ ScrollViewer">
+    <Style Selector="mdxaml|MarkdownScrollViewer ScrollViewer">
         <Setter Property="Padding" Value="8"/>
     </Style>
 </Styles>


### PR DESCRIPTION
## 变更

Fixes #1938。

`MarkdownScrollViewer` 的内部 `ScrollViewer` 是控件运行时动态创建的子控件，不属于模板树。原有 `MarkdownScrollViewer /template/ ScrollViewer` 选择器因此不会命中，设置的 `Padding=8` 没有生效，隐私政策文本会贴到垂直滚动条下方。

将选择器改为 `MarkdownScrollViewer ScrollViewer`，让现有的内容留白样式实际应用到内部滚动容器。

## 验证

- `dotnet build ClassIsland.Core/ClassIsland.Core.csproj -c Debug`（通过，0 errors）
- `git diff --check`（通过）

完整桌面项目构建需要 macOS 的完整 Xcode.app；当前环境只有 CommandLineTools，因此未执行桌面运行验证。