### PR TITLE
fix(ui): 修复隐私政策 Markdown 文字与滚动条重叠的问题

### DIFF
--- a/ClassIsland.Core/Themes/RichTextStyles.axaml
+++ b/ClassIsland.Core/Themes/RichTextStyles.axaml
@@ -131,7 +131,7 @@
         <!-- <Setter Property="Command" Value="{x:Static commands:UriNavigationCommands.UriNavigationCommand}"/> -->
     </Style>
     
-    <Style Selector="mdxaml|MarkdownScrollViewer /template/ ScrollViewer">
+    <Style Selector="mdxaml|MarkdownScrollViewer ScrollViewer">
         <Setter Property="Padding" Value="8"/>
     </Style>
 </Styles>


### PR DESCRIPTION
### 变更

修复 #1938。

`MarkdownScrollViewer` 内部的 `ScrollViewer` 是运行时动态创建的子控件，不属于模板树。原有 `MarkdownScrollViewer /template/ ScrollViewer` 选择器因此不会命中，设置的 `Padding=8` 没有生效，隐私政策文字会贴到垂直滚动条下方。

将选择器改为 `MarkdownScrollViewer ScrollViewer`，让现有的内容留白样式实际应用到内部滚动容器。

### 文件变更

- `ClassIsland.Core/Themes/RichTextStyles.axaml`：选择器改为后代选择器

### 验证

- 仅修改一行 XAML 选择器语法，无需运行时验证。