### PR TITLE
fix(ui): 修复换课窗口反复切换模式时高度不断增长的问题

### DIFF
--- a/ClassIsland/Views/ClassChangingWindow.axaml
+++ b/ClassIsland/Views/ClassChangingWindow.axaml
@@ -20,7 +20,6 @@
         MinHeight="175"
         Icon="/Assets/AppLogo.png"
         EnableMicaWindow="True"
-        SizeToContent="WidthAndHeight"
         d:DataContext="{d:DesignInstance local:ClassChangingWindow}"
         WindowStartupLocation="CenterScreen"
         Unloaded="Control_OnUnloaded">


### PR DESCRIPTION
### 变更

修复 #1523。

窗口设置了 `SizeToContent="WidthAndHeight"`，每次切换"替换/交换"模式时，Carousel 内不同高度的内容项（替换页面 → 紧凑的 ComboBox，交换页面 → 较高的 LessonsListBox）会触发布局重算，窗口高度不断累加增长。

移除 `SizeToContent="WidthAndHeight"`，改为使用固定尺寸 `Height="250"`（+ `MinHeight="175"` / `MinWidth="730"`），切换模式时窗口高度不再变化。

### 文件变更

- `ClassIsland/Views/ClassChangingWindow.axaml`：移除 `SizeToContent="WidthAndHeight"`

### 验证

- 问题有录屏证据和明确重现步骤（点击应用图标 → 选择换课 → 选择一个课程 → 在第二界面反复切换"交换"与"替换"）
- 修复后窗口高度不再增长