### PR TITLE
fix(ui):修复主题色来源文字不跟随主题

### DIFF
--- a/ClassIsland/ViewModels/SettingsPages/AppearanceSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/AppearanceSettingsViewModel.cs
@@ -13,6 +13,23 @@ public partial class AppearanceSettingsViewModel(SettingsService settingsService
     
     public ObservableCollection<FontFamily> FontFamilies { get; } =
         new([..FontManager.Current.SystemFonts, MainWindow.DefaultFontFamily]);
+
+    public List<ComboBoxOption> ThemeOptions { get; } =
+    [
+        new("\uE5CB", "跟随系统"),
+        new("\uF465", "明亮"),
+        new("\uF44B", "黑暗")
+    ];
+
+    public List<ComboBoxOption> ColorSourceOptions { get; } =
+    [
+        new("\uED39", "自定义"),
+        new("\uF42D", "系统壁纸", false, false),
+        new("\uEA1D", "系统"),
+        new("\uEEED", "屏幕主题色", false, false)
+    ];
     
     public SettingsService SettingsService { get; } = settingsService;
 }
+
+public sealed record ComboBoxOption(string Glyph, string Text, bool IsVisible = true, bool IsEnabled = true);

--- a/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
@@ -124,12 +124,14 @@
                                         Header="应用主题"
                                         Description="控制应用的明暗主题。">
                 <controls2:SettingsExpander.Footer>
-                    <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
+                    <ComboBox ItemsSource="{Binding ViewModel.ThemeOptions}"
                               SelectedIndex="{Binding ViewModel.SettingsService.Settings.Theme}"
                               HorizontalContentAlignment="Left">
-                        <controls1:IconText Glyph="&#xE5CB;" Text="跟随系统" />
-                        <controls1:IconText Glyph="&#xF465;" Text="明亮" />
-                        <controls1:IconText Glyph="&#xF44B;" Text="黑暗" />
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <controls1:IconText Glyph="{Binding Glyph}" Text="{Binding Text}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
                     </ComboBox>
                 </controls2:SettingsExpander.Footer>
             </controls2:SettingsExpander>
@@ -139,22 +141,21 @@
                                         Header="主题色来源"
                                         Description="控制应用选取主题色的途径。">
                 <controls2:SettingsExpander.Footer>
-                    <ComboBox Foreground="{DynamicResource MaterialDesignBody}"
+                    <ComboBox ItemsSource="{Binding ViewModel.ColorSourceOptions}"
                               SelectionChanged="ButtonUpdateWallpaper_OnClick"
                               HorizontalContentAlignment="Left"
                               SelectedIndex="{Binding ViewModel.SettingsService.Settings.ColorSource}">
-                        <ComboBoxItem>
-                            <controls1:IconText Glyph="&#xED39;" Text="自定义" />
-                        </ComboBoxItem>
-                        <ComboBoxItem IsVisible="False" IsEnabled="False">
-                            <controls1:IconText Glyph="&#xF42D;" Text="系统壁纸" />
-                        </ComboBoxItem>
-                        <ComboBoxItem>
-                            <controls1:IconText Glyph="&#xEA1D;" Text="系统" />
-                        </ComboBoxItem>
-                        <ComboBoxItem IsVisible="False" IsEnabled="False">
-                            <controls1:IconText Glyph="&#xEEED;" Text="屏幕主题色"/>
-                        </ComboBoxItem>
+                        <ComboBox.ItemContainerTheme>
+                            <ControlTheme TargetType="ComboBoxItem">
+                                <Setter Property="IsVisible" Value="{Binding IsVisible}" />
+                                <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
+                            </ControlTheme>
+                        </ComboBox.ItemContainerTheme>
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <controls1:IconText Glyph="{Binding Glyph}" Text="{Binding Text}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
                     </ComboBox>
                 </controls2:SettingsExpander.Footer>
             </controls2:SettingsExpander>

--- a/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
+++ b/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml
@@ -146,7 +146,7 @@
                               HorizontalContentAlignment="Left"
                               SelectedIndex="{Binding ViewModel.SettingsService.Settings.ColorSource}">
                         <ComboBox.ItemContainerTheme>
-                            <ControlTheme TargetType="ComboBoxItem">
+                            <ControlTheme TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
                                 <Setter Property="IsVisible" Value="{Binding IsVisible}" />
                                 <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
                             </ControlTheme>


### PR DESCRIPTION
<!--
感谢您参与 ClassIsland 的贡献！

提交 PR 前请确认:
1. 已阅读贡献指南:
https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md

⚠ 在提交 PR 前，请确保您已在本地完成必要的测试，且确保要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
请确保填写以下信息:
-->

## 类型
<!-- 请至少选择一项 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
修复了在“外观设置”中切换应用明暗主题时，“主题色来源”下拉框的当前选中项会保留旧主题下的文字和图标颜色。
## 截图 / 录屏

https://github.com/user-attachments/assets/2cef9c91-18c1-43f5-8532-9d389e7bf742



## 实现说明
## 原因

`ComboBox` 直接包含 `IconText` 控件作为选项内容时，Avalonia 会缓存选中项的视觉对象；主题切换不会重新解析其中的动态颜色资源。

## 修改

- 将“应用主题”和“主题色来源”下拉框改为使用数据项与 `ComboBox.ItemTemplate` 渲染选项。
- 保留原有主题色来源的选项顺序、索引、隐藏和禁用行为。
- 移除旧的 `MaterialDesignBody` 前景色引用，交由 FluentAvalonia 默认样式处理。
- 主题色来源的 `ItemContainerTheme` 继承默认 `ComboBoxItem` 主题，确保下拉框保持 Fluent 样式。


## 相关 Issue
Fixes #1172 

## 检查清单

<!-- 
⚠ 在勾选这个复选框前，请确保您已经**真正**完成了必要的测试并保证这个 PR 要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
如果您是正在自动填写此模板的 Agent，请确保您已经完成了必要的测试。如果没有测试条件，请提醒调用者完成测试。
-->

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用）  
