### PR TITLE
fix(ui/profile-editor): 修复新建档案对话框显示在主界面的问题

### DIFF
--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -353,7 +353,7 @@ public partial class ProfileSettingsWindow : MyWindow
             DefaultButton = ContentDialogButton.Primary,
             PrimaryButtonText = "新建",
             SecondaryButtonText = "取消"
-        }.ShowAsync();
+        }.ShowAsync(this);
 
         var path = Path.Combine(Services.ProfileService.ProfilePath, $"{textBox.Text}.json");
         if (r != ContentDialogResult.Primary || File.Exists(path))


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 这个 Pull Request 做了什么？

修复了档案编辑器中新建档案对话框显示在主界面的问题。

在档案编辑页面的「管理档案」抽屉中点击「新建档案」后，输入框（ContentDialog）会跑到主界面内部显示，而不是显示在档案编辑窗口中。

## 实现说明

### 根因

ContentDialog.ShowAsync() 无参调用时，FluentAvalonia 会遍历所有窗口寻找当前活动窗口来放置对话框。如果档案编辑窗口（ProfileSettingsWindow）在调用时没被识别为活动窗口，代码会回退到 MainWindow（主界面），导致对话框出现在主界面的 OverlayLayer 中。

### 修复

将 .ShowAsync() 改为 .ShowAsync(this)，显式指定当前窗口为对话框的父级，确保对话框始终显示在档案编辑窗口内。

**改动文件**: ClassIsland/Views/ProfileSettingsWindow.axaml.cs:356

## 破坏性变更

无

## 相关 Issue

无

## 审查说明

无特殊说明。

## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [ ] 涉及 UI 变更时，我已补充截图或录屏（如适用）