### PR TITLE
fix(ui/profile-editor): 修复删除时间表弹窗自动关闭与 CommandBar 溢出盖住 MICA 的问题

### DIFF
--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -489,6 +489,26 @@
                         Click="ButtonDeleteSelectedClassPlan_OnClick" />
             </StackPanel>
         </Flyout>
+        
+        <Flyout x:Key="DeleteTimeLayoutConfirmFlyout"
+                ShowMode="Transient">
+            <StackPanel Spacing="8">
+                <TextBlock FontWeight="Bold">
+                    <Run Text="要删除时间表" />
+                    <Run
+                        Text="{Binding ViewModel.SelectedTimeLayout.Name}" />
+                    <Run Text="吗？" />
+                </TextBlock>
+                <TextBlock Text="此操作无法撤销。" />
+                <Button Content="删除" Classes="accent"
+                        Click="ButtonDeleteTimeLayout_OnClick" />
+            </StackPanel>
+        </Flyout>
+
+        <!-- 打开溢出菜单时保持透明背景，避免盖住窗口的 MICA 效果 -->
+        <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+        <!-- 打开溢出菜单时去掉 CommandBar 的描边边框 -->
+        <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
     </ci:MyWindow.Resources>
     <ci:DrawerHost DrawerPlacement="Right"
                IsDrawerOpen="{Binding ViewModel.IsDrawerOpen, Mode=TwoWay}"
@@ -1162,7 +1182,8 @@
 
                                 <ci:TutorialBarrier Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="3"
                                                     ExcludedTags="classisland.profileSettingsWindow.timeLayouts.timePoints.add">
-                                    <controls:CommandBar DefaultLabelPosition="Right"
+                                    <controls:CommandBar x:Name="CommandBarTimeLayout"
+                                                         DefaultLabelPosition="Right"
                                                          IsEnabled="{Binding !$parent[views:ProfileSettingsWindow].ViewModel.ManagementService.Policy.DisableProfileTimeLayoutEditing}"
                                                          Classes="hide-popup-indicator">
                                         <controls:CommandBar.PrimaryCommands>
@@ -1247,25 +1268,10 @@
                                                                        IconSource="{ci:FluentIconSource &#xE9E4;}"
                                                                        ToolTip.Tip="查看并编辑时间表的基本信息。"
                                                                        Label="时间表信息" />
-                                            <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE61D;}"
+                                            <controls:CommandBarButton Click="ButtonDeleteTimeLayoutMenu_OnClick"
+                                                                       IconSource="{ci:FluentIconSource &#xE61D;}"
                                                                        ToolTip.Tip="删除该时间表。"
-                                                                       Label="删除时间表">
-                                                <controls:CommandBarButton.Flyout>
-                                                    <Flyout>
-                                                        <StackPanel Spacing="8">
-                                                            <TextBlock FontWeight="Bold">
-                                                                <Run Text="要删除时间表" />
-                                                                <Run
-                                                                    Text="{Binding $parent[views:ProfileSettingsWindow].ViewModel.SelectedTimeLayout.Name}" />
-                                                                <Run Text="吗？" />
-                                                            </TextBlock>
-                                                            <TextBlock Text="此操作无法撤销。" />
-                                                            <Button Content="删除" Classes="accent"
-                                                                    Click="ButtonDeleteTimeLayout_OnClick" />
-                                                        </StackPanel>
-                                                    </Flyout>
-                                                </controls:CommandBarButton.Flyout>
-                                            </controls:CommandBarButton>
+                                                                       Label="删除时间表" />
                                         </controls:CommandBar.PrimaryCommands>
                                     </controls:CommandBar>
                                 </ci:TutorialBarrier>

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -844,7 +844,27 @@ public partial class ProfileSettingsWindow : MyWindow
         SentrySdk.Metrics.EmitCounter("views.ProfileSettingsWindow.timeLayout.duplicate", 1);
     }
     
-    private async void ButtonDeleteTimeLayout_OnClick(object sender, RoutedEventArgs e)
+    private void ButtonDeleteTimeLayoutMenu_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (this.FindResource("DeleteTimeLayoutConfirmFlyout") is not Flyout flyout)
+        {
+            return;
+        }
+
+        var target = sender is CommandBarButton { IsInOverflow: true }
+            ? GetOverflowAnchor()
+            : (Control)sender;
+        flyout.ShowAt(target);
+    }
+
+    private Control GetOverflowAnchor()
+    {
+        return (Control?)CommandBarTimeLayout.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Name == "MoreButton") ?? CommandBarTimeLayout;
+    }
+
+    private void ButtonDeleteTimeLayout_OnClick(object sender, RoutedEventArgs e)
     {
         var key = ViewModel.ProfileService.Profile.TimeLayouts
             .FirstOrDefault(x => x.Value == ViewModel.SelectedTimeLayout).Key;

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -353,7 +353,7 @@ public partial class ProfileSettingsWindow : MyWindow
             DefaultButton = ContentDialogButton.Primary,
             PrimaryButtonText = "新建",
             SecondaryButtonText = "取消"
-        }.ShowAsync();
+        }.ShowAsync(this);
 
         var path = Path.Combine(Services.ProfileService.ProfilePath, $"{textBox.Text}.json");
         if (r != ContentDialogResult.Primary || File.Exists(path))

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -851,6 +851,10 @@ public partial class ProfileSettingsWindow : MyWindow
             return;
         }
 
+        // 确认弹窗的生命周期不再绑定在“删除时间表”按钮上：按钮在 CommandBar 溢出区时，
+        // 点击后 FluentAvalonia 会关闭溢出弹窗并使按钮从可视化树分离，若 Flyout 以按钮为
+        // placement target，会因 target 分离被自动关闭。因此按钮在溢出区时改为锚定到
+        // CommandBar 行的溢出按钮（三个点）。
         var target = sender is CommandBarButton { IsInOverflow: true }
             ? GetOverflowAnchor()
             : (Control)sender;


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 这个 Pull Request 做了什么？

修复档案编辑器中"删除时间表"按钮在 CommandBar 溢出区时无法使用的问题，以及该 CommandBar 打开溢出菜单时盖住窗口 MICA 效果的问题。

- 修复：当窗口较窄、"删除时间表"按钮被挤入 CommandBar 溢出区时，点击后确认弹窗会立即自动关闭。根因是确认弹窗锚定在溢出区内的按钮上，点击后 FluentAvalonia 会因 `IsInOverflow` 关闭 CommandBar 溢出弹窗，导致按钮从可视化树分离，确认弹窗因 placement target 分离被自动关闭。
- 将删除时间表确认弹窗改为窗口资源，手动 `ShowAt`：按钮在溢出区时锚定到 CommandBar 行的"三个点"按钮，不再依赖溢出区按钮的生命周期。
- 设置 `ShowMode="Transient"`，避免焦点移入弹窗内容导致父窗口失焦触发 light-dismiss 关闭。
- 修复：打开溢出菜单时，CommandBar `:compact:open` 状态会把背景换成不透明亚克力画刷并显示 1px 描边边框，盖住窗口的 MICA 效果。已在档案编辑窗口资源中覆盖 `CommandBarBackgroundOpen` / `CommandBarBorderBrushOpen` 为透明。

## 截图 / 录屏

修改前：

https://github.com/user-attachments/assets/46727ae7-a7bb-445b-ac7b-1c276228de59


修改后：
https://github.com/user-attachments/assets/cfa088eb-9bb0-4b73-b693-2207547517de


## 实现说明

根因：`ProfileSettingsWindow` 时间表编辑器的 CommandBar 有 11 个带文字按钮，窗口未最大化时放不下，末尾的"删除时间表"按钮进入溢出区。FluentAvalonia 的 `CommandBarButton.OnClick` 在 `IsInOverflow == true` 时会设置 `CommandBar.IsOpen = false` 关闭溢出弹窗，进而使按钮（即 Flyout 的 placement target）从可视化树分离；`PopupFlyoutBase.PlacementTarget_DetachedFromVisualTree` 随即调用 `HideCore(false)` 关闭确认弹窗。由此产生 "PlatformImpl is null" 警告及确认弹窗打开即关的现象。

## 破坏性变更

无

## 相关 Issue

无

## 审查说明

- 涉及 FluentAvalonia 内部行为（CommandBar 溢出按钮生命周期、`:compact:open` 样式覆盖），请维护者留意。
- `CommandBarBackgroundOpen` / `CommandBarBorderBrushOpen` 的透明覆盖当前仅作用于档案编辑窗口，若其他窗口（如设置页）的 CommandBar 也需要，可后续提升到全局主题。

## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南。
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用）。
