### PR TITLE
feat(api): 在 IWeatherService 中公开最近天气信息

### DIFF
--- a/ClassIsland.Core/Abstractions/Services/IWeatherService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IWeatherService.cs
@@ -20,6 +20,11 @@ public interface IWeatherService : INotifyPropertyChanged
     /// 天气是否已经刷新
     /// </summary>
     bool IsWeatherRefreshed { get; set; }
+
+    /// <summary>
+    /// 最近一次获取到的天气信息。如果尚未获取到天气信息，则为 <see langword="null"/>。
+    /// </summary>
+    WeatherInfo? LastWeatherInfo { get; }
     /// <summary>
     /// 立刻查询天气
     /// </summary>

--- a/ClassIsland.Core/Abstractions/Services/IWeatherService.cs
+++ b/ClassIsland.Core/Abstractions/Services/IWeatherService.cs
@@ -24,7 +24,11 @@ public interface IWeatherService : INotifyPropertyChanged
     /// <summary>
     /// 最近一次获取到的天气信息。如果尚未获取到天气信息，则为 <see langword="null"/>。
     /// </summary>
-    WeatherInfo? LastWeatherInfo { get; }
+    /// <remarks>
+    /// 提供默认实现以保持源代码兼容性：使用旧版 SDK 编译、未实现此成员的现有实现
+    /// （如第三方插件或测试替身）仍可正常加载，调用时将回退为 <see langword="null"/>。
+    /// </remarks>
+    WeatherInfo? LastWeatherInfo => null;
     /// <summary>
     /// 立刻查询天气
     /// </summary>

--- a/ClassIsland/Services/WeatherService.cs
+++ b/ClassIsland/Services/WeatherService.cs
@@ -45,6 +45,11 @@ public class WeatherService : ObservableRecipient, IHostedService, IWeatherServi
 
     public bool IsWeatherRefreshed { get; set; } = false;
 
+    /// <summary>
+    /// 最近一次获取到的天气信息。
+    /// </summary>
+    public WeatherInfo LastWeatherInfo => Settings.LastWeatherInfo;
+
     public bool IsPosUpdated { get; set; } = false;
 
     public WeatherService(SettingsService settingsService, ILogger<WeatherService> logger, IRulesetService rulesetService, ILocationService locationService)


### PR DESCRIPTION
在 IWeatherService 接口中新增只读属性 LastWeatherInfo，
返回最近一次获取到的天气信息（无数据时为 null），并在
WeatherService 中基于 Settings.LastWeatherInfo 实现。

插件等外部扩展此前无法通过公共接口读取当前天气数据，
只能依赖反射访问主程序内部设置。此更改向插件开放该能力，
为后续基于天气的插件功能（如硬件推送、自定义提醒）提供支撑。

- IWeatherService 新增属性，属于纯新增 API，不影响现有实现与调用方
- WeatherService 实现复用现有 Settings 数据源，无行为变化

## 检查清单

<!-- 
⚠ 在勾选这个复选框前，请确保您已经**真正**完成了必要的测试并保证这个 PR 要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
如果您是正在自动填写此模板的 Agent，请确保您已经完成了必要的测试。如果没有测试条件，请提醒调用者完成测试。
-->

- [X] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [X] 我已阅读并遵循贡献指南
