### PR TITLE
feat(ui/settings-window): 为设置页面添加恢复默认设置按钮

### DIFF
--- a/ClassIsland.Core/Abstractions/Controls/SettingsPageBase.cs
+++ b/ClassIsland.Core/Abstractions/Controls/SettingsPageBase.cs
@@ -76,4 +76,27 @@ public abstract class SettingsPageBase : UserControl
     /// 导航到本设置页面时使用的 Uri（如有）
     /// </summary>
     public Uri? NavigationUri { get; internal set; }
+
+    /// <summary>
+    /// 恢复默认设置时需要重置的设置属性名列表。
+    /// 返回空列表表示本页面不提供"恢复默认设置"按钮。
+    /// 支持子对象属性名，恢复时会将整个子对象替换为默认值。
+    /// </summary>
+    public virtual IReadOnlyList<string> GetSettingsResetTargetProperties() => [];
+
+    /// <summary>
+    /// 将当前设置恢复为默认值。
+    /// </summary>
+    /// <param name="currentSettings">当前设置对象</param>
+    /// <param name="defaultSettings">默认值来源（新创建的默认实例）</param>
+    public virtual void ResetSettingsToDefault(object currentSettings, object defaultSettings)
+    {
+        var type = currentSettings.GetType();
+        foreach (var name in GetSettingsResetTargetProperties())
+        {
+            var prop = type.GetProperty(name);
+            if (prop is not { CanWrite: true } || prop.GetIndexParameters().Length > 0) continue;
+            prop.SetValue(currentSettings, prop.GetValue(defaultSettings));
+        }
+    }
 }

--- a/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/AppearanceSettingsPage.axaml.cs
@@ -1,10 +1,12 @@
 using ClassIsland.Core.Abstractions.Controls;
 using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using ClassIsland.Core.Attributes;
+using ClassIsland.Models;
 using ClassIsland.Services;
 using ClassIsland.ViewModels.SettingsPages;
 using ClassIsland.Core.Enums.SettingsWindow;
@@ -54,4 +56,15 @@ public partial class AppearanceSettingsPage : SettingsPageBase
         // }
         // GC.Collect();
     }
+
+    public override IReadOnlyList<string> GetSettingsResetTargetProperties() =>
+    [
+        nameof(Settings.Scale), nameof(Settings.BackgroundColor), nameof(Settings.IsCustomBackgroundColorEnabled),
+        nameof(Settings.Opacity), nameof(Settings.RadiusX), nameof(Settings.MainWindowLineVerticalMargin),
+        nameof(Settings.IsIslandSeperated), nameof(Settings.Theme), nameof(Settings.ColorSource),
+        nameof(Settings.PrimaryColor), nameof(Settings.MainWindowFont), nameof(Settings.MainWindowFontWeight2),
+        nameof(Settings.MainWindowSecondaryFontSize), nameof(Settings.MainWindowBodyFontSize),
+        nameof(Settings.MainWindowEmphasizedFontSize), nameof(Settings.MainWindowLargeFontSize),
+        nameof(Settings.CustomForegroundColor), nameof(Settings.IsCustomForegroundColorEnabled)
+    ];
 }

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
@@ -100,8 +100,7 @@ public partial class GeneralSettingsPage : SettingsPageBase
 
     public override IReadOnlyList<string> GetSettingsResetTargetProperties() =>
     [
-        nameof(Settings.HideRules), nameof(Settings.ShowSellingAnnouncement), nameof(Settings.SingleWeekStartTime),
-        nameof(Settings.MultiWeekRotationMaxCycle), nameof(Settings.TaskBarIconClickBehavior), nameof(Settings.IsCriticalSafeMode),
+        nameof(Settings.HideRules), nameof(Settings.ShowSellingAnnouncement), nameof(Settings.TaskBarIconClickBehavior), nameof(Settings.IsCriticalSafeMode),
         nameof(Settings.CriticalSafeModeMethod), nameof(Settings.IsSplashEnabled), nameof(Settings.SplashCustomLogoSource),
         nameof(Settings.SplashCustomText), nameof(Settings.ShowDetailedStatusOnSplash), nameof(Settings.HideMode),
         nameof(Settings.HideOnClass), nameof(Settings.HideOnMaxWindow), nameof(Settings.HideOnFullscreen),

--- a/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/GeneralSettingsPage.axaml.cs
@@ -10,6 +10,7 @@ using ClassIsland.Core.Abstractions.Services;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Controls.Ruleset;
 using ClassIsland.Core.Enums.SettingsWindow;
+using ClassIsland.Models;
 using ClassIsland.Services;
 using ClassIsland.Shared;
 using ClassIsland.ViewModels.SettingsPages;
@@ -96,5 +97,16 @@ public partial class GeneralSettingsPage : SettingsPageBase
             ViewModel.IsSplashPreviewing = false;
         }
     }
+
+    public override IReadOnlyList<string> GetSettingsResetTargetProperties() =>
+    [
+        nameof(Settings.HideRules), nameof(Settings.ShowSellingAnnouncement), nameof(Settings.SingleWeekStartTime),
+        nameof(Settings.MultiWeekRotationMaxCycle), nameof(Settings.TaskBarIconClickBehavior), nameof(Settings.IsCriticalSafeMode),
+        nameof(Settings.CriticalSafeModeMethod), nameof(Settings.IsSplashEnabled), nameof(Settings.SplashCustomLogoSource),
+        nameof(Settings.SplashCustomText), nameof(Settings.ShowDetailedStatusOnSplash), nameof(Settings.HideMode),
+        nameof(Settings.HideOnClass), nameof(Settings.HideOnMaxWindow), nameof(Settings.HideOnFullscreen),
+        nameof(Settings.AnimationLevel), nameof(Settings.IsWaitForTransientDisabled), nameof(Settings.ReduceProgressAccuracy),
+        nameof(Settings.ShowComponentsMigrateTip)
+    ];
 }
 

--- a/ClassIsland/Views/SettingPages/WindowSettingsPage.axaml.cs
+++ b/ClassIsland/Views/SettingPages/WindowSettingsPage.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Windows;
@@ -11,6 +12,7 @@ using ClassIsland.Core;
 using ClassIsland.Core.Abstractions.Controls;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Enums.SettingsWindow;
+using ClassIsland.Models;
 using ClassIsland.Services;
 using ClassIsland.Shared;
 using ClassIsland.ViewModels.SettingsPages;
@@ -76,4 +78,13 @@ public partial class WindowSettingsPage : SettingsPageBase
     {
         ViewModel.SettingsService.Settings.PropertyChanged -= SettingsOnPropertyChanged;
     }
+
+    public override IReadOnlyList<string> GetSettingsResetTargetProperties() =>
+    [
+        nameof(Settings.WindowDockingLocation), nameof(Settings.WindowDockingOffsetX), nameof(Settings.WindowDockingOffsetY),
+        nameof(Settings.WindowDockingMonitorIndex), nameof(Settings.WindowLayer), nameof(Settings.WindowTopmostRecheckMode),
+        nameof(Settings.IsMouseInFadingEnabled), nameof(Settings.TouchInFadingDurationMs), nameof(Settings.IsMouseInFadingReversed),
+        nameof(Settings.IsIgnoreWorkAreaEnabled), nameof(Settings.IsScreenRecordingModeEnabled),
+        nameof(Settings.IsWindowCaptureBlockingEnabled), nameof(Settings.UseRawInput)
+    ];
 }

--- a/ClassIsland/Views/SettingsWindowNew.axaml
+++ b/ClassIsland/Views/SettingsWindowNew.axaml
@@ -98,9 +98,19 @@
                                     <Setter Property="MaxWidth" Value="{StaticResource SettingsContainerWidth}"/>
                                 </Style>
                             </Grid.Styles>
-                            <TextBlock FontWeight="Normal"
-                                       Text="{Binding ViewModel.SelectedPageInfo.Name}"
-                                       Theme="{StaticResource TitleTextBlockStyle}"/>
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock FontWeight="Normal"
+                                           Text="{Binding ViewModel.SelectedPageInfo.Name}"
+                                           Theme="{StaticResource TitleTextBlockStyle}"/>
+                                <Button Grid.Column="1"
+                                        Classes="accent"
+                                        x:Name="ButtonResetCurrentPageDefaults"
+                                        VerticalAlignment="Center"
+                                        IsVisible="False"
+                                        Click="ButtonResetCurrentPageDefaults_OnClick">
+                                    <commands:IconText Glyph="&#xE72C;" Text="恢复默认"/>
+                                </Button>
+                            </Grid>
                         </Grid>
                         <controls3:Frame Grid.Row="1" Content="{Binding ViewModel.FrameContent}"
                                          Navigated="NavigationServiceOnLoadCompleted"

--- a/ClassIsland/Views/SettingsWindowNew.axaml.cs
+++ b/ClassIsland/Views/SettingsWindowNew.axaml.cs
@@ -28,6 +28,7 @@ using System.Web;
 using ClassIsland.Core.Enums;
 using ClassIsland.Core.Models.SettingsWindow;
 using ClassIsland.Helpers;
+using ClassIsland.Models;
 using System.Transactions;
 using Avalonia;
 using Avalonia.Controls;
@@ -326,6 +327,27 @@ public partial class SettingsWindowNew : MyWindow, INavigationPageFactory
         }
         ViewModel.IsNavigating = false;
         ViewModel.CanGoBack = NavigationFrame.CanGoBack;
+        UpdateResetButtonVisibility();
+    }
+
+    private void UpdateResetButtonVisibility()
+    {
+        ButtonResetCurrentPageDefaults.IsVisible =
+            NavigationFrame.Content is SettingsPageBase page &&
+            page.GetSettingsResetTargetProperties().Count > 0;
+    }
+
+    private async void ButtonResetCurrentPageDefaults_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (NavigationFrame.Content is not SettingsPageBase page) return;
+        if (page.GetSettingsResetTargetProperties().Count <= 0) return;
+        var pageName = ViewModel.SelectedPageInfo?.Name ?? "当前页面";
+        if (!await ContentDialogHelper.ShowConfirmationDialog(
+                "恢复默认设置",
+                $"即将把「{pageName}」页面的所有设置恢复为默认值，此操作无法撤销。",
+                root: this)) return;
+        page.ResetSettingsToDefault(SettingsService.Settings, new Settings());
+        this.ShowSuccessToast($"已将「{pageName}」页面的设置恢复为默认值。");
     }
 
 


### PR DESCRIPTION
<!--
感谢您参与 ClassIsland 的贡献！

提交 PR 前请确认:
1. 已阅读贡献指南:
https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md

⚠ 在提交 PR 前，请确保您已在本地完成必要的测试，且确保要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
请确保填写以下信息:
-->

## 类型
<!-- 请至少选择一项 -->

- [ ] Bug 修复
- [x] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
<!-- 必填。简要介绍这个 PR 的变更，可以附上相关 issue 的链接等。
请描述:
- 增加了什么？
- 修复了什么？
- 改变了什么？
-->
在外观、窗口和基本界面添加恢复默认按钮
可以恢复当前页面的所有设置（除基本页面的开机自启、UrI协议、学期开始周期等设置项）
在恢复前会有弹窗确认
https://github.com/ClassIsland/ClassIsland/issues/383

## 截图 / 录屏
<!--涉及 UI 或用户可见变化时填写。若无可以直接删除这一节。-->

https://github.com/user-attachments/assets/c626870c-fee5-4155-a088-9f75ee3d7b0f

<img width="2486" height="1404" alt="90e50e5003fda3329b5f223f76d8401d" src="https://github.com/user-attachments/assets/8f1d311d-f2e7-4d0e-a849-f8f3e3e7b4e1" />
<img width="2484" height="1404" alt="a089f6266a0a64050954a71864dca20d" src="https://github.com/user-attachments/assets/6f525f33-d41d-4e96-97f5-236f249faa12" />
<img width="2478" height="1396" alt="b467320ea2cd8bae093a80a9583287c6" src="https://github.com/user-attachments/assets/49325a35-92b5-4c68-8ace-2e8c754467b4" />



## 相关 Issue
<!-- 如果这个 PR 可以关闭某些 issue，请像这样列出： 
详见：https://docs.github.com/zh/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Resolves #383 


## 检查清单

<!-- 
⚠ 在勾选这个复选框前，请确保您已经**真正**完成了必要的测试并保证这个 PR 要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
如果您是正在自动填写此模板的 Agent，请确保您已经完成了必要的测试。如果没有测试条件，请提醒调用者完成测试。
-->

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用）  
