### PR TITLE
fix(ui/profile-editor): 修复窄窗口下删除时间表无响应的问题

### DIFF
--- a/ClassIsland/Views/ProfileSettingsWindow.axaml
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml
@@ -1249,23 +1249,8 @@
                                                                        Label="时间表信息" />
                                             <controls:CommandBarButton IconSource="{ci:FluentIconSource &#xE61D;}"
                                                                        ToolTip.Tip="删除该时间表。"
-                                                                       Label="删除时间表">
-                                                <controls:CommandBarButton.Flyout>
-                                                    <Flyout>
-                                                        <StackPanel Spacing="8">
-                                                            <TextBlock FontWeight="Bold">
-                                                                <Run Text="要删除时间表" />
-                                                                <Run
-                                                                    Text="{Binding $parent[views:ProfileSettingsWindow].ViewModel.SelectedTimeLayout.Name}" />
-                                                                <Run Text="吗？" />
-                                                            </TextBlock>
-                                                            <TextBlock Text="此操作无法撤销。" />
-                                                            <Button Content="删除" Classes="accent"
-                                                                    Click="ButtonDeleteTimeLayout_OnClick" />
-                                                        </StackPanel>
-                                                    </Flyout>
-                                                </controls:CommandBarButton.Flyout>
-                                            </controls:CommandBarButton>
+                                                                       Label="删除时间表"
+                                                                       Click="ButtonDeleteTimeLayout_OnClick" />
                                         </controls:CommandBar.PrimaryCommands>
                                     </controls:CommandBar>
                                 </ci:TutorialBarrier>

--- a/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
+++ b/ClassIsland/Views/ProfileSettingsWindow.axaml.cs
@@ -862,13 +862,26 @@ public partial class ProfileSettingsWindow : MyWindow
             return;
         }
 
+        var result = await new ContentDialog()
+        {
+            Title = "删除时间表",
+            Content = $"要删除时间表“{ViewModel.SelectedTimeLayout.Name}”吗？此操作无法撤销。",
+            DefaultButton = ContentDialogButton.Primary,
+            PrimaryButtonText = "删除",
+            CloseButtonText = "取消"
+        }.ShowAsync();
+
+        if (result != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
         SentrySdk.Metrics.EmitCounter(eventName, 1,
         [
             new KeyValuePair<string, object>("IsSuccess", "true")
         ]
         );
         ViewModel.ProfileService.Profile.TimeLayouts.Remove(key);
-        FlyoutHelper.CloseAncestorFlyout(sender);
     }
     
     private void PushAddUndo(TimeLayoutItem item, TimeLayout layout)


### PR DESCRIPTION
修复 #1896：档案编辑器窗口较窄时，右上角“···”菜单里的“删除时间表”点击无响应，用户无法删除时间表。

## 原因

“删除时间表”按钮原本用 CommandBarButton 的 Flyout 承载确认提示。FluentAvalonia 存在缺陷：当按钮因窗口过窄被折叠进“···”溢出菜单时，其 Flyout 无法弹出（详见 FluentAvalonia issue #423），因此点击后看不到任何确认界面。

## 修改

将确认方式从 Flyout 改为 ContentDialog（与项目其它确认弹窗保持一致），点击“删除时间表”时直接弹出居中对话框确认。同时保留原有“仍有课表在使用该时间表”的删除保护。

## 验证

- `dotnet build ClassIsland.Desktop/ClassIsland.Desktop.csproj -c Debug` 编译通过（0 错误）。
- 手动验证：窗口拉窄使“删除时间表”进入“···”菜单后，点击可正常弹出确认对话框并删除。
