### PR TITLE
feat(speech): add OpenAI-compatible TTS provider

### DIFF
--- a/ClassIsland/App.Services.xaml.cs
+++ b/ClassIsland/App.Services.xaml.cs
@@ -283,6 +283,7 @@ public partial class App
         }
         services.AddSpeechProvider<EdgeTtsService, EdgeTtsSpeechServiceSettingsControl>();
         services.AddSpeechProvider<GptSoVitsService, GptSovitsSpeechServiceSettingsControl>();
+        services.AddSpeechProvider<OpenAiTtsService, OpenAiTtsSpeechServiceSettingsControl>();
         // 天气图标模板
         services.AddWeatherIconTemplate("classisland.weatherIcons.lucide", "Lucide（默认）", (this.FindResource("LucideWeatherIconTemplate") as IDataTemplate)!);
         services.AddWeatherIconTemplate("classisland.weatherIcons.fluentDesign", "Fluent Design", (this.FindResource("FluentDesignWeatherIconTemplate") as IDataTemplate)!);

--- a/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml
+++ b/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml
@@ -36,8 +36,9 @@
         <controls:SettingsExpanderItem Content="声音">
             <controls:SettingsExpanderItem.Footer>
                 <ComboBox Width="180"
+                          IsEditable="True"
                           ItemsSource="{Binding Voices}"
-                          SelectedItem="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.Voice, Mode=TwoWay}" />
+                          Text="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.Voice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </controls:SettingsExpanderItem.Footer>
         </controls:SettingsExpanderItem>
 

--- a/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml
+++ b/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml
@@ -1,0 +1,63 @@
+﻿<ci:SpeechProviderControlBase x:Class="ClassIsland.Controls.SpeechProviderSettingsControls.OpenAiTtsSpeechServiceSettingsControl"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ClassIsland.Controls.SpeechProviderSettingsControls"
+             xmlns:ci="http://classisland.tech/schemas/xaml/core"
+             xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <StackPanel DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:OpenAiTtsSpeechServiceSettingsControl}}"
+                Spacing="1">
+        <controls:SettingsExpanderItem Description="兼容 OpenAI TTS 接口的服务地址，会自动请求其 /v1/audio/speech 路径。">
+            <ci:Field Label="服务地址">
+                <TextBox Text="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.BaseUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Watermark="https://api.openai.com" />
+            </ci:Field>
+        </controls:SettingsExpanderItem>
+
+        <controls:SettingsExpanderItem Description="请求接口使用的 Bearer API Key。留空时不发送 Authorization 请求头。">
+            <ci:Field Label="API Key">
+                <TextBox Text="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.ApiKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         PasswordChar="●"
+                         Watermark="sk-…" />
+            </ci:Field>
+        </controls:SettingsExpanderItem>
+
+        <controls:SettingsExpanderItem Content="模型">
+            <controls:SettingsExpanderItem.Footer>
+                <TextBox Width="180"
+                         Text="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.Model, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Watermark="tts-1" />
+            </controls:SettingsExpanderItem.Footer>
+        </controls:SettingsExpanderItem>
+
+        <controls:SettingsExpanderItem Content="声音">
+            <controls:SettingsExpanderItem.Footer>
+                <ComboBox Width="180"
+                          ItemsSource="{Binding Voices}"
+                          SelectedItem="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.Voice, Mode=TwoWay}" />
+            </controls:SettingsExpanderItem.Footer>
+        </controls:SettingsExpanderItem>
+
+        <controls:SettingsExpanderItem Content="音频格式">
+            <controls:SettingsExpanderItem.Footer>
+                <ComboBox Width="180"
+                          ItemsSource="{Binding ResponseFormats}"
+                          SelectedItem="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.ResponseFormat, Mode=TwoWay}" />
+            </controls:SettingsExpanderItem.Footer>
+        </controls:SettingsExpanderItem>
+
+        <controls:SettingsExpanderItem Content="语速" Description="OpenAI TTS 支持 0.25 到 4 倍速。">
+            <controls:SettingsExpanderItem.Footer>
+                <NumericUpDown Width="180"
+                               Minimum="0.25"
+                               Maximum="4"
+                               Increment="0.05"
+                               FormatString="0.##"
+                               Value="{Binding SettingsService.Settings.OpenAiTtsSpeechSettings.Speed, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={x:Static ci:NotNaNConverter.Instance}}" />
+            </controls:SettingsExpanderItem.Footer>
+        </controls:SettingsExpanderItem>
+    </StackPanel>
+</ci:SpeechProviderControlBase>

--- a/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml.cs
+++ b/ClassIsland/Controls/SpeechProviderSettingsControls/OpenAiTtsSpeechServiceSettingsControl.axaml.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Services;
+
+namespace ClassIsland.Controls.SpeechProviderSettingsControls;
+
+/// <summary>
+/// OpenAiTtsSpeechServiceSettingsControl.xaml 的交互逻辑。
+/// </summary>
+public partial class OpenAiTtsSpeechServiceSettingsControl : SpeechProviderControlBase
+{
+    public SettingsService SettingsService { get; }
+
+    public IReadOnlyList<string> Voices { get; } =
+        ["alloy", "echo", "fable", "onyx", "nova", "shimmer"];
+
+    public IReadOnlyList<string> ResponseFormats { get; } =
+        ["mp3", "opus", "aac", "flac", "wav", "pcm"];
+
+    public OpenAiTtsSpeechServiceSettingsControl(SettingsService settingsService)
+    {
+        SettingsService = settingsService;
+        InitializeComponent();
+    }
+}

--- a/ClassIsland/Models/OpenAiTtsSpeechSettings.cs
+++ b/ClassIsland/Models/OpenAiTtsSpeechSettings.cs
@@ -1,0 +1,27 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ClassIsland.Models;
+
+/// <summary>
+/// OpenAI 兼容语音合成服务设置。
+/// </summary>
+public partial class OpenAiTtsSpeechSettings : ObservableObject
+{
+    [ObservableProperty]
+    private string _baseUrl = "https://api.openai.com";
+
+    [ObservableProperty]
+    private string _apiKey = "";
+
+    [ObservableProperty]
+    private string _model = "tts-1";
+
+    [ObservableProperty]
+    private string _voice = "alloy";
+
+    [ObservableProperty]
+    private string _responseFormat = "mp3";
+
+    [ObservableProperty]
+    private double _speed = 1.0;
+}

--- a/ClassIsland/Models/Settings.cs
+++ b/ClassIsland/Models/Settings.cs
@@ -216,10 +216,21 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
     private string _selectedUpdateMirrorV2 = "main";
     private string _selectedUpdateChannelV2 = "stable";
     private GptSoVitsSpeechSettings _gptSoVitsSpeechSettings = new();
+    private OpenAiTtsSpeechSettings _openAiTtsSpeechSettings = new();
     private double _mainWindowLineVerticalMargin = 5;
     private ObservableCollection<Guid> _trustedProfileIds = [];
     private bool _isNonExactCountdownEnabled = false;
     private bool _showDetailedStatusOnSplash = false;
+
+    public Settings()
+    {
+        _openAiTtsSpeechSettings.PropertyChanged += OpenAiTtsSpeechSettingsOnPropertyChanged;
+    }
+
+    private void OpenAiTtsSpeechSettingsOnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(OpenAiTtsSpeechSettings));
+    }
 
     public void NotifyPropertyChanged(string propertyName)
     {
@@ -1610,6 +1621,19 @@ public class Settings : ObservableRecipient, ILessonControlSettings, INotificati
         {
             if (Equals(value, _gptSoVitsSpeechSettings)) return;
             _gptSoVitsSpeechSettings = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public OpenAiTtsSpeechSettings OpenAiTtsSpeechSettings
+    {
+        get => _openAiTtsSpeechSettings;
+        set
+        {
+            if (Equals(value, _openAiTtsSpeechSettings)) return;
+            _openAiTtsSpeechSettings.PropertyChanged -= OpenAiTtsSpeechSettingsOnPropertyChanged;
+            _openAiTtsSpeechSettings = value ?? new OpenAiTtsSpeechSettings();
+            _openAiTtsSpeechSettings.PropertyChanged += OpenAiTtsSpeechSettingsOnPropertyChanged;
             OnPropertyChanged();
         }
     }

--- a/ClassIsland/Services/SpeechService/OpenAiTtsPlayInfo.cs
+++ b/ClassIsland/Services/SpeechService/OpenAiTtsPlayInfo.cs
@@ -3,9 +3,18 @@ using System.Threading.Tasks;
 
 namespace ClassIsland.Services.SpeechService;
 
-public class OpenAiTtsPlayInfo(string filePath, CancellationTokenSource cts, Task<bool>? generationTask)
+public class OpenAiTtsPlayInfo(string filePath, CancellationTokenSource cts,
+    InFlightSpeechGeneration? generation)
 {
     public string FilePath { get; } = filePath;
     public CancellationTokenSource CancellationTokenSource { get; } = cts;
-    public Task<bool>? GenerationTask { get; } = generationTask;
+    public InFlightSpeechGeneration? Generation { get; } = generation;
+    public bool IsGenerationConsumerReleased { get; set; }
+}
+
+public class InFlightSpeechGeneration(CancellationTokenSource cancellationTokenSource)
+{
+    public CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
+    public Task<bool> Task { get; set; } = null!;
+    public int ConsumerCount { get; set; }
 }

--- a/ClassIsland/Services/SpeechService/OpenAiTtsPlayInfo.cs
+++ b/ClassIsland/Services/SpeechService/OpenAiTtsPlayInfo.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClassIsland.Services.SpeechService;
+
+public class OpenAiTtsPlayInfo(string filePath, CancellationTokenSource cts, Task<bool>? generationTask)
+{
+    public string FilePath { get; } = filePath;
+    public CancellationTokenSource CancellationTokenSource { get; } = cts;
+    public Task<bool>? GenerationTask { get; } = generationTask;
+}

--- a/ClassIsland/Services/SpeechService/OpenAiTtsService.cs
+++ b/ClassIsland/Services/SpeechService/OpenAiTtsService.cs
@@ -1,0 +1,381 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassIsland.Core;
+using ClassIsland.Models;
+using ClassIsland.Core.Abstractions.Services;
+using ClassIsland.Core.Abstractions.Services.SpeechService;
+using ClassIsland.Core.Attributes;
+using ClassIsland.Shared.Abstraction.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ClassIsland.Services.SpeechService;
+
+/// <summary>
+/// 使用 OpenAI /v1/audio/speech 格式的语音合成服务。
+/// </summary>
+[SpeechProviderInfo("classisland.speech.openai", "OpenAI TTS")]
+public class OpenAiTtsService : ISpeechService
+{
+    public static readonly string OpenAiTtsCacheFolderPath =
+        Path.Combine(CommonDirectories.AppCacheFolderPath, "OpenAITTS");
+
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(60)
+    };
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly HashSet<string> SupportedResponseFormats =
+        ["mp3", "opus", "aac", "flac", "wav", "pcm"];
+
+    public IAudioService AudioService { get; }
+    private ILogger<OpenAiTtsService> Logger { get; }
+    private SettingsService SettingsService { get; }
+    private Queue<OpenAiTtsPlayInfo> PlayingQueue { get; } = new();
+    private object QueueLock { get; } = new();
+
+    private bool IsPlaying { get; set; }
+    private OpenAiTtsPlayInfo? _currentPlayInfo;
+
+    public OpenAiTtsService(IAudioService audioService, ILogger<OpenAiTtsService> logger,
+        SettingsService settingsService)
+    {
+        AudioService = audioService;
+        Logger = logger;
+        SettingsService = settingsService;
+
+        Logger.LogInformation("初始化了 OpenAI TTS 服务。");
+    }
+
+    public void EnqueueSpeechQueue(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        var currentSettings = SettingsService.Settings.OpenAiTtsSpeechSettings;
+        var settings = new OpenAiTtsSpeechSettings
+        {
+            BaseUrl = currentSettings.BaseUrl ?? string.Empty,
+            ApiKey = currentSettings.ApiKey ?? string.Empty,
+            Model = currentSettings.Model ?? string.Empty,
+            Voice = currentSettings.Voice ?? string.Empty,
+            ResponseFormat = currentSettings.ResponseFormat ?? string.Empty,
+            Speed = currentSettings.Speed
+        };
+        Logger.LogInformation("以 {Voice}（{Model}）朗读文本：{Text}", settings.Voice, settings.Model, text);
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        var cache = GetCachePath(text, settings);
+        Logger.LogDebug("OpenAI TTS 语音缓存路径：{CachePath}", cache);
+
+        lock (QueueLock)
+        {
+            Task<bool>? generationTask = null;
+            if (!File.Exists(cache))
+            {
+                generationTask = GenerateSpeechAsync(text, cache, settings, cancellationTokenSource.Token);
+            }
+
+            PlayingQueue.Enqueue(new OpenAiTtsPlayInfo(cache, cancellationTokenSource, generationTask));
+        }
+        _ = ProcessPlayerList();
+    }
+
+    public void ClearSpeechQueue()
+    {
+        OpenAiTtsPlayInfo? currentPlayInfo;
+        lock (QueueLock)
+        {
+            currentPlayInfo = _currentPlayInfo;
+            currentPlayInfo?.CancellationTokenSource.Cancel();
+            while (PlayingQueue.Count > 0)
+            {
+                CancelQueuedPlayInfo(PlayingQueue.Dequeue());
+            }
+        }
+    }
+
+    private static void CancelQueuedPlayInfo(OpenAiTtsPlayInfo playInfo)
+    {
+        playInfo.CancellationTokenSource.Cancel();
+        if (playInfo.GenerationTask == null)
+        {
+            playInfo.CancellationTokenSource.Dispose();
+            return;
+        }
+
+        _ = playInfo.GenerationTask.ContinueWith(_ => playInfo.CancellationTokenSource.Dispose(),
+            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+    }
+
+    private string GetCachePath(string text, OpenAiTtsSpeechSettings settings)
+    {
+        var responseFormat = GetResponseFormat(settings.ResponseFormat);
+        var cacheKey = string.Join("\n", text, settings.BaseUrl, settings.Model, settings.Voice,
+            responseFormat, settings.Speed.ToString("R", CultureInfo.InvariantCulture));
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cacheKey))).ToLowerInvariant();
+        var extension = responseFormat == "pcm"
+            ? "wav"
+            : SupportedResponseFormats.Contains(responseFormat) ? responseFormat : "invalid";
+        var path = Path.Combine(OpenAiTtsCacheFolderPath, extension, $"{hash}.{extension}");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        return path;
+    }
+
+    private async Task<bool> GenerateSpeechAsync(string text, string filePath, OpenAiTtsSpeechSettings settings,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        if (text.Length > 4096)
+        {
+            Logger.LogWarning("OpenAI TTS 文本长度超过 4096 个字符，无法生成语音。");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.BaseUrl) || string.IsNullOrWhiteSpace(settings.Model) ||
+            string.IsNullOrWhiteSpace(settings.Voice))
+        {
+            Logger.LogWarning("OpenAI TTS 设置不完整，请检查服务地址、模型和声音设置。");
+            return false;
+        }
+
+        if (settings.Speed is < 0.25 or > 4)
+        {
+            Logger.LogWarning("OpenAI TTS 语速必须在 0.25 到 4 之间。");
+            return false;
+        }
+
+        var responseFormat = GetResponseFormat(settings.ResponseFormat);
+        if (!SupportedResponseFormats.Contains(responseFormat))
+        {
+            Logger.LogWarning("OpenAI TTS 不支持音频格式：{ResponseFormat}", settings.ResponseFormat);
+            return false;
+        }
+
+        try
+        {
+            var requestUri = BuildSpeechUri(settings.BaseUrl);
+            using var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            if (!string.IsNullOrWhiteSpace(settings.ApiKey))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", settings.ApiKey.Trim());
+            }
+
+            request.Content = new StringContent(JsonSerializer.Serialize(new
+            {
+                model = settings.Model,
+                input = text,
+                voice = settings.Voice,
+                response_format = responseFormat,
+                speed = settings.Speed
+            }, JsonOptions), Encoding.UTF8, "application/json");
+
+            Logger.LogDebug("发送 OpenAI TTS 请求到：{RequestUri}", requestUri);
+            using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                Logger.LogError("OpenAI TTS 请求失败，状态码：{StatusCode}，内容：{ErrorContent}", response.StatusCode,
+                    errorContent);
+                return false;
+            }
+
+            var audio = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            if (audio.Length == 0)
+            {
+                Logger.LogError("OpenAI TTS 返回了空音频。");
+                return false;
+            }
+
+            var temporaryPath = $"{filePath}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                if (responseFormat == "pcm")
+                {
+                    await WritePcmAsWavAsync(temporaryPath, audio, cancellationToken);
+                }
+                else
+                {
+                    await File.WriteAllBytesAsync(temporaryPath, audio, cancellationToken);
+                }
+                File.Move(temporaryPath, filePath, true);
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+            }
+
+            Logger.LogDebug("OpenAI TTS 语音生成并保存到：{FilePath}", filePath);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            Logger.LogInformation("已取消获取 OpenAI TTS 语音：{Text}", text);
+            return false;
+        }
+        catch (UriFormatException ex)
+        {
+            Logger.LogError(ex, "OpenAI TTS 服务地址无效：{BaseUrl}", settings.BaseUrl);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "发送 OpenAI TTS 请求时发生异常。");
+            return false;
+        }
+    }
+
+    private static string GetResponseFormat(string? responseFormat) =>
+        responseFormat?.Trim().ToLowerInvariant() ?? string.Empty;
+
+    private static async Task WritePcmAsWavAsync(string filePath, byte[] pcmAudio,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+        var dataLength = pcmAudio.Length;
+
+        writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(36 + dataLength);
+        writer.Write(Encoding.ASCII.GetBytes("WAVE"));
+        writer.Write(Encoding.ASCII.GetBytes("fmt "));
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)1);
+        writer.Write(24000);
+        writer.Write(24000 * 2);
+        writer.Write((short)2);
+        writer.Write((short)16);
+        writer.Write(Encoding.ASCII.GetBytes("data"));
+        writer.Write(dataLength);
+        writer.Flush();
+        await stream.WriteAsync(pcmAudio.AsMemory(), cancellationToken);
+    }
+
+    private static Uri BuildSpeechUri(string? baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl) ||
+            !Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out var baseUri) ||
+            baseUri.Scheme is not ("http" or "https"))
+        {
+            throw new UriFormatException("OpenAI TTS 服务地址必须是有效的 HTTP(S) 地址。");
+        }
+
+        var path = baseUri.AbsolutePath.TrimEnd('/');
+        if (!path.EndsWith("/v1/audio/speech", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+                ? $"{path}/audio/speech"
+                : $"{path}/v1/audio/speech";
+        }
+
+        var builder = new UriBuilder(baseUri)
+        {
+            Path = path
+        };
+        return builder.Uri;
+    }
+
+    private async Task ProcessPlayerList()
+    {
+        lock (QueueLock)
+        {
+            if (IsPlaying)
+            {
+                return;
+            }
+
+            IsPlaying = true;
+        }
+
+        try
+        {
+            while (true)
+            {
+                OpenAiTtsPlayInfo playInfo;
+                lock (QueueLock)
+                {
+                    if (PlayingQueue.Count == 0)
+                    {
+                        break;
+                    }
+
+                    playInfo = _currentPlayInfo = PlayingQueue.Dequeue();
+                }
+
+                try
+                {
+                    if (playInfo.CancellationTokenSource.IsCancellationRequested)
+                    {
+                        continue;
+                    }
+
+                    if (playInfo.GenerationTask != null)
+                    {
+                        Logger.LogDebug("等待 OpenAI TTS 语音生成完成。");
+                        if (!await playInfo.GenerationTask)
+                        {
+                            Logger.LogError("OpenAI TTS 语音生成失败：{FilePath}", playInfo.FilePath);
+                            continue;
+                        }
+                    }
+
+                    if (!File.Exists(playInfo.FilePath))
+                    {
+                        Logger.LogError("OpenAI TTS 语音文件不存在：{FilePath}", playInfo.FilePath);
+                        continue;
+                    }
+
+                    Logger.LogDebug("开始播放 OpenAI TTS 语音：{FilePath}", playInfo.FilePath);
+                    await AudioService.PlayAudioAsync(playInfo.FilePath,
+                        (float)SettingsService.Settings.SpeechVolume, playInfo.CancellationTokenSource.Token);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "无法播放 OpenAI TTS 语音。");
+                }
+                finally
+                {
+                    lock (QueueLock)
+                    {
+                        _currentPlayInfo = null;
+                    }
+                    playInfo.CancellationTokenSource.Dispose();
+                }
+            }
+        }
+        finally
+        {
+            var shouldRestart = false;
+            lock (QueueLock)
+            {
+                _currentPlayInfo = null;
+                IsPlaying = false;
+                shouldRestart = PlayingQueue.Count > 0;
+            }
+
+            if (shouldRestart)
+            {
+                _ = ProcessPlayerList();
+            }
+        }
+    }
+}

--- a/ClassIsland/Services/SpeechService/OpenAiTtsService.cs
+++ b/ClassIsland/Services/SpeechService/OpenAiTtsService.cs
@@ -40,6 +40,7 @@ public class OpenAiTtsService : ISpeechService
     private ILogger<OpenAiTtsService> Logger { get; }
     private SettingsService SettingsService { get; }
     private Queue<OpenAiTtsPlayInfo> PlayingQueue { get; } = new();
+    private Dictionary<string, InFlightSpeechGeneration> InFlightGenerations { get; } = new();
     private object QueueLock { get; } = new();
 
     private bool IsPlaying { get; set; }
@@ -80,13 +81,34 @@ public class OpenAiTtsService : ISpeechService
 
         lock (QueueLock)
         {
-            Task<bool>? generationTask = null;
+            InFlightSpeechGeneration? generation = null;
             if (!File.Exists(cache))
             {
-                generationTask = GenerateSpeechAsync(text, cache, settings, cancellationTokenSource.Token);
+                if (InFlightGenerations.TryGetValue(cache, out generation) && generation.Task.IsCompleted)
+                {
+                    InFlightGenerations.Remove(cache);
+                    generation = null;
+                }
+
+                if (generation == null && !File.Exists(cache))
+                {
+                    generation = new InFlightSpeechGeneration(new CancellationTokenSource())
+                    {
+                        ConsumerCount = 1
+                    };
+                    InFlightGenerations[cache] = generation;
+                    generation.Task = GenerateSpeechAsync(text, cache, settings,
+                        generation.CancellationTokenSource.Token);
+                    _ = generation.Task.ContinueWith(_ => OnGenerationCompleted(cache, generation),
+                        CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                }
+                else if (generation != null)
+                {
+                    generation.ConsumerCount++;
+                }
             }
 
-            PlayingQueue.Enqueue(new OpenAiTtsPlayInfo(cache, cancellationTokenSource, generationTask));
+            PlayingQueue.Enqueue(new OpenAiTtsPlayInfo(cache, cancellationTokenSource, generation));
         }
         _ = ProcessPlayerList();
     }
@@ -97,7 +119,11 @@ public class OpenAiTtsService : ISpeechService
         lock (QueueLock)
         {
             currentPlayInfo = _currentPlayInfo;
-            currentPlayInfo?.CancellationTokenSource.Cancel();
+            if (currentPlayInfo != null)
+            {
+                currentPlayInfo.CancellationTokenSource.Cancel();
+                ReleaseGenerationConsumer(currentPlayInfo);
+            }
             while (PlayingQueue.Count > 0)
             {
                 CancelQueuedPlayInfo(PlayingQueue.Dequeue());
@@ -105,17 +131,34 @@ public class OpenAiTtsService : ISpeechService
         }
     }
 
-    private static void CancelQueuedPlayInfo(OpenAiTtsPlayInfo playInfo)
+    private void CancelQueuedPlayInfo(OpenAiTtsPlayInfo playInfo)
     {
         playInfo.CancellationTokenSource.Cancel();
-        if (playInfo.GenerationTask == null)
+        playInfo.CancellationTokenSource.Dispose();
+        ReleaseGenerationConsumer(playInfo);
+    }
+
+    private static void ReleaseGenerationConsumer(OpenAiTtsPlayInfo playInfo)
+    {
+        if (playInfo.Generation == null || playInfo.IsGenerationConsumerReleased)
         {
-            playInfo.CancellationTokenSource.Dispose();
             return;
         }
 
-        _ = playInfo.GenerationTask.ContinueWith(_ => playInfo.CancellationTokenSource.Dispose(),
-            CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        playInfo.IsGenerationConsumerReleased = true;
+        playInfo.Generation.ConsumerCount--;
+    }
+
+    private void OnGenerationCompleted(string cache, InFlightSpeechGeneration generation)
+    {
+        lock (QueueLock)
+        {
+            if (InFlightGenerations.TryGetValue(cache, out var current) && ReferenceEquals(current, generation))
+            {
+                InFlightGenerations.Remove(cache);
+            }
+        }
+        generation.CancellationTokenSource.Dispose();
     }
 
     private string GetCachePath(string text, OpenAiTtsSpeechSettings settings)
@@ -328,10 +371,10 @@ public class OpenAiTtsService : ISpeechService
                         continue;
                     }
 
-                    if (playInfo.GenerationTask != null)
+                    if (playInfo.Generation != null)
                     {
                         Logger.LogDebug("等待 OpenAI TTS 语音生成完成。");
-                        if (!await playInfo.GenerationTask)
+                        if (!await playInfo.Generation.Task.WaitAsync(playInfo.CancellationTokenSource.Token))
                         {
                             Logger.LogError("OpenAI TTS 语音生成失败：{FilePath}", playInfo.FilePath);
                             continue;
@@ -357,6 +400,7 @@ public class OpenAiTtsService : ISpeechService
                     lock (QueueLock)
                     {
                         _currentPlayInfo = null;
+                        ReleaseGenerationConsumer(playInfo);
                     }
                     playInfo.CancellationTokenSource.Dispose();
                 }


### PR DESCRIPTION
## 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？

新增 OpenAI 兼容格式的 TTS 语音提供方，允许使用实现了 `POST /v1/audio/speech` 接口的服务生成提醒语音。

主要变更：

- 新增 **OpenAI TTS** 语音引擎。
- 支持配置：
  - OpenAI 兼容服务地址
  - Bearer API Key
  - 模型
  - Voice
  - 音频格式
  - 语速
- 支持 `mp3`、`opus`、`aac`、`flac`、`wav` 和 `pcm` 响应格式。
- 对 OpenAI 返回的原始 PCM 音频自动封装为 WAV 后播放。
- 将文本及模型、Voice、格式、语速等参数纳入缓存键，避免配置变化后错误复用旧缓存。
- 支持语音生成队列、播放取消及并发访问保护。
- 在提醒设置页面的语音引擎列表中注册该提供方。
- 保持默认语音提供方不变，不影响现有系统 TTS、EdgeTTS 和 GPT-SoVITS 配置。

接口格式参考：

https://doc.ai-api.chat/ai-model/audio/openai/createspeech/

## 截图 / 录屏

<img width="1140" height="939" alt="image" src="https://github.com/user-attachments/assets/bb89ae3e-f58c-4e82-a6ef-187d286a8df7" />


## 实现说明

实现沿用现有 EdgeTTS 和 GPT-SoVITS 服务的处理方式：

1. 将语音请求加入队列。
2. 使用 `HttpClient` 向兼容服务的 `/v1/audio/speech` 端点发送 JSON 请求。
3. 成功生成音频后，将文件写入本地缓存。
4. 使用现有 `IAudioService` 按顺序播放缓存音频。
5. 清空语音队列时，同时取消正在进行的网络请求和音频播放。

服务地址支持以下形式：

```text
https://api.openai.com
https://api.openai.com/v1
https://api.openai.com/v1/audio/speech
```

应用会根据地址自动补全 `/v1/audio/speech` 路径。

请求内容包括：

```json
{
  "model": "tts-1",
  "input": "要朗读的文本",
  "voice": "alloy",
  "response_format": "mp3",
  "speed": 1.0
}
```

缓存写入采用临时文件加原子移动的方式，避免请求取消或写入失败时留下不完整的有效缓存文件。

OpenAI 的 `pcm` 响应按照 24 kHz、单声道、16 位 PCM 封装为 WAV，以便交给现有音频服务播放。

## 破坏性变更

无已知破坏性变更。

- 没有修改 `ISpeechService` 公共接口。
- 默认语音引擎仍为 EdgeTTS。
- 不影响已有系统 TTS、EdgeTTS 和 GPT-SoVITS 设置。
- 配置文件中会新增 `OpenAiTtsSpeechSettings` 字段，旧配置可继续加载。
- API Key 会随其他应用设置保存在本地配置文件中。

## 审查说明

已完成以下自动验证：

```bash
dotnet build ClassIsland.Desktop/ClassIsland.Desktop.csproj \
  -c Debug \
  -p:NIX=true \
  --no-restore
```

构建结果：

```text
已成功生成。
1 个警告
0 个错误
```

使用 `NIX=true` 是因为当前 fork 缺少可供版本生成器执行 `git describe` 的版本标签；这是仓库 `AssemblyInfo.cs` 已提供的无标签构建方式。

另外完成了：

- OpenAI TTS 设置 XAML 的 XML 结构检查。
- 提交内容的 `git diff --check` 检查。
- OpenAI TTS 提供方注册、设置持久化、队列取消和缓存逻辑的静态审查。

## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用）