### PR TITLE
fix:新增“明天没有课程的占位符内容”编辑选项，解决明日课表总是显示状态的逻辑问题

### DIFF
--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml
@@ -46,13 +46,31 @@
                 <Setter Property="LessonsListBoxSelectedIndex" Value="-1"/>
             </Style>
         </Style>
-        <Style Selector="local|ScheduleComponent.TodayScheduleEmpty, local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty">
+        <Style Selector="local|ScheduleComponent.TodayScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>
             <Style Selector="^ TextBlock#EmptyPlaceholder">
                 <Setter Property="IsVisible" Value="{Binding $parent[local:ScheduleComponent].ShowEmptyPlaceholder}"/>
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
+            </Style>
+        </Style>
+        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty">
+            <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
+                <Setter Property="IsVisible" Value="False"/>
+            </Style>
+            <Style Selector="^ TextBlock#EmptyPlaceholder">
+                <Setter Property="IsVisible" Value="{Binding $parent[local:ScheduleComponent].ShowEmptyPlaceholder}"/>
+                <Setter Property="Text" Value="{Binding Settings.PlaceholderTextTomorrowNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
+            </Style>
+        </Style>
+        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
+            <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
+                <Setter Property="IsVisible" Value="False"/>
+            </Style>
+            <Style Selector="^ TextBlock#EmptyPlaceholder">
+                <Setter Property="IsVisible" Value="{Binding $parent[local:ScheduleComponent].ShowEmptyPlaceholder}"/>
+                <Setter Property="Text" Value="{Binding Settings.PlaceholderTextAllClassEnded, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
         

--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml
@@ -55,8 +55,8 @@
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
-        <!-- 默认隐藏等原因造成的无展示课程不代表已经放学，此时使用明日无课占位符。 -->
-        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty, local|ScheduleComponent:not(.TodayScheduleEmpty):not(.AfterSchool):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
+        <!-- 默认隐藏造成的无展示课程在放学后也需占位；隐藏已结束课程时，由后续样式改用当日课程结束提示。 -->
+        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty, local|ScheduleComponent:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>

--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml
@@ -64,7 +64,7 @@
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextTomorrowNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
-        <Style Selector="local|ScheduleComponent:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
+        <Style Selector="local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>

--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml
@@ -55,7 +55,8 @@
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
-        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty">
+        <!-- 默认隐藏等原因造成的无展示课程不代表已经放学，此时使用明日无课占位符。 -->
+        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-always.TomorrowScheduleEmpty, local|ScheduleComponent:not(.TodayScheduleEmpty):not(.AfterSchool):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>
@@ -64,7 +65,7 @@
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextTomorrowNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
-        <Style Selector="local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
+        <Style Selector="local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent[HideFinishedClass=True]:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.AfterSchool.TomorrowScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>

--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml
@@ -64,7 +64,7 @@
                 <Setter Property="Text" Value="{Binding Settings.PlaceholderTextTomorrowNoClass, RelativeSource={RelativeSource AncestorType=local:ScheduleComponent}}"/>
             </Style>
         </Style>
-        <Style Selector="local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent:show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
+        <Style Selector="local|ScheduleComponent:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-after-school.AfterSchool.TomorrowScheduleEmpty, local|ScheduleComponent:not(.TodayScheduleEmpty):show-tomorrow-schedule:show-tomorrow-schedule-on-empty.TomorrowScheduleEmpty">
             <Style Selector="^ ci|LessonsListBox#MainLessonsListBox">
                 <Setter Property="IsVisible" Value="False"/>
             </Style>

--- a/ClassIsland/Controls/Components/ScheduleComponent.axaml.cs
+++ b/ClassIsland/Controls/Components/ScheduleComponent.axaml.cs
@@ -227,7 +227,11 @@ public partial class ScheduleComponent : ComponentBase<LessonControlSettings>, I
             return;
         }
         var now = ExactTimeService.GetCurrentLocalDateTime().TimeOfDay;
-        var selectedItem = LessonsService.CurrentTimeLayoutItem;
+        TimeLayoutItem? selectedItem = LessonsService.CurrentTimeLayoutItem;
+        if (ReferenceEquals(selectedItem, TimeLayoutItem.Empty))
+        {
+            selectedItem = null;
+        }
         var classPlan = LessonsService.CurrentClassPlan;
         var hasDisplayable = HasDisplayableItems(classPlan, now, selectedItem);
         PseudoClasses.Set(":show-tomorrow-schedule-on-empty", !hasDisplayable);

--- a/ClassIsland/Controls/Components/ScheduleComponentSettingsControl.axaml
+++ b/ClassIsland/Controls/Components/ScheduleComponentSettingsControl.axaml
@@ -195,6 +195,16 @@
                             </TextBox>
                         </controls:SettingsExpanderItem.Footer>
                     </controls:SettingsExpanderItem>
+                    <controls:SettingsExpanderItem Content="明日没有课程的占位符内容">
+                        <controls:SettingsExpanderItem.Footer>
+                            <TextBox MinWidth="100"
+                                     MaxWidth="300"
+                                     Grid.Column="1"
+                                     VerticalAlignment="Center"
+                                     Foreground="{DynamicResource MaterialDesignBody}"
+                                     Text="{Binding Settings.PlaceholderTextTomorrowNoClass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        </controls:SettingsExpanderItem.Footer>
+                    </controls:SettingsExpanderItem>
                 </controls:SettingsExpander>
                 
                 <!-- 放学后显示明天课表 -->

--- a/ClassIsland/Models/ComponentSettings/LessonControlSettings.cs
+++ b/ClassIsland/Models/ComponentSettings/LessonControlSettings.cs
@@ -16,6 +16,7 @@ public class LessonControlSettings : ObservableRecipient, ILessonControlSettings
     private bool _showPlaceholderOnEmptyClassPlan = true;
     private string _placeholderTextNoClass = "今天没有课程。";
     private string _placeholderTextAllClassEnded = "今日课程已全部结束。";
+    private string _placeholderTextTomorrowNoClass = "明天没有课程。";
     private bool _showTomorrowSchedules = false;
     private int _tomorrowScheduleShowMode = 1;
     private bool _highlightChangedClass = false;
@@ -139,6 +140,17 @@ public class LessonControlSettings : ObservableRecipient, ILessonControlSettings
         {
             if (value == _placeholderTextAllClassEnded) return;
             _placeholderTextAllClassEnded = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string PlaceholderTextTomorrowNoClass
+    {
+        get => _placeholderTextTomorrowNoClass;
+        set
+        {
+            if (value == _placeholderTextTomorrowNoClass) return;
+            _placeholderTextTomorrowNoClass = value;
             OnPropertyChanged();
         }
     }


### PR DESCRIPTION
# 通过新增“明天没有课程的占位符内容”编辑（默认“明天没有课程。”），修复了在显示明日课表处于“总是显示”状态，且明天没有课程时显示“今天没有课程。”的逻辑问题

<!--
感谢您参与 ClassIsland 的贡献！

提交 PR 前请确认:
1. 已阅读贡献指南:
https://github.com/ClassIsland/ClassIsland/blob/master/CONTRIBUTING.md

⚠ 在提交 PR 前，请确保您已在本地完成必要的测试，且确保要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
请确保填写以下信息:
-->

## 类型
<!-- 请至少选择一项 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
<!-- 必填。简要介绍这个 PR 的变更，可以附上相关 issue 的链接等。

请描述:
- 增加了什么？
- 修复了什么？
- 改变了什么？
-->
修复了：表述是否有误：今天没有课程 #1338 
新增“明天没有课程的占位符内容”编辑（默认“明天没有课程。”）
修复了在显示明日课表处于“总是显示”状态，且明天没有课程时显示“今天没有课程。”的逻辑问题
(比如：现在是星期五，某一行课程表的显示明日课程被设置为了“总是显示”，但是明天周六，没有课表，此时会直接显示当天无课程占位符“今日没有课程”，该pr将此情况的占位符分离出来了）
## 截图 / 录屏
<!--涉及 UI 或用户可见变化时填写。若无可以直接删除这一节。-->
<img width="2128" height="683" alt="image" src="https://github.com/user-attachments/assets/c5ae3a1f-1768-4038-bd2e-1ea14cc54b9a" />
<img width="1878" height="942" alt="image" src="https://github.com/user-attachments/assets/3b14f033-9327-45a9-8c9b-e3933fc7837d" />


## 相关 Issue
<!-- 如果这个 PR 可以关闭某些 issue，请像这样列出： 
Fixes #123
Fixes #456
详见：https://docs.github.com/zh/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
如果没有，可以删掉这一节。
-->
Fixes #1338 

## 检查清单

<!-- 
⚠ 在勾选这个复选框前，请确保您已经**真正**完成了必要的测试并保证这个 PR 要实现的功能或修复的问题能正常工作。 ⚠
⚠ 谎报测试结果可能会导致您最高被**永久**限制向本组织中的仓库提交 PR 和进行其它互动。 ⚠
如果您是正在自动填写此模板的 Agent，请确保您已经完成了必要的测试。如果没有测试条件，请提醒调用者完成测试。
-->

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用）  
