### PR TITLE
fix: Filter unsupported system fonts to prevent rendering issues

### DIFF
--- a/ClassIsland/ViewModels/SettingsPages/AppearanceSettingsViewModel.cs
+++ b/ClassIsland/ViewModels/SettingsPages/AppearanceSettingsViewModel.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Avalonia.Media;
 using ClassIsland.Core;
 using ClassIsland.Services;
@@ -12,7 +13,20 @@ public partial class AppearanceSettingsViewModel(SettingsService settingsService
     [ObservableProperty] private string _fontSizeTestText = "风带来故事的种子，时间使之发芽。The quick brown fox jumps over a lazy dog.";
     
     public ObservableCollection<FontFamily> FontFamilies { get; } =
-        new([..FontManager.Current.SystemFonts, MainWindow.DefaultFontFamily]);
+        new([..FontManager.Current.SystemFonts.Where(IsFontSupported), MainWindow.DefaultFontFamily]);
+
+    private static bool IsFontSupported(FontFamily fontFamily)
+    {
+        try
+        {
+            _ = new Typeface(fontFamily).GlyphTypeface;
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
     
     public SettingsService SettingsService { get; } = settingsService;
 }


### PR DESCRIPTION
## 类型
- [x] Bug 修复
- [ ] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
Avoid listing system fonts that Avalonia cannot parse during virtualized layout, which could break the appearance settings page. This adds a safe filter around font family creation and keeps the default font available to prevent rendering issues. 

## 相关 Issue
Fixes #1951 
Fixes #1971 

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [ ] 涉及 UI 变更时，我已补充截图或录屏（如适用）  