### PR TITLE
fix(plugin): 修复 macOS 平台插件加载与程序集解析问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,7 +367,7 @@ cipx/
 *.cipx
 
 # macOS Desktop Services Store
-.DS_Store
-
 **/.idea/avalonia.xml
 **/.idea/copilot.*
+ClassIsland/secrets.g.cs
+

--- a/ClassIsland.PluginSdk/ClassIsland.PluginSdk.targets
+++ b/ClassIsland.PluginSdk/ClassIsland.PluginSdk.targets
@@ -31,6 +31,6 @@
 		
 		<!-- Generate MD5 -->
 		<Exec Command="$(PowershellBinaryName) -ep bypass -NoLogo -File &quot;$(ClassIslandSdk_PackageRoot)generate-md5.ps1&quot; &quot;$(CipxPackageOutputDirectory)&quot;"
-		      Condition="'$(GenerateHashSummary)'=='true'"/>
+		      Condition="'$(GenerateHashSummary)'=='true' and '$(OS)'=='Windows_NT'"/>
 	</Target>
 </Project>

--- a/ClassIsland/PluginLoadContext.cs
+++ b/ClassIsland/PluginLoadContext.cs
@@ -125,63 +125,81 @@ public class PluginLoadContext : AssemblyLoadContext
             return null;
         }
 
-        // 3. 尝试从声明的依赖插件上下文查找
+        // 3. 依赖项与多层路径解析
+        return TryLoadFromDependencies(assemblyName)
+            ?? TryLoadFromResolver(assemblyName)
+            ?? TryLoadFromPluginDirectory(assemblyName);
+    }
+
+    private Assembly? TryLoadFromDependencies(AssemblyName assemblyName)
+    {
         foreach (var dep in Info.Manifest.Dependencies)
         {
-            if (!PluginService.PluginLoadContexts.TryGetValue(dep.Id, out var context))
+            if (PluginService.PluginLoadContexts.TryGetValue(dep.Id, out var context))
             {
-                continue;
-            }
-
-            var assembly = context.LoadFromAssemblyName(assemblyName);
-            if (assembly != null)
-            {
-                return assembly;
-            }
-        }
-
-        // 4. 优先通过 .deps.json 标准依赖解析器解析（若可用）
-        if (_resolver != null)
-        {
-            try
-            {
-                var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-                if (assemblyPath != null && File.Exists(assemblyPath))
+                var assembly = context.LoadFromAssemblyName(assemblyName);
+                if (assembly != null)
                 {
-                    return LoadFromAssemblyPath(assemblyPath);
+                    return assembly;
                 }
             }
-            catch
-            {
-                // ignore
-            }
+        }
+        return null;
+    }
+
+    private Assembly? TryLoadFromResolver(AssemblyName assemblyName)
+    {
+        if (_resolver == null)
+        {
+            return null;
         }
 
-        // 5. 回退到插件根目录搜索
-        if (!string.IsNullOrEmpty(_pluginDirectory) && !string.IsNullOrEmpty(assemblyName.Name))
+        try
         {
-            var fallbackDll = Path.Combine(_pluginDirectory, assemblyName.Name + ".dll");
-            if (File.Exists(fallbackDll))
+            var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            if (!string.IsNullOrEmpty(assemblyPath) && File.Exists(assemblyPath))
             {
-                return LoadFromAssemblyPath(fallbackDll);
+                return LoadFromAssemblyPath(assemblyPath);
             }
+        }
+        catch
+        {
+            // ignore
+        }
 
-            // 搜索 runtimes 目录下的托管依赖
-            var os = OperatingSystem.IsMacOS() ? "osx" :
-                     OperatingSystem.IsLinux() ? "linux" :
-                     OperatingSystem.IsWindows() ? "win" : "";
+        return null;
+    }
 
-            var subPaths = new[]
+    private Assembly? TryLoadFromPluginDirectory(AssemblyName assemblyName)
+    {
+        if (string.IsNullOrEmpty(_pluginDirectory) || string.IsNullOrEmpty(assemblyName.Name))
+        {
+            return null;
+        }
+
+        var directDll = Path.Combine(_pluginDirectory, $"{assemblyName.Name}.dll");
+        if (File.Exists(directDll))
+        {
+            return LoadFromAssemblyPath(directDll);
+        }
+
+        return TryLoadFromRuntimeSubpaths(assemblyName.Name);
+    }
+
+    private Assembly? TryLoadFromRuntimeSubpaths(string assemblyName)
+    {
+        var os = GetOsName();
+        var candidates = new[]
+        {
+            Path.Combine(_pluginDirectory, "runtimes", os, "lib", "net8.0", $"{assemblyName}.dll"),
+            Path.Combine(_pluginDirectory, "runtimes", "any", "lib", "net8.0", $"{assemblyName}.dll")
+        };
+
+        foreach (var path in candidates)
+        {
+            if (File.Exists(path))
             {
-                Path.Combine(_pluginDirectory, "runtimes", os, "lib", "net8.0", assemblyName.Name + ".dll"),
-                Path.Combine(_pluginDirectory, "runtimes", "any", "lib", "net8.0", assemblyName.Name + ".dll"),
-            };
-            foreach (var sp in subPaths)
-            {
-                if (File.Exists(sp))
-                {
-                    return LoadFromAssemblyPath(sp);
-                }
+                return LoadFromAssemblyPath(path);
             }
         }
 
@@ -220,16 +238,17 @@ public class PluginLoadContext : AssemblyLoadContext
         return IntPtr.Zero;
     }
 
-    private string? ResolveUnmanagedDllFallback(string unmanagedDllName)
+    private static string GetOsName()
     {
-        if (string.IsNullOrEmpty(_pluginDirectory))
-            return null;
+        if (OperatingSystem.IsMacOS()) return "osx";
+        if (OperatingSystem.IsLinux()) return "linux";
+        if (OperatingSystem.IsWindows()) return "win";
+        return "";
+    }
 
-        var os = OperatingSystem.IsMacOS() ? "osx" :
-                 OperatingSystem.IsLinux() ? "linux" :
-                 OperatingSystem.IsWindows() ? "win" : "";
-
-        var arch = RuntimeInformation.ProcessArchitecture switch
+    private static string? GetArchitectureName()
+    {
+        return RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.X64 => "x64",
             Architecture.Arm64 => "arm64",
@@ -237,41 +256,62 @@ public class PluginLoadContext : AssemblyLoadContext
             Architecture.X86 => "x86",
             _ => null
         };
+    }
 
-        var searchPaths = new List<string>
-        {
-            _pluginDirectory
-        };
+    private List<string> GetNativeSearchDirectories()
+    {
+        var paths = new List<string> { _pluginDirectory };
+        var os = GetOsName();
+        var arch = GetArchitectureName();
 
         if (!string.IsNullOrEmpty(os))
         {
-            searchPaths.Add(Path.Combine(_pluginDirectory, "runtimes", os, "native"));
+            paths.Add(Path.Combine(_pluginDirectory, "runtimes", os, "native"));
             if (arch != null)
             {
-                searchPaths.Add(Path.Combine(_pluginDirectory, "runtimes", $"{os}-{arch}", "native"));
+                paths.Add(Path.Combine(_pluginDirectory, "runtimes", $"{os}-{arch}", "native"));
             }
         }
 
+        return paths;
+    }
+
+    private static IEnumerable<string> GetCandidateLibraryFileNames(string name)
+    {
         var extensions = OperatingSystem.IsMacOS() ? new[] { ".dylib", "" } :
                          OperatingSystem.IsLinux() ? new[] { ".so", "" } :
                          new[] { ".dll", "" };
 
-        foreach (var path in searchPaths)
+        foreach (var ext in extensions)
         {
-            if (!Directory.Exists(path)) continue;
+            yield return $"lib{name}{ext}";
+            yield return $"{name}{ext}";
+        }
+    }
 
-            foreach (var ext in extensions)
+    private string? ResolveUnmanagedDllFallback(string unmanagedDllName)
+    {
+        if (string.IsNullOrEmpty(_pluginDirectory))
+        {
+            return null;
+        }
+
+        var searchDirs = GetNativeSearchDirectories();
+        var candidateNames = GetCandidateLibraryFileNames(unmanagedDllName).ToList();
+
+        foreach (var dir in searchDirs)
+        {
+            if (!Directory.Exists(dir))
             {
-                var candidates = new[]
-                {
-                    Path.Combine(path, $"lib{unmanagedDllName}{ext}"),
-                    Path.Combine(path, $"{unmanagedDllName}{ext}")
-                };
+                continue;
+            }
 
-                foreach (var candidate in candidates)
+            foreach (var filename in candidateNames)
+            {
+                var fullPath = Path.Combine(dir, filename);
+                if (File.Exists(fullPath))
                 {
-                    if (File.Exists(candidate))
-                        return candidate;
+                    return fullPath;
                 }
             }
         }

--- a/ClassIsland/PluginLoadContext.cs
+++ b/ClassIsland/PluginLoadContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.Loader;
 using System;
 using System.Collections.Generic;
@@ -13,19 +13,19 @@ namespace ClassIsland;
 
 /// <summary>
 /// 为插件加载提供隔离的 <see cref="AssemblyLoadContext"/> 实现。<para/>
-/// 根据运行平台选择不同的依赖解析器，并负责从插件目录解析托管与非托管依赖项。
-/// <remarks>macOS平台的依赖解析器为<see cref="MacPluginAssemblyResolver"/></remarks>
+/// 负责从插件依赖项解析托管与非托管依赖项，同时严格保证宿主共享程序集单例加载。
 /// </summary>
 public class PluginLoadContext : AssemblyLoadContext
 {
-    private readonly bool _suppressMacPluginLoader;
+    private readonly string _pluginDirectory;
+    private readonly AssemblyDependencyResolver _resolver;
 
-    public PluginLoadContext(PluginInfo info, string fullPath, bool suppressMacPluginLoader) : base($"ClassIsland.PluginLoadContext[{info.Manifest.Id}]")
+    public PluginLoadContext(PluginInfo info, string fullPath, bool suppressMacPluginLoader = false) 
+        : base($"ClassIsland.PluginLoadContext[{info.Manifest.Id}]", isCollectible: true)
     {
-        _suppressMacPluginLoader = suppressMacPluginLoader;
         Info = info;
-        CoreResolver = UseMacOsPluginLoadingBehavior ? null : new(fullPath);
-        MacResolver = UseMacOsPluginLoadingBehavior ? new(fullPath) : null;
+        _pluginDirectory = Path.GetDirectoryName(fullPath) ?? "";
+        _resolver = new AssemblyDependencyResolver(fullPath);
     }
 
     /// <summary>
@@ -33,31 +33,84 @@ public class PluginLoadContext : AssemblyLoadContext
     /// </summary>
     public PluginInfo Info { get; }
 
-    private bool UseMacOsPluginLoadingBehavior =>
-        _suppressMacPluginLoader || RuntimeInformation.IsOSPlatform(OSPlatform.OSX); 
-
-    private AssemblyDependencyResolver? CoreResolver { get; }
-    
-    private MacPluginAssemblyResolver? MacResolver { get; }
-
     private static IReadOnlyList<string> WinRTDeps { get; } = [
         "WinRT.Runtime",
         "Microsoft.Windows.SDK.NET"
     ];
 
+    private static readonly HashSet<string> HostAssemblyExactNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ClassIsland",
+        "ClassIsland.Core",
+        "ClassIsland.Shared",
+        "ClassIsland.Shared.IPC",
+        "ClassIsland.Platforms.Abstractions",
+        "ClassIsland.Platforms.Windows",
+        "ClassIsland.Platforms.Linux",
+        "ClassIsland.Platforms.MacOs",
+        "ClassIsland.Desktop",
+        "ClassIsland.Launcher",
+        "ClassIsland.PluginSdk"
+    };
+
+    private static readonly HashSet<string> HostAssemblyPrefixes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Avalonia",
+        "FluentAvalonia",
+        "CommunityToolkit.",
+        "Microsoft.",
+        "System.",
+        "System",
+        "netstandard",
+        "mscorlib",
+        "YamlDotNet",
+        "Newtonsoft.Json",
+        "Google.Protobuf",
+        "Sentry",
+        "Material.Icons"
+    };
+
+    private static bool IsHostAssembly(string? assemblyName)
+    {
+        if (string.IsNullOrEmpty(assemblyName))
+            return false;
+
+        // 1. 完全匹配已知宿主核心程序集
+        if (HostAssemblyExactNames.Contains(assemblyName))
+            return true;
+
+        // 2. 检查前缀或完全匹配基础框架程序集
+        foreach (var prefix in HostAssemblyPrefixes)
+        {
+            if (assemblyName.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                assemblyName.StartsWith(prefix + ".", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        // 3. 检查是否已经在默认主上下文加载
+        return Default.Assemblies.Any(a => string.Equals(a.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase));
+    }
+
     /// <summary>
-    /// 在需要加载程序集时被调用。优先从已加载的插件依赖项上下文中解析，如果在插件目录中找到对应的程序集则从路径加载。
-    /// 对 WinRT 相关依赖会使用宿主的实现。
+    /// 在需要加载程序集时被调用。优先委托给宿主共享程序集，接着解析插件依赖项及插件目录程序集。
     /// </summary>
     protected override Assembly? Load(AssemblyName assemblyName)
     {
-        if (WinRTDeps.Contains(assemblyName.Name))
+        // 1. WinRT 依赖使用宿主实现
+        if (assemblyName.Name != null && WinRTDeps.Contains(assemblyName.Name))
         {
-            // 为了防止因引用 WinRT 依赖导致重复初始化 WinRT 相关运行时使应用代码无法正常调用 WinRT，
-            // 这里将插件要的加载的 WinRT 相关程序集替换为应用自带的 WinRT 相关程序集。
             return null;
         }
-        // 尝试查找依赖
+
+        // 2. 宿主核心与框架程序集直接委托给默认上下文，确保类型一致性
+        if (IsHostAssembly(assemblyName.Name))
+        {
+            return null;
+        }
+
+        // 3. 尝试从声明的依赖插件上下文查找
         foreach (var dep in Info.Manifest.Dependencies)
         {
             if (!PluginService.PluginLoadContexts.TryGetValue(dep.Id, out var context))
@@ -65,97 +118,109 @@ public class PluginLoadContext : AssemblyLoadContext
                 continue;
             }
 
-            var assembly = context.Load(assemblyName);
+            var assembly = context.LoadFromAssemblyName(assemblyName);
             if (assembly != null)
             {
                 return assembly;
             }
         }
-        
-        string? assemblyPath;
-        assemblyPath = UseMacOsPluginLoadingBehavior ? MacResolver?.ResolveAssemblyToPath(assemblyName) : CoreResolver?.ResolveAssemblyToPath(assemblyName);
-        
-        if (assemblyPath != null)
+
+        // 4. 优先通过 .deps.json 标准依赖解析器解析
+        var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null && File.Exists(assemblyPath))
         {
             return LoadFromAssemblyPath(assemblyPath);
         }
 
+        // 5. 回退到插件根目录搜索
+        if (!string.IsNullOrEmpty(_pluginDirectory) && !string.IsNullOrEmpty(assemblyName.Name))
+        {
+            var fallbackDll = Path.Combine(_pluginDirectory, assemblyName.Name + ".dll");
+            if (File.Exists(fallbackDll))
+            {
+                return LoadFromAssemblyPath(fallbackDll);
+            }
+        }
+
         return null;
     }
 
     /// <summary>
-    /// 解析并加载插件的非托管（本地）库，按平台和插件目录的约定搜索文件。
-    /// 返回非托管库句柄，找不到则返回 <see cref="IntPtr.Zero"/>。
+    /// 解析并加载插件的非托管（本地）库，支持跨平台约定与 runtimes 架构目录。
     /// </summary>
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {
-        string? libraryPath;
-        libraryPath = UseMacOsPluginLoadingBehavior ? MacResolver?.ResolveUnmanagedDllToPath(unmanagedDllName) : CoreResolver?.ResolveUnmanagedDllToPath(unmanagedDllName);
-
-        if (libraryPath != null)
+        // 1. 尝试使用标准解析器
+        var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (libraryPath != null && File.Exists(libraryPath))
         {
             return LoadUnmanagedDllFromPath(libraryPath);
         }
 
+        // 2. 回退跨平台多路径搜索
+        var fallbackPath = ResolveUnmanagedDllFallback(unmanagedDllName);
+        if (fallbackPath != null && File.Exists(fallbackPath))
+        {
+            return LoadUnmanagedDllFromPath(fallbackPath);
+        }
+
         return IntPtr.Zero;
     }
-}
 
-/// <summary>
-/// macOS 专用的插件程序集与本地库解析器。根据插件目录结构查找真实文件路径。
-/// </summary>
-[SupportedOSPlatform("macos")]
-public class MacPluginAssemblyResolver(string componentAssemblyPath)
-{
-    private readonly string _pluginDirectory = Path.GetDirectoryName(componentAssemblyPath) ?? "";
-
-    /// <summary>
-    /// 将程序集名解析为插件目录下的 dll 文件路径（若存在），否则返回 null。
-    /// </summary>
-    public string? ResolveAssemblyToPath(AssemblyName assemblyName)
+    private string? ResolveUnmanagedDllFallback(string unmanagedDllName)
     {
-        var dllPath = Path.Combine(_pluginDirectory, assemblyName.Name + ".dll");
-        if (File.Exists(dllPath))
-            return dllPath;
-        return null;
-    }
+        if (string.IsNullOrEmpty(_pluginDirectory))
+            return null;
 
-    /// <summary>
-    /// 在插件目录及其可能的 runtimes 子目录中查找非托管库文件，并返回第一个匹配的完整路径。
-    /// 支持按处理器架构查找文件。
-    /// </summary>
-    public string? ResolveUnmanagedDllToPath(string unmanagedDllName)
-    {
-        var searchPaths = new List<string>
-        {
-            _pluginDirectory,
-            Path.Combine(_pluginDirectory, "runtimes", "osx", "native")
-        };
-        
+        var os = OperatingSystem.IsMacOS() ? "osx" :
+                 OperatingSystem.IsLinux() ? "linux" :
+                 OperatingSystem.IsWindows() ? "win" : "";
+
         var arch = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.X64 => "x64",
             Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            Architecture.X86 => "x86",
             _ => null
         };
-        
-        if (arch != null)
+
+        var searchPaths = new List<string>
         {
-            searchPaths.Add(Path.Combine(_pluginDirectory, "runtimes", $"osx-{arch}", "native"));
+            _pluginDirectory
+        };
+
+        if (!string.IsNullOrEmpty(os))
+        {
+            searchPaths.Add(Path.Combine(_pluginDirectory, "runtimes", os, "native"));
+            if (arch != null)
+            {
+                searchPaths.Add(Path.Combine(_pluginDirectory, "runtimes", $"{os}-{arch}", "native"));
+            }
         }
+
+        var extensions = OperatingSystem.IsMacOS() ? new[] { ".dylib", "" } :
+                         OperatingSystem.IsLinux() ? new[] { ".so", "" } :
+                         new[] { ".dll", "" };
 
         foreach (var path in searchPaths)
         {
             if (!Directory.Exists(path)) continue;
-            
-            var p1 = Path.Combine(path, $"lib{unmanagedDllName}.dylib");
-            if (File.Exists(p1)) return p1;
-            
-            var p2 = Path.Combine(path, $"{unmanagedDllName}.dylib");
-            if (File.Exists(p2)) return p2;
 
-            var p3 = Path.Combine(path, unmanagedDllName);
-            if (File.Exists(p3)) return p3;
+            foreach (var ext in extensions)
+            {
+                var candidates = new[]
+                {
+                    Path.Combine(path, $"lib{unmanagedDllName}{ext}"),
+                    Path.Combine(path, $"{unmanagedDllName}{ext}")
+                };
+
+                foreach (var candidate in candidates)
+                {
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
         }
 
         return null;

--- a/ClassIsland/PluginLoadContext.cs
+++ b/ClassIsland/PluginLoadContext.cs
@@ -137,10 +137,21 @@ public class PluginLoadContext : AssemblyLoadContext
         {
             if (PluginService.PluginLoadContexts.TryGetValue(dep.Id, out var context))
             {
-                var assembly = context.LoadFromAssemblyName(assemblyName);
-                if (assembly != null)
+                try
                 {
-                    return assembly;
+                    var assembly = context.LoadFromAssemblyName(assemblyName);
+                    if (assembly != null)
+                    {
+                        return assembly;
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                    // 依赖插件上下文中未找到该程序集，继续检查后续依赖或当前插件自身回退路径
+                }
+                catch (FileLoadException)
+                {
+                    // 忽略加载异常，允许后续回退继续探测
                 }
             }
         }
@@ -189,11 +200,18 @@ public class PluginLoadContext : AssemblyLoadContext
     private Assembly? TryLoadFromRuntimeSubpaths(string assemblyName)
     {
         var os = GetOsName();
-        var candidates = new[]
+        var arch = GetArchitectureName();
+        var candidates = new List<string>();
+
+        if (!string.IsNullOrEmpty(os))
         {
-            Path.Combine(_pluginDirectory, "runtimes", os, "lib", "net8.0", $"{assemblyName}.dll"),
-            Path.Combine(_pluginDirectory, "runtimes", "any", "lib", "net8.0", $"{assemblyName}.dll")
-        };
+            if (arch != null)
+            {
+                candidates.Add(Path.Combine(_pluginDirectory, "runtimes", $"{os}-{arch}", "lib", "net8.0", $"{assemblyName}.dll"));
+            }
+            candidates.Add(Path.Combine(_pluginDirectory, "runtimes", os, "lib", "net8.0", $"{assemblyName}.dll"));
+        }
+        candidates.Add(Path.Combine(_pluginDirectory, "runtimes", "any", "lib", "net8.0", $"{assemblyName}.dll"));
 
         foreach (var path in candidates)
         {

--- a/ClassIsland/PluginLoadContext.cs
+++ b/ClassIsland/PluginLoadContext.cs
@@ -18,14 +18,29 @@ namespace ClassIsland;
 public class PluginLoadContext : AssemblyLoadContext
 {
     private readonly string _pluginDirectory;
-    private readonly AssemblyDependencyResolver _resolver;
+    private readonly AssemblyDependencyResolver? _resolver;
 
     public PluginLoadContext(PluginInfo info, string fullPath, bool suppressMacPluginLoader = false) 
         : base($"ClassIsland.PluginLoadContext[{info.Manifest.Id}]", isCollectible: true)
     {
         Info = info;
         _pluginDirectory = Path.GetDirectoryName(fullPath) ?? "";
-        _resolver = new AssemblyDependencyResolver(fullPath);
+        _resolver = TryCreateResolver(fullPath);
+    }
+
+    private static AssemblyDependencyResolver? TryCreateResolver(string fullPath)
+    {
+        try
+        {
+            return new AssemblyDependencyResolver(fullPath);
+        }
+        catch
+        {
+            // 在 macOS 原生打包（Microsoft.macOS.Sdk）运行时中，hostfxr/corehost_main 未被显式初始化，
+            // AssemblyDependencyResolver 会抛出 InvalidOperationException。
+            // 此时回退到自定义目录解析逻辑。
+            return null;
+        }
     }
 
     /// <summary>
@@ -125,11 +140,21 @@ public class PluginLoadContext : AssemblyLoadContext
             }
         }
 
-        // 4. 优先通过 .deps.json 标准依赖解析器解析
-        var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-        if (assemblyPath != null && File.Exists(assemblyPath))
+        // 4. 优先通过 .deps.json 标准依赖解析器解析（若可用）
+        if (_resolver != null)
         {
-            return LoadFromAssemblyPath(assemblyPath);
+            try
+            {
+                var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+                if (assemblyPath != null && File.Exists(assemblyPath))
+                {
+                    return LoadFromAssemblyPath(assemblyPath);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
         }
 
         // 5. 回退到插件根目录搜索
@@ -139,6 +164,24 @@ public class PluginLoadContext : AssemblyLoadContext
             if (File.Exists(fallbackDll))
             {
                 return LoadFromAssemblyPath(fallbackDll);
+            }
+
+            // 搜索 runtimes 目录下的托管依赖
+            var os = OperatingSystem.IsMacOS() ? "osx" :
+                     OperatingSystem.IsLinux() ? "linux" :
+                     OperatingSystem.IsWindows() ? "win" : "";
+
+            var subPaths = new[]
+            {
+                Path.Combine(_pluginDirectory, "runtimes", os, "lib", "net8.0", assemblyName.Name + ".dll"),
+                Path.Combine(_pluginDirectory, "runtimes", "any", "lib", "net8.0", assemblyName.Name + ".dll"),
+            };
+            foreach (var sp in subPaths)
+            {
+                if (File.Exists(sp))
+                {
+                    return LoadFromAssemblyPath(sp);
+                }
             }
         }
 
@@ -150,11 +193,21 @@ public class PluginLoadContext : AssemblyLoadContext
     /// </summary>
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {
-        // 1. 尝试使用标准解析器
-        var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
-        if (libraryPath != null && File.Exists(libraryPath))
+        // 1. 尝试使用标准解析器（若可用）
+        if (_resolver != null)
         {
-            return LoadUnmanagedDllFromPath(libraryPath);
+            try
+            {
+                var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+                if (libraryPath != null && File.Exists(libraryPath))
+                {
+                    return LoadUnmanagedDllFromPath(libraryPath);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
         }
 
         // 2. 回退跨平台多路径搜索

--- a/ClassIsland/Services/PluginService.cs
+++ b/ClassIsland/Services/PluginService.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -171,6 +172,18 @@ public class PluginService : IPluginService
                 info.Exception = new InvalidOperationException($"不兼容的 API 版本 {apiVersion}。插件的 API 版本需要至少为 2.0.0.0 才能被当前版本的 ClassIsland 加载。");
                 PluginLoadedStatus.Add(info);
             }
+            if (info.IsEnabled && info.LoadStatus == PluginLoadStatus.NotLoaded && manifest.SupportedOSPlatforms != null && manifest.SupportedOSPlatforms.Count > 0)
+            {
+                var isSupported = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && manifest.SupportedOSPlatforms.Contains(OSPlatform.Windows)) ||
+                                  (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && manifest.SupportedOSPlatforms.Contains(OSPlatform.Linux)) ||
+                                  (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && manifest.SupportedOSPlatforms.Contains(OSPlatform.OSX));
+                if (!isSupported)
+                {
+                    info.LoadStatus = PluginLoadStatus.Error;
+                    info.Exception = new PlatformNotSupportedException($"插件 {manifest.Name} 不支持当前操作系统平台。");
+                    PluginLoadedStatus.Add(info);
+                }
+            }
         }
         var loadOrder = ResolveLoadOrder(IPluginService.LoadedPluginsInternal.Where(x => x.LoadStatus == PluginLoadStatus.NotLoaded).ToList());
         Console.WriteLine($"Resolved load order: {string.Join(", ", loadOrder)}");
@@ -181,27 +194,52 @@ public class PluginService : IPluginService
         foreach (var id in loadOrder)
         {
             var info = IPluginService.LoadedPluginsInternal.First(x => x.Manifest.Id == id);
+            if (info.LoadStatus != PluginLoadStatus.NotLoaded)
+            {
+                continue;
+            }
             var manifest = info.Manifest;
             var pluginDir = info.PluginFolderPath;
             try
             {
                 var fullPath = Path.GetFullPath(Path.Combine(pluginDir, manifest.EntranceAssembly));
+                if (!File.Exists(fullPath))
+                {
+                    throw new FileNotFoundException($"找不到插件入口程序集文件: {fullPath}", fullPath);
+                }
                 var loadContext = new PluginLoadContext(info, fullPath, suppressMacOsPluginLoadBehavior);
                 PluginLoadContexts[info.Manifest.Id] = loadContext;
                 var asm = loadContext.LoadFromAssemblyName(
                     new AssemblyName(Path.GetFileNameWithoutExtension(fullPath)));
-                var entrance = asm.ExportedTypes.FirstOrDefault(x =>
-                    x.BaseType == typeof(PluginBase) ||
-                    x.GetCustomAttributes().FirstOrDefault(a => a.GetType() == typeof(PluginEntrance)) != null);
+
+                System.Type[] types;
+                try
+                {
+                    types = asm.GetExportedTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(t => t != null).ToArray()!;
+                }
+
+                var entrance = types.FirstOrDefault(x =>
+                    typeof(PluginBase).IsAssignableFrom(x) && !x.IsAbstract &&
+                    (x.BaseType == typeof(PluginBase) ||
+                     x.GetCustomAttributes().Any(a => a.GetType() == typeof(PluginEntrance) || a is PluginEntrance)));
 
                 if (entrance == null)
                 {
-                    continue;
+                    entrance = types.FirstOrDefault(x => typeof(PluginBase).IsAssignableFrom(x) && !x.IsAbstract);
+                }
+
+                if (entrance == null)
+                {
+                    throw new InvalidOperationException($"在入口程序集 {manifest.EntranceAssembly} 中找不到继承自 PluginBase 的插件入口类。");
                 }
 
                 if (Activator.CreateInstance(entrance) is not PluginBase entranceObj)
                 {
-                    continue;
+                    throw new InvalidOperationException($"无法实例化插件入口类 {entrance.FullName} 为 PluginBase。");
                 }
 
                 entranceObj.PluginConfigFolder = Path.Combine(PluginConfigsFolderPath, manifest.Id);
@@ -222,7 +260,6 @@ public class PluginService : IPluginService
                 services.AddSingleton(typeof(PluginBase), entranceObj);
                 services.AddSingleton(entrance, entranceObj);
                 info.LoadStatus = PluginLoadStatus.Loaded;
-                // Console.WriteLine($"Initialized plugin: {pluginDir} ({manifest.Version})");
                 PluginLoadedStatus.Add(info);
             }
             catch (Exception ex)
@@ -230,7 +267,6 @@ public class PluginService : IPluginService
                 info.Exception = ex;
                 info.LoadStatus = PluginLoadStatus.Error;
                 PluginLoadedStatus.Add(info);
-                // Console.WriteLine($"Failed to initialize plugin {manifest.Name}:"+ex);
             }
         }
         

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.100",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.100",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] CI
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？

修复在 macOS 环境下 ClassIsland 无法正常扫描、加载第三方插件以及类型解析异常的问题。

## 实现说明
   - 适配 macOS/Linux 原生宿主环境，增加当 AssemblyDependencyResolver 不受支持时的降级加载；
   - 完善跨平台 Native 动态链接库（.dylib / .so / .dll）在各平台架构下的检索路径与加载支持。
   - 改进插件入口类的判定逻辑（采用 `typeof(PluginBase).IsAssignableFrom(x) && !x.IsAbstract`）；
   - 在调用 `GetExportedTypes()` 遇到 `ReflectionTypeLoadException` 时进行安全类型捕获与过滤，避免因部分可选依赖缺失导致整个程序集加载崩溃。
   - 支持根据插件清单中的 SupportedOSPlatforms 校验当前操作系统；
   - 提供更清晰明确的插件加载失败与缺失入口类异常提示信息。

## 检查清单

- [x] 我阅读并已经在本地测试过这个 PR，确保欲实现的功能或修复的问题能正常工作。
- [x] 我已阅读并遵循贡献指南
- [ ] 涉及 UI 变更时，我已补充截图或录屏（如适用）  
